### PR TITLE
Return empty process object if pid is not given.

### DIFF
--- a/lib/elastic_apm/process_info.rb
+++ b/lib/elastic_apm/process_info.rb
@@ -8,9 +8,11 @@ module ElasticAPM
     end
 
     def build
+      pid = $PID || Process.pid
+      return unless pid
       {
         argv: ARGV,
-        pid: $PID,
+        pid: pid,
         title: $PROGRAM_NAME
       }
     end


### PR DESCRIPTION
Comply to apm-server spec that pid is required
if process object is sent.