### PR TITLE
Allow transaction.name to be nil

### DIFF
--- a/lib/elastic_apm.rb
+++ b/lib/elastic_apm.rb
@@ -61,7 +61,7 @@ module ElasticAPM
   # @param context [Context] An optional [Context]
   # @yield [Transaction] Optional block encapsulating transaction
   # @return [Transaction] Unless block given
-  def self.transaction(name, type = nil, context: nil, &block)
+  def self.transaction(name = nil, type = nil, context: nil, &block)
     return (block_given? ? yield : nil) unless agent
 
     agent.transaction(name, type, context: context, &block)

--- a/lib/elastic_apm/transaction.rb
+++ b/lib/elastic_apm/transaction.rb
@@ -6,7 +6,7 @@ module ElasticAPM
     DEFAULT_TYPE = 'custom'.freeze
 
     # rubocop:disable Metrics/MethodLength
-    def initialize(instrumenter, name, type = nil, context: nil, sampled: true)
+    def initialize(instrumenter, name = nil, type = nil, context: nil, sampled: true)
       @id = SecureRandom.uuid
       @instrumenter = instrumenter
       @name = name

--- a/lib/elastic_apm/transaction.rb
+++ b/lib/elastic_apm/transaction.rb
@@ -6,7 +6,13 @@ module ElasticAPM
     DEFAULT_TYPE = 'custom'.freeze
 
     # rubocop:disable Metrics/MethodLength
-    def initialize(instrumenter, name = nil, type = nil, context: nil, sampled: true)
+    def initialize(
+      instrumenter,
+      name = nil,
+      type = nil,
+      context: nil,
+      sampled: true
+    )
       @id = SecureRandom.uuid
       @instrumenter = instrumenter
       @name = name

--- a/spec/elastic_apm/agent_spec.rb
+++ b/spec/elastic_apm/agent_spec.rb
@@ -77,7 +77,7 @@ module ElasticAPM
       subject { Agent.new Config.new(flush_interval: nil) }
 
       it 'enqueues a collection of transactions' do
-        transaction = subject.transaction 'T'
+        transaction = subject.transaction
 
         subject.enqueue_transaction(transaction)
         wait_for_requests_to_finish 1

--- a/spec/elastic_apm/instrumenter_spec.rb
+++ b/spec/elastic_apm/instrumenter_spec.rb
@@ -22,7 +22,7 @@ module ElasticAPM
       it 'cleans up after itself' do
         instrumenter = Instrumenter.new(Config.new, nil)
 
-        instrumenter.transaction 'T'
+        instrumenter.transaction
 
         expect(instrumenter.current_transaction).to_not be_nil
 
@@ -39,6 +39,8 @@ module ElasticAPM
       it 'returns a new transaction and sets it as current' do
         context = Context.new
         transaction = subject.transaction 'Test', 't', context: context
+        expect(transaction.name).to eq 'Test'
+        expect(transaction.type).to eq 't'
         expect(transaction.id).to be subject.current_transaction.id
         expect(subject.current_transaction).to be transaction
         expect(transaction.context).to be context

--- a/spec/elastic_apm/transaction_spec.rb
+++ b/spec/elastic_apm/transaction_spec.rb
@@ -6,18 +6,18 @@ module ElasticAPM
   RSpec.describe Transaction do
     describe '#initialize', :mock_time do
       it 'has no spans, timestamp and start time' do
-        transaction = Transaction.new nil, 'Test'
+        transaction = Transaction.new nil
 
         expect(transaction.spans.length).to be 0
         expect(transaction.timestamp).to eq 694_224_000_000_000
       end
 
       it 'has a uuid' do
-        expect(Transaction.new(nil, 'Test').id).to_not be_nil
+        expect(Transaction.new(nil).id).to_not be_nil
       end
 
       it 'has a default type' do
-        expect(Transaction.new(nil, 'Test').type).to_not be_nil
+        expect(Transaction.new(nil).type).to_not be_nil
       end
     end
 

--- a/spec/elastic_apm_spec.rb
+++ b/spec/elastic_apm_spec.rb
@@ -53,7 +53,7 @@ RSpec.describe ElasticAPM do
     it 'still yields block' do
       ran = false
 
-      ElasticAPM.transaction('Test') { ran = true }
+      ElasticAPM.transaction { ran = true }
 
       expect(ran).to be true
     end


### PR DESCRIPTION
Fixes elastic/apm-agent-ruby#49