### PR TITLE
Add delayed job injector

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,7 @@ git_source(:github) { |repo_name| "https://github.com/#{repo_name}" }
 
 gemspec
 
+gem 'delayed_job'
 gem 'fakeredis', require: nil,
   github: 'guilleiguaran/fakeredis' # needs master right now
 gem 'json-schema'
@@ -13,6 +14,7 @@ gem 'pry'
 gem 'rack-test'
 gem 'redis', require: nil
 gem 'rspec'
+gem 'rspec-its'
 gem 'rubocop'
 gem 'sequel'
 gem 'timecop'

--- a/lib/elastic_apm/injectors/delayed_job.rb
+++ b/lib/elastic_apm/injectors/delayed_job.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+module ElasticAPM
+  # @api private
+  module Injectors
+    # @api private
+    class DelayedJobInjector
+      def install
+        ::Delayed::Backend::Base.class_eval do
+          alias invoke_job_without_apm invoke_job
+
+          def invoke_job(*args, &block)
+            ::ElasticAPM::Injectors::DelayedJobInjector
+              .invoke_job(self, *args, &block)
+          end
+        end
+      end
+
+      def self.invoke_job(job, *args, &block)
+        job_name = name_from_payload(job.payload_object)
+        transaction = ElasticAPM.transaction(job_name, 'Delayed::Job')
+        job.invoke_job_without_apm(*args, &block)
+        transaction.submit
+      rescue ::Exception => e
+        ElasticAPM.report(e, handled: false)
+        transaction.submit
+        raise
+      ensure
+        transaction.release if transaction
+      end
+
+      def self.name_from_payload(payload_object)
+        if payload_object.is_a?(::Delayed::PerformableMethod)
+          performable_method_name(payload_object)
+        else
+          payload_object.class.name
+        end
+      end
+
+      def self.performable_method_name(payload_object)
+        class_name = object_name(payload_object)
+        separator = name_separator(payload_object)
+        method_name = payload_object.method_name
+        "#{class_name}#{separator}#{method_name}"
+      end
+
+      def self.object_name(payload_object)
+        object = payload_object.object
+        klass = object.is_a?(Class) ? object : object.class
+        klass.name
+      end
+
+      def self.name_separator(payload_object)
+        payload_object.object.is_a?(Class) ? '.' : '#'
+      end
+    end
+
+    register(
+      'Delayed::Backend::Base',
+      'delayed/backend/base',
+      DelayedJobInjector.new
+    )
+  end
+end

--- a/spec/elastic_apm/injectors/delayed_job_spec.rb
+++ b/spec/elastic_apm/injectors/delayed_job_spec.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+require 'elastic_apm/injectors/delayed_job'
+require 'delayed_job'
+
+class TransactionCapturingJob
+  attr_accessor :transaction
+
+  def perform
+    self.transaction = ElasticAPM.current_transaction
+  end
+end
+
+class MockJobBackend
+  include Delayed::Backend::Base
+
+  def initialize(job)
+    @job = job
+  end
+
+  def payload_object
+    @job
+  end
+end
+
+module ElasticAPM
+  RSpec.describe Injectors::DelayedJobInjector do
+    it 'registers' do
+      registration =
+        Injectors.require_hooks['delayed/backend/base'] ||
+        Injectors.installed['Delayed::Backend::Base']
+
+      expect(registration.injector).to be_a described_class
+    end
+
+    describe 'tracing' do
+      let(:enabled_injectors) { %w[delayed_job] }
+      let(:config) { Config.new(enabled_injectors: enabled_injectors) }
+      let(:mock_job) { TransactionCapturingJob.new }
+      let(:invokable) { mock_job }
+
+      before do
+        Delayed::Worker.backend = MockJobBackend
+        ElasticAPM.start
+        Delayed::Job.new(invokable).invoke_job
+      end
+
+      after do
+        ElasticAPM.stop
+      end
+
+      subject { mock_job.transaction }
+
+      describe 'class-based job transaction' do
+        it { is_expected.not_to be_nil }
+        its(:name) { is_expected.to eq 'TransactionCapturingJob' }
+        its(:type) { is_expected.to eq 'Delayed::Job' }
+      end
+
+      describe 'method-based job transaction' do
+        let(:invokable) do
+          Delayed::PerformableMethod.new(mock_job, :perform, [])
+        end
+
+        it { is_expected.not_to be_nil }
+        its(:name) { is_expected.to eq 'TransactionCapturingJob#perform' }
+        its(:type) { is_expected.to eq 'Delayed::Job' }
+      end
+    end
+  end
+end


### PR DESCRIPTION
This adds support for tracing `Delayed::Job`s. I attempted to follow patterns in the other injectors. Let me know if the approach is reasonable. Any feedback appreciated!