### PR TITLE
Add experimental stacktrace frame cache

### DIFF
--- a/spec/elastic_apm/util/lru_cache_spec.rb
+++ b/spec/elastic_apm/util/lru_cache_spec.rb
@@ -15,5 +15,13 @@ module ElasticAPM
       expect(subject.length).to be 2
       expect(subject.to_a).to match([[:a, 1], [:c, 3]])
     end
+
+    it 'taks a block' do
+      subject = described_class.new do |cache, key|
+        cache[key] = 'missing'
+      end
+
+      expect(subject['other key']).to eq 'missing'
+    end
   end
 end


### PR DESCRIPTION
Significantly decreases the time spent building frames for every span.
At the cost no cache invalidation. So if the code changes after the
process starts, we'll capture the wrong frames. _Shouldn't_ happen, but…

Will try this in a production app over the weekend to see if it gives any weird results.