### PR TITLE
Freeze config after init to avoid modification.

### DIFF
--- a/lib/elastic_apm/config.rb
+++ b/lib/elastic_apm/config.rb
@@ -34,8 +34,6 @@ module ElasticAPM
       root_path: Dir.pwd
     }.freeze
 
-    LOCK = Mutex.new
-
     def initialize(options = nil)
       options = {} if options.nil?
 
@@ -43,10 +41,7 @@ module ElasticAPM
         send("#{key}=", value)
       end
 
-      return unless block_given?
-
-      yield self
-
+      yield self if block_given?
       freeze
     end
 

--- a/lib/elastic_apm/config.rb
+++ b/lib/elastic_apm/config.rb
@@ -16,6 +16,7 @@ module ElasticAPM
 
       log_path: '-',
       log_level: Logger::INFO,
+      logger: nil,
 
       timeout: 10,
       open_timeout: 10,
@@ -45,13 +46,15 @@ module ElasticAPM
       return unless block_given?
 
       yield self
+
+      freeze
     end
 
     attr_accessor :server_url
     attr_accessor :secret_token
 
     attr_accessor :app_name
-    attr_writer :environment
+    attr_reader   :environment
     attr_accessor :framework_name
     attr_accessor :framework_version
 
@@ -74,7 +77,7 @@ module ElasticAPM
     attr_accessor :current_user_email_method
     attr_accessor :current_user_username_method
 
-    attr_writer :logger
+    attr_reader   :logger
 
     # rubocop:disable Metrics/MethodLength, Metrics/AbcSize
     def app=(app)
@@ -111,19 +114,16 @@ module ElasticAPM
       nil
     end
 
-    def environment
-      @environment ||= ENV['RAILS_ENV'] || ENV['RACK_ENV']
-    end
-
-    def logger
-      @logger ||=
-        LOCK.synchronize do
-          build_logger(log_path, log_level)
-        end
-    end
-
     def use_ssl?
       server_url.start_with?('https')
+    end
+
+    def environment=(env)
+      @environment = env || ENV['RAILS_ENV'] || ENV['RACK_ENV']
+    end
+
+    def logger=(logger)
+      @logger = logger || build_logger(log_path, log_level)
     end
 
     private


### PR DESCRIPTION
* Freeze config after creation to avoid overwriting some config by incident.
* Remove lock from setting logger as it is not memoized any longer, but directly set when initializing the config.

@mikker I don't have the big picture yet but this is an attempt to avoid overwriting the config by accident anywhere, as it is needed in many places. 