### PR TITLE
Omit collecting full redis statements

### DIFF
--- a/spec/elastic_apm/injectors/json_spec.rb
+++ b/spec/elastic_apm/injectors/json_spec.rb
@@ -5,7 +5,7 @@ require 'spec_helper'
 module ElasticAPM
   RSpec.describe 'Injectors::JSONInjector' do
     it 'spans #parse' do
-      ElasticAPM.start
+      ElasticAPM.start disabled_injectors: []
 
       transaction = ElasticAPM.transaction 'T' do
         JSON.parse('[{"simply":"the best"}]')
@@ -18,7 +18,7 @@ module ElasticAPM
     end
 
     it 'spans #parse!' do
-      ElasticAPM.start
+      ElasticAPM.start disabled_injectors: []
 
       transaction = ElasticAPM.transaction 'T' do
         JSON.parse!('[{"simply":"the best"}]')
@@ -31,7 +31,7 @@ module ElasticAPM
     end
 
     it 'spans #generate' do
-      ElasticAPM.start
+      ElasticAPM.start disabled_injectors: []
 
       transaction = ElasticAPM.transaction 'T' do
         JSON.generate([{ simply: 'the_best' }])

--- a/spec/elastic_apm/injectors/redis_spec.rb
+++ b/spec/elastic_apm/injectors/redis_spec.rb
@@ -18,7 +18,6 @@ module ElasticAPM
       expect(transaction.spans.length).to be 1
       span = transaction.spans.last
       expect(span.name).to eq 'LRANGE'
-      expect(span.context.statement).to eq 'LRANGE some:where 0 -1'
 
       ElasticAPM.stop
     end


### PR DESCRIPTION
Statements could very well include very large or confidential data, so for now we'll just omit them from APM.

Closes elastic/apm-agent-ruby#94