### PR TITLE
Log time with ms

### DIFF
--- a/lib/elastic_apm/serializers/errors.rb
+++ b/lib/elastic_apm/serializers/errors.rb
@@ -9,7 +9,7 @@ module ElasticAPM
         base = {
           id: error.id,
           culprit: error.culprit,
-          timestamp: micros_to_time(error.timestamp).utc.iso8601,
+          timestamp: micros_to_time(error.timestamp).utc.iso8601(3),
           context: error.context.to_h
         }
 

--- a/lib/elastic_apm/serializers/transactions.rb
+++ b/lib/elastic_apm/serializers/transactions.rb
@@ -12,7 +12,7 @@ module ElasticAPM
           type: transaction.type,
           result: transaction.result.to_s,
           duration: ms(transaction.duration),
-          timestamp: micros_to_time(transaction.timestamp).utc.iso8601,
+          timestamp: micros_to_time(transaction.timestamp).utc.iso8601(3),
           spans: transaction.spans.map(&method(:build_span)),
           sampled: transaction.sampled,
           context: transaction.context.to_h

--- a/spec/elastic_apm/serializers/errors_spec.rb
+++ b/spec/elastic_apm/serializers/errors_spec.rb
@@ -24,7 +24,7 @@ module ElasticAPM
             should eq(
               id: @mock_uuid,
               culprit: '/',
-              timestamp: Time.utc(1992, 1, 1).iso8601,
+              timestamp: Time.utc(1992, 1, 1).iso8601(3),
               context: { custom: {}, tags: {} },
               exception: {
                 message: 'ZeroDivisionError: divided by 0',

--- a/spec/elastic_apm/serializers/transactions_spec.rb
+++ b/spec/elastic_apm/serializers/transactions_spec.rb
@@ -28,7 +28,7 @@ module ElasticAPM
               "result": '200',
               "context": { custom: {}, tags: {} },
               "duration": 100.0,
-              "timestamp": Time.utc(1992, 1, 1).iso8601,
+              "timestamp": Time.utc(1992, 1, 1).iso8601(3),
               "spans": [],
               "sampled": true
             )
@@ -62,7 +62,7 @@ module ElasticAPM
               "result": '200',
               "context": { custom: {}, tags: {} },
               "duration": 50,
-              "timestamp": Time.utc(1992, 1, 1).iso8601,
+              "timestamp": Time.utc(1992, 1, 1).iso8601(3),
               "spans": [
                 {
                   id: 0,


### PR DESCRIPTION
Hi, guys!

Why not log `@timestamp` with milliseconds for better verbosity and ordering in elasticsearch.