### PR TITLE
set env config after args/config_file

### DIFF
--- a/lib/elastic_apm/config.rb
+++ b/lib/elastic_apm/config.rb
@@ -85,8 +85,8 @@ module ElasticAPM
       set_defaults
 
       set_from_args(options)
-      set_from_env
       set_from_config_file
+      set_from_env
 
       yield self if block_given?
     end


### PR DESCRIPTION
**What**
Load environment variable config last (after defaults and yml config)

**Why**
I did not use the yml file because I prefer to use environment variable to secure secrets with apps using APM.

Without a yml file with hardcoded `server_url` and `secret_token`
configs, ENV variables were not being applied because they were being
overwritten by the defaults.

**Other Solutions**
If there is something I'm not seeing with the importance of the order for these options, I think allowing embedded ruby in that yml file so we don't have to check in secrets would be great. Happy to do that PR if you'd prefer that. 

Example:

```yml
server_url: <%= ENV['ELASTIC_APM_SERVER_URL'] %>
```
