### PR TITLE
Bundle (old) version of AS' Inflector

### DIFF
--- a/lib/elastic_apm/injectors.rb
+++ b/lib/elastic_apm/injectors.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'active_support/inflector'
+require 'elastic_apm/util/inflector'
 
 module ElasticAPM
   # @api private
@@ -46,7 +46,7 @@ module ElasticAPM
     end
 
     def self.const_defined?(const_name)
-      const = ActiveSupport::Inflector.constantize(const_name)
+      const = Util::Inflector.constantize(const_name)
       !!const
     rescue NameError
       false

--- a/lib/elastic_apm/util/inflector.rb
+++ b/lib/elastic_apm/util/inflector.rb
@@ -1,0 +1,59 @@
+module ElasticAPM
+  module Util
+    # @api private
+    module Inflector
+      # rubocop:disable all
+      # From https://github.com/rails/rails/blob/861b70e92f4a1fc0e465ffcf2ee62680519c8f6f/activesupport/lib/active_support/inflector/methods.rb#L249
+      #
+      # Tries to find a constant with the name specified in the argument string.
+      #
+      #   'Module'.constantize     # => Module
+      #   'Test::Unit'.constantize # => Test::Unit
+      #
+      # The name is assumed to be the one of a top-level constant, no matter
+      # whether it starts with "::" or not. No lexical context is taken into
+      # account:
+      #
+      #   C = 'outside'
+      #   module M
+      #     C = 'inside'
+      #     C               # => 'inside'
+      #     'C'.constantize # => 'outside', same as ::C
+      #   end
+      #
+      # NameError is raised when the name is not in CamelCase or the constant is
+      # unknown.
+      def self.constantize(camel_cased_word)
+        names = camel_cased_word.split('::')
+
+        # Trigger a built-in NameError exception including the ill-formed constant in the message.
+        Object.const_get(camel_cased_word) if names.empty?
+
+        # Remove the first blank element in case of '::ClassName' notation.
+        names.shift if names.size > 1 && names.first.empty?
+
+        names.inject(Object) do |constant, name|
+          if constant == Object
+            constant.const_get(name)
+          else
+            candidate = constant.const_get(name)
+            next candidate if constant.const_defined?(name, false)
+            next candidate unless Object.const_defined?(name)
+
+            # Go down the ancestors to check if it is owned directly. The check
+            # stops when we reach Object or the end of ancestors tree.
+            constant = constant.ancestors.inject do |const, ancestor|
+              break const    if ancestor == Object
+              break ancestor if ancestor.const_defined?(name, false)
+              const
+            end
+
+            # owner is in Object, so raise
+            constant.const_get(name, false)
+          end
+        end
+      end
+      # rubocop:enable all
+    end
+  end
+end


### PR DESCRIPTION
This might end up allowing us to remove the ActiveSupport dependency.

Removing AS would also require us to only load `Subscriber` if needed.