### PR TITLE
Add support for HTTP compression

### DIFF
--- a/lib/elastic_apm/config.rb
+++ b/lib/elastic_apm/config.rb
@@ -35,6 +35,9 @@ module ElasticAPM
       debug_transactions: false,
       debug_http: false,
       verify_server_cert: true,
+      http_compression: true,
+      compression_minimum_size: 1024 * 5,
+      compression_level: 6,
 
       source_lines_error_app_frames: 5,
       source_lines_span_app_frames: 5,
@@ -119,6 +122,9 @@ module ElasticAPM
     attr_accessor :http_open_timeout
     attr_accessor :debug_transactions
     attr_accessor :debug_http
+    attr_accessor :http_compression
+    attr_accessor :compression_minimum_size
+    attr_accessor :compression_level
 
     attr_accessor :source_lines_error_app_frames
     attr_accessor :source_lines_span_app_frames

--- a/lib/elastic_apm/http.rb
+++ b/lib/elastic_apm/http.rb
@@ -58,18 +58,21 @@ module ElasticAPM
           req['Authorization'] = "Bearer #{token}"
         end
 
-        if @config.http_compression && data.bytesize > @config.compression_minimum_size
-          deflated = Zlib.deflate data, @config.compression_level
-          puts "Deflating #{data.bytesize} bytes to #{deflated.bytesize} bytes"
+        prepare_request_body! req, data
+      end
+    end
 
-          req['Content-Encoding'] = 'deflate'
-          req['Content-Length'] = deflated.bytesize.to_s
-          req.body = deflated
-        else
-          puts "Not deflating!"
-          req['Content-Length'] = data.bytesize.to_s
-          req.body = data
-        end
+    def prepare_request_body!(req, data)
+      if @config.http_compression &&
+         data.bytesize > @config.compression_minimum_size
+        deflated = Zlib.deflate data, @config.compression_level
+
+        req['Content-Encoding'] = 'deflate'
+        req['Content-Length'] = deflated.bytesize.to_s
+        req.body = deflated
+      else
+        req['Content-Length'] = data.bytesize.to_s
+        req.body = data
       end
     end
 

--- a/spec/elastic_apm/http_spec.rb
+++ b/spec/elastic_apm/http_spec.rb
@@ -5,9 +5,14 @@ require 'spec_helper'
 module ElasticAPM
   RSpec.describe Http do
     describe '#post', :with_fake_server do
-      let(:config) { { } }
+      let(:config) { {} }
 
-      subject { Http.new Config.new({service_name: 'app-1', environment: 'test'}.merge(config)) }
+      subject do
+        Http.new Config.new({
+          service_name: 'app-1',
+          environment: 'test'
+        }.merge(config))
+      end
 
       it 'sets the appropriate headers' do
         subject.post('/v1/transactions', things: 1)
@@ -51,36 +56,53 @@ module ElasticAPM
         expect(headers['ApiKey']).to eq '[FILTERED]'
       end
 
-      context "compression" do
+      context 'compression' do
         before do
           subject.post('/v1/transactions', things: 1)
         end
 
-        context "with payloads under the minimum compression size" do
-          let(:config) {{ compression_minimum_size: 1_024_000 }}
+        context 'with payloads under the minimum compression size' do
+          let(:config) do
+            {
+              compression_minimum_size: 1_024_000
+            }
+          end
 
           it "doesn't compress the payload" do
-            expect(WebMock).to_not have_requested(:post, %r{/v1/transactions}).with(
-              headers: { 'Content-Encoding' => 'deflate' }
-            )
+            expect(WebMock).to_not have_requested(:post, %r{/v1/transactions})
+              .with(
+                headers: { 'Content-Encoding' => 'deflate' }
+              )
           end
         end
 
-        context "with payloads over the minimum compression size" do
-          let(:config) {{ compression_minimum_size: 1 }}
-
-          it "compresses the payload" do
-            expect(WebMock).to have_requested(:post, %r{/v1/transactions}).with(
-              headers: { 'Content-Encoding' => 'deflate' }
-            )
+        context 'with payloads over the minimum compression size' do
+          let(:config) do
+            {
+              compression_minimum_size: 1
+            }
           end
 
-          context "and compression disabled" do
-            let(:config) {{ compression_minimum_size: 1, http_compression: false }}
-            it "doesn't compress the payload" do
-              expect(WebMock).to_not have_requested(:post, %r{/v1/transactions}).with(
+          it 'compresses the payload' do
+            expect(WebMock).to have_requested(:post, %r{/v1/transactions})
+              .with(
                 headers: { 'Content-Encoding' => 'deflate' }
               )
+          end
+
+          context 'and compression disabled' do
+            let(:config) do
+              {
+                compression_minimum_size: 1,
+                http_compression: false
+              }
+            end
+
+            it "doesn't compress the payload" do
+              expect(WebMock).to_not have_requested(:post, %r{/v1/transactions})
+                .with(
+                  headers: { 'Content-Encoding' => 'deflate' }
+                )
             end
           end
         end

--- a/spec/support/with_fake_server.rb
+++ b/spec/support/with_fake_server.rb
@@ -23,7 +23,12 @@ class FakeServer
 
     def call(env)
       request = Rack::Request.new(env)
-      requests << JSON.parse(request.body.read)
+      body = request.body.read
+      encoding = request.env["HTTP_CONTENT_ENCODING"]
+      if encoding && encoding.match(/deflate/)
+        body = Zlib.inflate(body)
+      end
+      requests << JSON.parse(body)
 
       [200, { 'Content-Type' => 'application/json' }, ['ok']]
     end

--- a/spec/support/with_fake_server.rb
+++ b/spec/support/with_fake_server.rb
@@ -26,7 +26,7 @@ class FakeServer
       body = request.body.read
       encoding = request.env['HTTP_CONTENT_ENCODING']
       if encoding && encoding.match(/deflate/)
-        body = Zlib.inflate(body)
+        body = Zlib::Inflate.inflate(body)
       end
       requests << JSON.parse(body)
 

--- a/spec/support/with_fake_server.rb
+++ b/spec/support/with_fake_server.rb
@@ -24,7 +24,7 @@ class FakeServer
     def call(env)
       request = Rack::Request.new(env)
       body = request.body.read
-      encoding = request.env["HTTP_CONTENT_ENCODING"]
+      encoding = request.env['HTTP_CONTENT_ENCODING']
       if encoding && encoding.match(/deflate/)
         body = Zlib.inflate(body)
       end


### PR DESCRIPTION
Non-compressed payloads are frequently failing to post with broken pipe errors due to the excessive size  of the payloads. This is due in part to the tremendous size of backtraces captured for transactions, but is helped by deflating the content prior to posting. This satisfies #93, which helps, but probably won't be sufficient for production usage by itself.

Adds 3 config options:

* http_compression: bool (default true)        - Turns compression on or off
* compression_minimum_size: int (default 5120) - Sets the minimum payload length to deflate.
                                                 Smaller payloads will not be deflated.
* compression_level: int (default 6)           - Sets the zlib deflate level to use.

The 5k minimum size is arbitrarily chosen. I've seen recommendations as low as 1kb and as high as 10kb.