### PR TITLE
Always load config from file if it exists

### DIFF
--- a/lib/elastic_apm/agent.rb
+++ b/lib/elastic_apm/agent.rb
@@ -27,7 +27,7 @@ module ElasticAPM
     def self.start(config)
       return @instance if @instance
 
-      config = Config.new(config) if config.is_a?(Hash)
+      config = Config.new(config) unless config.is_a?(Config)
 
       unless config.enabled_environments.include?(config.environment)
         config.logger && config.logger.info(

--- a/lib/elastic_apm/railtie.rb
+++ b/lib/elastic_apm/railtie.rb
@@ -7,14 +7,7 @@ module ElasticAPM
     Config::DEFAULTS.each { |option, value| config.elastic_apm[option] = value }
 
     initializer 'elastic_apm.initialize' do |app|
-      config = Config.new app.config.elastic_apm do |c|
-        c.app = app
-      end
-
-      file_config = load_config(app)
-      file_config.each do |option, value|
-        config.send(:"#{option}=", value)
-      end
+      config = app.config.elastic_apm.merge(app: app)
 
       begin
         ElasticAPM.start config
@@ -28,15 +21,6 @@ module ElasticAPM
 
     config.after_initialize do
       require 'elastic_apm/injectors/action_dispatch'
-    end
-
-    private
-
-    def load_config(app)
-      config_path = app.root.join('config', 'elastic_apm.yml')
-      return {} unless File.exist?(config_path)
-
-      YAML.load_file(config_path) || {}
     end
   end
 end

--- a/spec/elastic_apm/config_spec.rb
+++ b/spec/elastic_apm/config_spec.rb
@@ -14,6 +14,11 @@ module ElasticAPM
       expect(config.server_url).to eq 'somewhere-else.com'
     end
 
+    it 'loads from config file' do
+      config = Config.new(config_file: 'spec/fixtures/elastic_apm.yml')
+      expect(config.server_url).to eq 'somewhere-config.com'
+    end
+
     it 'takes options from ENV' do
       ENV['ELASTIC_APM_SERVER_URL'] = 'by-env!'
       config = Config.new

--- a/spec/fixtures/elastic_apm.yml
+++ b/spec/fixtures/elastic_apm.yml
@@ -1,0 +1,2 @@
+---
+server_url: 'somewhere-config.com'


### PR DESCRIPTION
This moves the responsibility to check for and load the config file
from the Railtie to the individual Config. This means every app should
configure by file, Rack/Sinatra as well as Rails.

Closes #83 