### PR TITLE
Add public ElasticAPM.set_user method

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -21,6 +21,10 @@ Metrics/BlockLength:
   Exclude:
     - 'spec/**/*.rb'
 
+Metrics/ModuleLength:
+  Exclude:
+    - 'spec/**/*.rb'
+
 Naming/PredicateName:
   Enabled: false
 

--- a/docs/api.asciidoc
+++ b/docs/api.asciidoc
@@ -44,6 +44,7 @@ Returns whether the ElasticAPM Agent is currently running.
 
 Returns the currently running agent or nil.
 
+[float]
 === Instrumentation
 
 [float]
@@ -119,6 +120,7 @@ Arguments:
 
 Returns the built context.
 
+[float]
 === Errors
 
 [float]
@@ -165,6 +167,7 @@ Arguments:
 
 Returns `[ElasticAPM::Error]`.
 
+[float]
 === Context
 
 [float]
@@ -207,4 +210,16 @@ Arguments:
   * `context`: A hash of JSON-compatible key-values. Can be nested.
 
 Returns current custom context.
+
+[float]
+[[api-set-user]]
+==== `ElasticAPM.set_user`
+
+Add the current user to the current transaction's context.
+
+Arguments:
+
+  * `user`: An object representing the user
+
+Returns the given user
 

--- a/docs/configuration.asciidoc
+++ b/docs/configuration.asciidoc
@@ -3,6 +3,7 @@
 
 There are several ways to shape how Elastic APM behaves.
 
+[float]
 === Rails
 
 The recommended way to configure Elastic APM for Rails is to create a file `config/elastic_apm.yml` and specify options in there:
@@ -14,6 +15,7 @@ server_url: 'http://localhost:8200'
 secret_token: 'very_very_secret'
 ----
 
+[float]
 === Sinatra and Rack
 
 When using APM with Sinatra and Rack, you should configure it when starting the agent:

--- a/docs/context.asciidoc
+++ b/docs/context.asciidoc
@@ -1,6 +1,8 @@
+[float]
 [[context]]
 === Adding additional context
 
+[float]
 ==== Adding custom context
 
 You can add your own custom, nested JSON-compatible data to the current transaction using `ElasticAPM.add_custom_context(hash)` eg.:
@@ -16,6 +18,7 @@ class ThingsController < ApplicationController
 end
 ----
 
+[float]
 ==== Adding tags
 
 Tags are special in that they are indexed in your Elasticsearch database and therefore searchable.
@@ -25,3 +28,16 @@ Tags are special in that they are indexed in your Elasticsearch database and the
 ElasticAPM.set_tag(:company_name, 'Acme, Inc.')
 ----
 
+[float]
+==== Providing info about the user
+
+You can provide ElasticAPM with info about the current user.
+
+[source,ruby]
+----
+class ApplicationController < ActionController::Base
+  before_action do
+    current_user && ElasticAPM.set_user(current_user)
+  end
+end
+----

--- a/lib/elastic_apm.rb
+++ b/lib/elastic_apm.rb
@@ -125,6 +125,14 @@ module ElasticAPM
     agent && agent.set_custom_context(custom)
   end
 
+  # Provide a user to the current transaction
+  #
+  # @param user [Object] An object representing a user
+  # @return [Object] Given user
+  def self.set_user(user)
+    agent && agent.set_user(user)
+  end
+
   class << self
     private
 

--- a/lib/elastic_apm/agent.rb
+++ b/lib/elastic_apm/agent.rb
@@ -150,6 +150,10 @@ module ElasticAPM
       instrumenter.set_custom_context(*args)
     end
 
+    def set_user(*args)
+      instrumenter.set_user(*args)
+    end
+
     def inspect
       '<ElasticAPM::Agent>'
     end

--- a/lib/elastic_apm/config.rb
+++ b/lib/elastic_apm/config.rb
@@ -25,7 +25,6 @@ module ElasticAPM
 
       enabled_injectors: %w[net_http],
 
-      current_user_method: :current_user,
       current_user_id_method: :id,
       current_user_email_method: :email,
       current_user_username_method: :username,

--- a/lib/elastic_apm/context_builder.rb
+++ b/lib/elastic_apm/context_builder.rb
@@ -3,8 +3,6 @@
 module ElasticAPM
   # @api private
   class ContextBuilder
-    CONTROLLER_KEY = 'action_controller.instance'.freeze
-
     def initialize(config)
       @config = config
     end
@@ -13,10 +11,7 @@ module ElasticAPM
 
     def build(rack_env)
       context = Context.new
-
       apply_to_request(context, rack_env)
-      apply_to_user(context, rack_env)
-
       context
     end
 
@@ -39,18 +34,6 @@ module ElasticAPM
       context
     end
     # rubocop:enable Metrics/AbcSize
-
-    def apply_to_user(context, rack_env)
-      return unless (controller = rack_env[CONTROLLER_KEY])
-
-      method = config.current_user_method.to_sym
-      return unless controller.respond_to?(method)
-
-      return unless (record = controller.send method)
-
-      context.user = Context::User.new(config, record)
-      context
-    end
 
     def get_body(req)
       return req.POST if req.form_data?

--- a/lib/elastic_apm/instrumenter.rb
+++ b/lib/elastic_apm/instrumenter.rb
@@ -92,6 +92,10 @@ module ElasticAPM
       transaction.context.custom.merge!(context)
     end
 
+    def set_user(user)
+      transaction.context.user = Context::User.new(config, user)
+    end
+
     def submit_transaction(transaction)
       @pending_transactions << transaction
 

--- a/spec/elastic_apm/agent_spec.rb
+++ b/spec/elastic_apm/agent_spec.rb
@@ -32,6 +32,7 @@ module ElasticAPM
       it { should delegate :span, to: subject.instrumenter }
       it { should delegate :set_tag, to: subject.instrumenter }
       it { should delegate :set_custom_context, to: subject.instrumenter }
+      it { should delegate :set_user, to: subject.instrumenter }
     end
 
     context 'reporting' do

--- a/spec/elastic_apm/context_builder_spec.rb
+++ b/spec/elastic_apm/context_builder_spec.rb
@@ -32,24 +32,6 @@ module ElasticAPM
           'Content-Type' => 'application/json'
         )
       end
-
-      it 'enriches user' do
-        class Controller
-          ProbablyUser = Struct.new(:id, :email, :username)
-
-          def current_user
-            ProbablyUser.new(1, 'john@example.com', 'leroy')
-          end
-        end
-
-        env = Rack::MockRequest.env_for '/',
-          'action_controller.instance' => Controller.new
-        context = subject.build(env)
-
-        expect(context.user.id).to be 1
-        expect(context.user.email).to eq 'john@example.com'
-        expect(context.user.username).to eq 'leroy'
-      end
     end
   end
 end

--- a/spec/elastic_apm/instrumenter_spec.rb
+++ b/spec/elastic_apm/instrumenter_spec.rb
@@ -100,6 +100,25 @@ module ElasticAPM
       end
     end
 
+    describe '#set_user' do
+      User = Struct.new(:id, :email, :username)
+
+      subject { Instrumenter.new(Config.new, nil) }
+
+      it 'sets user in context' do
+        transaction = subject.transaction 'Test' do |t|
+          subject.set_user(User.new(1, 'a@a', 'abe'))
+          t
+        end
+
+        expect(transaction.context.user.to_h).to match(
+          id: 1,
+          email: 'a@a',
+          username: 'abe'
+        )
+      end
+    end
+
     describe '#submit_transaction' do
       context "when it shouldn't send" do
         subject { Instrumenter.new(Config.new, nil) }

--- a/spec/elastic_apm_spec.rb
+++ b/spec/elastic_apm_spec.rb
@@ -37,6 +37,7 @@ RSpec.describe ElasticAPM do
     end
     it { should delegate :set_tag, to: agent, args: [nil, nil] }
     it { should delegate :set_custom_context, to: agent, args: [nil] }
+    it { should delegate :set_user, to: agent, args: [nil] }
 
     after { ElasticAPM.stop }
   end


### PR DESCRIPTION
Turns out we can't get current controller from rack (anymore?).
But it might as well have been a better idea to do it with less
magic from the start.