### PR TITLE
Include transaction.id in errors if available

### DIFF
--- a/lib/elastic_apm/error.rb
+++ b/lib/elastic_apm/error.rb
@@ -14,9 +14,11 @@ module ElasticAPM
 
       @timestamp = Util.micros
       @context = Context.new
+
+      @transaction_id = nil
     end
 
-    attr_accessor :id, :culprit, :exception, :log
+    attr_accessor :id, :culprit, :exception, :log, :transaction_id
     attr_reader :timestamp, :context
   end
 end

--- a/lib/elastic_apm/serializers/errors.rb
+++ b/lib/elastic_apm/serializers/errors.rb
@@ -4,6 +4,7 @@ module ElasticAPM
   module Serializers
     # @api private
     class Errors < Serializer
+      # rubocop:disable Metrics/MethodLength
       def build(error)
         base = {
           id: error.id,
@@ -15,8 +16,13 @@ module ElasticAPM
           base[:exception] = build_exception exception
         end
 
+        if (transaction_id = error.transaction_id)
+          base[:transaction] = { id: transaction_id }
+        end
+
         base
       end
+      # rubocop:enable Metrics/MethodLength
 
       def build_all(errors)
         { errors: Array(errors).map(&method(:build)) }

--- a/spec/elastic_apm/serializers/errors_spec.rb
+++ b/spec/elastic_apm/serializers/errors_spec.rb
@@ -37,6 +37,14 @@ module ElasticAPM
             )
           end
         end
+
+        context 'an error with a transaction id' do
+          it 'attaches the transaction' do
+            error = Error.new.tap { |e| e.transaction_id = 'abc123' }
+            subject = builder.build(error)
+            expect(subject[:transaction]).to eq(id: 'abc123')
+          end
+        end
       end
     end
   end

--- a/spec/integration/rails_spec.rb
+++ b/spec/integration/rails_spec.rb
@@ -107,7 +107,10 @@ if defined? Rails
         expect(response.status).to be 500
         expect(FakeServer.requests.length).to be 2
 
-        exception = FakeServer.requests.first['errors'][0]['exception']
+        error = FakeServer.requests.first['errors'][0]
+        expect(error['transaction']['id']).to_not be_nil
+
+        exception = error['exception']
         expect(exception['type']).to eq 'PagesController::FancyError'
       end
 


### PR DESCRIPTION
As per https://github.com/elastic/apm-server/pull/437  