### PR TITLE
Rename injectors -> spies

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,2 +1,1 @@
---format documentation
 --color

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -53,5 +53,8 @@ Style/SafeNavigation:
 Style/DoubleNegation:
   Enabled: false
 
+Style/EmptyMethod:
+  Enabled: false
+
 Rails/Delegate:
   Enabled: false

--- a/lib/elastic_apm/config.rb
+++ b/lib/elastic_apm/config.rb
@@ -36,7 +36,7 @@ module ElasticAPM
       source_lines_error_library_frames: 0,
       source_lines_span_library_frames: 0,
 
-      disabled_injectors: %w[json],
+      disabled_spies: %w[json],
 
       current_user_id_method: :id,
       current_user_email_method: :email,
@@ -74,7 +74,7 @@ module ElasticAPM
       'ELASTIC_APM_VERIFY_SERVER_CERT' => [:bool, 'verify_server_cert'],
       'ELASTIC_APM_TRANSACTION_MAX_SPANS' => [:int, 'transaction_max_spans'],
 
-      'ELASTIC_APM_DISABLED_INJECTORS' => [:list, 'disabled_injectors']
+      'ELASTIC_APM_DISABLED_SPIES' => [:list, 'disabled_spies']
     }.freeze
 
     def initialize(options = {})
@@ -123,7 +123,7 @@ module ElasticAPM
     attr_accessor :source_lines_error_library_frames
     attr_accessor :source_lines_span_library_frames
 
-    attr_accessor :disabled_injectors
+    attr_accessor :disabled_spies
 
     attr_accessor :view_paths
     attr_accessor :root_path
@@ -170,7 +170,7 @@ module ElasticAPM
     end
 
     # rubocop:disable Metrics/MethodLength
-    def available_injectors
+    def available_spies
       %w[
         action_dispatch
         delayed_job
@@ -187,8 +187,8 @@ module ElasticAPM
     end
     # rubocop:enable Metrics/MethodLength
 
-    def enabled_injectors
-      available_injectors - disabled_injectors
+    def enabled_spies
+      available_spies - disabled_spies
     end
 
     private

--- a/lib/elastic_apm/instrumenter.rb
+++ b/lib/elastic_apm/instrumenter.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require 'elastic_apm/subscriber'
 require 'elastic_apm/span'
 require 'elastic_apm/transaction'
 
@@ -26,24 +25,26 @@ module ElasticAPM
       end
     end
 
-    def initialize(config, agent, subscriber_class: Subscriber)
+    def initialize(config, agent)
       @config = config
       @agent = agent
 
       @transaction_info = TransactionInfo.new
-
-      @subscriber = subscriber_class.new(config)
     end
 
     attr_reader :config, :pending_transactions
 
     def start
-      @subscriber.register!
     end
 
     def stop
       current_transaction.release if current_transaction
-      @subscriber.unregister!
+      @subscriber.unregister! if @subscriber
+    end
+
+    def subscriber=(subscriber)
+      @subscriber = subscriber
+      @subscriber.register!
     end
 
     def current_transaction

--- a/lib/elastic_apm/railtie.rb
+++ b/lib/elastic_apm/railtie.rb
@@ -20,7 +20,7 @@ module ElasticAPM
     end
 
     config.after_initialize do
-      require 'elastic_apm/injectors/action_dispatch'
+      require 'elastic_apm/spies/action_dispatch'
     end
   end
 end

--- a/lib/elastic_apm/railtie.rb
+++ b/lib/elastic_apm/railtie.rb
@@ -6,6 +6,7 @@ module ElasticAPM
   # @api private
   class Railtie < Rails::Railtie
     config.elastic_apm = ActiveSupport::OrderedOptions.new
+
     Config::DEFAULTS.each { |option, value| config.elastic_apm[option] = value }
 
     initializer 'elastic_apm.initialize' do |app|
@@ -15,8 +16,7 @@ module ElasticAPM
         agent = ElasticAPM.start config
 
         if agent
-          agent.instrumenter.subscriber =
-            ElasticAPM::Subscriber.new(agent.config)
+          agent.instrumenter.subscriber = ElasticAPM::Subscriber.new(agent)
 
           app.middleware.insert 0, Middleware
         end

--- a/lib/elastic_apm/spies.rb
+++ b/lib/elastic_apm/spies.rb
@@ -4,20 +4,20 @@ require 'elastic_apm/util/inflector'
 
 module ElasticAPM
   # @api private
-  module Injectors
+  module Spies
     # @api private
     class Registration
       extend Forwardable
 
-      def initialize(const_name, require_paths, injector)
+      def initialize(const_name, require_paths, spy)
         @const_name = const_name
         @require_paths = Array(require_paths)
-        @injector = injector
+        @spy = spy
       end
 
       attr_reader :const_name, :require_paths
 
-      def_delegator :@injector, :install
+      def_delegator :@spy, :install
     end
 
     def self.require_hooks
@@ -73,7 +73,7 @@ module Kernel
     res = require_without_apm(path)
 
     begin
-      ElasticAPM::Injectors.hook_into(path)
+      ElasticAPM::Spies.hook_into(path)
     rescue ::Exception => e
       puts "Failed hooking into '#{path}'. Please report this at " \
         'github.com/elastic/apm-agent-ruby'

--- a/lib/elastic_apm/spies/action_dispatch.rb
+++ b/lib/elastic_apm/spies/action_dispatch.rb
@@ -2,9 +2,9 @@
 
 module ElasticAPM
   # @api private
-  module Injectors
+  module Spies
     # @api private
-    class ActionDispatchInjector
+    class ActionDispatchSpy
       def install
         ::ActionDispatch::ShowExceptions.class_eval do
           alias render_exception_without_apm render_exception
@@ -20,7 +20,7 @@ module ElasticAPM
     register(
       'ActionDispatch::ShowExceptions',
       'action_dispatch/show_exception',
-      ActionDispatchInjector.new
+      ActionDispatchSpy.new
     )
   end
 end

--- a/lib/elastic_apm/spies/delayed_job.rb
+++ b/lib/elastic_apm/spies/delayed_job.rb
@@ -2,9 +2,9 @@
 
 module ElasticAPM
   # @api private
-  module Injectors
+  module Spies
     # @api private
-    class DelayedJobInjector
+    class DelayedJobSpy
       CLASS_SEPARATOR = '.'.freeze
       METHOD_SEPARATOR = '#'.freeze
       TYPE = 'Delayed::Job'.freeze
@@ -14,7 +14,7 @@ module ElasticAPM
           alias invoke_job_without_apm invoke_job
 
           def invoke_job(*args, &block)
-            ::ElasticAPM::Injectors::DelayedJobInjector
+            ::ElasticAPM::Spies::DelayedJobSpy
               .invoke_job(self, *args, &block)
           end
         end
@@ -62,7 +62,7 @@ module ElasticAPM
     register(
       'Delayed::Backend::Base',
       'delayed/backend/base',
-      DelayedJobInjector.new
+      DelayedJobSpy.new
     )
   end
 end

--- a/lib/elastic_apm/spies/elasticsearch.rb
+++ b/lib/elastic_apm/spies/elasticsearch.rb
@@ -2,9 +2,9 @@
 
 module ElasticAPM
   # @api private
-  module Injectors
+  module Spies
     # @api private
-    class ElasticsearchInjector
+    class ElasticsearchSpy
       NAME_FORMAT = '%s %s'.freeze
       TYPE = 'db.elasticsearch'.freeze
 
@@ -27,7 +27,7 @@ module ElasticAPM
     register(
       'Elasticsearch::Transport::Client',
       'elasticsearch-transport',
-      ElasticsearchInjector.new
+      ElasticsearchSpy.new
     )
   end
 end

--- a/lib/elastic_apm/spies/json.rb
+++ b/lib/elastic_apm/spies/json.rb
@@ -4,9 +4,9 @@ require 'elastic_apm/span_helpers'
 
 module ElasticAPM
   # @api private
-  module Injectors
+  module Spies
     # @api private
-    class JSONInjector
+    class JSONSpy
       def install
         ::JSON.class_eval do
           include SpanHelpers
@@ -17,6 +17,6 @@ module ElasticAPM
       end
     end
 
-    register 'JSON', 'json', JSONInjector.new
+    register 'JSON', 'json', JSONSpy.new
   end
 end

--- a/lib/elastic_apm/spies/mongo.rb
+++ b/lib/elastic_apm/spies/mongo.rb
@@ -2,9 +2,9 @@
 
 module ElasticAPM
   # @api private
-  module Injectors
+  module Spies
     # @api private
-    class MongoInjector
+    class MongoSpy
       def install
         ::Mongo::Monitoring::Global.subscribe(
           ::Mongo::Monitoring::COMMAND,
@@ -52,6 +52,6 @@ module ElasticAPM
       end
     end
 
-    register 'Mongo', 'mongo', MongoInjector.new
+    register 'Mongo', 'mongo', MongoSpy.new
   end
 end

--- a/lib/elastic_apm/spies/net_http.rb
+++ b/lib/elastic_apm/spies/net_http.rb
@@ -2,9 +2,9 @@
 
 module ElasticAPM
   # @api private
-  module Injectors
+  module Spies
     # @api private
-    class NetHTTPInjector
+    class NetHTTPSpy
       # rubocop:disable Metrics/MethodLength
       def install
         Net::HTTP.class_eval do
@@ -32,6 +32,6 @@ module ElasticAPM
       # rubocop:enable Metrics/MethodLength
     end
 
-    register 'Net::HTTP', 'net/http', NetHTTPInjector.new
+    register 'Net::HTTP', 'net/http', NetHTTPSpy.new
   end
 end

--- a/lib/elastic_apm/spies/redis.rb
+++ b/lib/elastic_apm/spies/redis.rb
@@ -2,9 +2,9 @@
 
 module ElasticAPM
   # @api private
-  module Injectors
+  module Spies
     # @api private
-    class RedisInjector
+    class RedisSpy
       def install
         ::Redis::Client.class_eval do
           alias call_without_apm call
@@ -22,6 +22,6 @@ module ElasticAPM
       end
     end
 
-    register 'Redis', 'redis', RedisInjector.new
+    register 'Redis', 'redis', RedisSpy.new
   end
 end

--- a/lib/elastic_apm/spies/sequel.rb
+++ b/lib/elastic_apm/spies/sequel.rb
@@ -4,9 +4,9 @@ require 'elastic_apm/sql_summarizer'
 
 module ElasticAPM
   # @api private
-  module Injectors
+  module Spies
     # @api private
-    class SequelInjector
+    class SequelSpy
       TYPE = 'db.sequel.sql'.freeze
 
       def self.summarizer
@@ -25,7 +25,7 @@ module ElasticAPM
               return log_connection_yield_without_apm(sql, *args, &block)
             end
 
-            summarizer = ElasticAPM::Injectors::SequelInjector.summarizer
+            summarizer = ElasticAPM::Spies::SequelSpy.summarizer
             name = summarizer.summarize sql
             context = Span::Context.new(
               statement: sql,
@@ -40,6 +40,6 @@ module ElasticAPM
       # rubocop:enable Metrics/MethodLength
     end
 
-    register 'Sequel', 'sequel', SequelInjector.new
+    register 'Sequel', 'sequel', SequelSpy.new
   end
 end

--- a/lib/elastic_apm/spies/sidekiq.rb
+++ b/lib/elastic_apm/spies/sidekiq.rb
@@ -2,9 +2,9 @@
 
 module ElasticAPM
   # @api private
-  module Injectors
+  module Spies
     # @api private
-    class SidekiqInjector
+    class SidekiqSpy
       ACTIVE_JOB_WRAPPER =
         'ActiveJob::QueueAdapters::SidekiqAdapter::JobWrapper'.freeze
 
@@ -12,7 +12,7 @@ module ElasticAPM
       class Middleware
         # rubocop:disable Metrics/MethodLength
         def call(_worker, job, queue)
-          name = SidekiqInjector.name_for(job)
+          name = SidekiqSpy.name_for(job)
           transaction = ElasticAPM.transaction(name, 'Sidekiq')
           ElasticAPM.set_tag(:queue, queue)
 
@@ -81,6 +81,6 @@ module ElasticAPM
       end
     end
 
-    register 'Sidekiq', 'sidekiq', SidekiqInjector.new
+    register 'Sidekiq', 'sidekiq', SidekiqSpy.new
   end
 end

--- a/lib/elastic_apm/spies/sinatra.rb
+++ b/lib/elastic_apm/spies/sinatra.rb
@@ -2,9 +2,9 @@
 
 module ElasticAPM
   # @api private
-  module Injectors
+  module Spies
     # @api private
-    class SinatraInjector
+    class SinatraSpy
       # rubocop:disable Metrics/MethodLength
       def install
         ::Sinatra::Base.class_eval do
@@ -34,8 +34,8 @@ module ElasticAPM
       # rubocop:enable Metrics/MethodLength
     end
 
-    register 'Sinatra::Base', 'sinatra/base', SinatraInjector.new
+    register 'Sinatra::Base', 'sinatra/base', SinatraSpy.new
 
-    require 'elastic_apm/injectors/tilt'
+    require 'elastic_apm/spies/tilt'
   end
 end

--- a/lib/elastic_apm/spies/tilt.rb
+++ b/lib/elastic_apm/spies/tilt.rb
@@ -2,9 +2,9 @@
 
 module ElasticAPM
   # @api private
-  module Injectors
+  module Spies
     # @api private
-    class TiltInjector
+    class TiltSpy
       TYPE = 'template.tilt'.freeze
 
       def install
@@ -22,6 +22,6 @@ module ElasticAPM
       end
     end
 
-    register 'Tilt::Template', 'tilt/template', TiltInjector.new
+    register 'Tilt::Template', 'tilt/template', TiltSpy.new
   end
 end

--- a/lib/elastic_apm/subscriber.rb
+++ b/lib/elastic_apm/subscriber.rb
@@ -8,10 +8,9 @@ module ElasticAPM
   class Subscriber
     include Log
 
-    def initialize(config, agent: ElasticAPM)
-      @config = config
+    def initialize(agent)
       @agent = agent
-      @normalizers = Normalizers.build(config)
+      @normalizers = Normalizers.build(agent.config)
     end
 
     def register!

--- a/spec/elastic_apm/config_spec.rb
+++ b/spec/elastic_apm/config_spec.rb
@@ -59,11 +59,11 @@ module ElasticAPM
       expect(config.server_url).to eq 'somewhere-else.com'
     end
 
-    it 'has injectors and may disable them' do
-      expect(Config.new.available_injectors).to_not be_empty
+    it 'has spies and may disable them' do
+      expect(Config.new.available_spies).to_not be_empty
 
-      config = Config.new disabled_injectors: ['json']
-      expect(config.enabled_injectors).to_not include('json')
+      config = Config.new disabled_spies: ['json']
+      expect(config.enabled_spies).to_not include('json')
     end
   end
 end

--- a/spec/elastic_apm/instrumenter_spec.rb
+++ b/spec/elastic_apm/instrumenter_spec.rb
@@ -5,20 +5,6 @@ require 'spec_helper'
 module ElasticAPM
   RSpec.describe Instrumenter do
     context 'life cycle' do
-      it 'registers and unregisters' do
-        mock_subscriber = double(Subscriber, register!: true, unregister!: true)
-        mock_class = double(new: mock_subscriber)
-
-        instrumenter =
-          Instrumenter.new(Config.new, nil, subscriber_class: mock_class)
-
-        instrumenter.start
-        expect(mock_subscriber).to have_received(:register!)
-
-        instrumenter.stop
-        expect(mock_subscriber).to have_received(:unregister!)
-      end
-
       it 'cleans up after itself' do
         instrumenter = Instrumenter.new(Config.new, nil)
 

--- a/spec/elastic_apm/normalizers/action_controller_spec.rb
+++ b/spec/elastic_apm/normalizers/action_controller_spec.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'spec_helper'
+require 'elastic_apm/normalizers'
 
 module ElasticAPM
   module Normalizers

--- a/spec/elastic_apm/normalizers/action_view_spec.rb
+++ b/spec/elastic_apm/normalizers/action_view_spec.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'spec_helper'
+require 'elastic_apm/normalizers'
 
 module ElasticAPM
   module Normalizers

--- a/spec/elastic_apm/normalizers/active_record_spec.rb
+++ b/spec/elastic_apm/normalizers/active_record_spec.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'spec_helper'
+require 'elastic_apm/normalizers'
 
 module ElasticAPM
   module Normalizers

--- a/spec/elastic_apm/spies/delayed_job_spec.rb
+++ b/spec/elastic_apm/spies/delayed_job_spec.rb
@@ -9,7 +9,7 @@ end
 
 if defined?(Delayed::Backend)
   module ElasticAPM
-    RSpec.describe 'Injectors::DelayedJobInjector' do
+    RSpec.describe 'Spy: DelayedJob' do
       describe 'transactions', :with_fake_server do
         class TransactionCapturingJob
           attr_accessor :transaction

--- a/spec/elastic_apm/spies/elasticsearch_spec.rb
+++ b/spec/elastic_apm/spies/elasticsearch_spec.rb
@@ -5,7 +5,7 @@ require 'spec_helper'
 require 'elasticsearch'
 
 module ElasticAPM
-  RSpec.describe 'Injectors::ElasticsearchInjector', :with_fake_server do
+  RSpec.describe 'Spy: Elasticsearch', :with_fake_server do
     it 'spans requests' do
       ElasticAPM.start
       WebMock.stub_request(:get, %r{http://localhost:9200/.*})

--- a/spec/elastic_apm/spies/json_spec.rb
+++ b/spec/elastic_apm/spies/json_spec.rb
@@ -3,9 +3,9 @@
 require 'spec_helper'
 
 module ElasticAPM
-  RSpec.describe 'Injectors::JSONInjector', :with_fake_server do
+  RSpec.describe 'JSON spans', :with_fake_server do
     it 'spans #parse' do
-      ElasticAPM.start disabled_injectors: []
+      ElasticAPM.start disabled_spies: []
 
       transaction = ElasticAPM.transaction 'T' do
         JSON.parse('[{"simply":"the best"}]')
@@ -18,7 +18,7 @@ module ElasticAPM
     end
 
     it 'spans #parse!' do
-      ElasticAPM.start disabled_injectors: []
+      ElasticAPM.start disabled_spies: []
 
       transaction = ElasticAPM.transaction 'T' do
         JSON.parse!('[{"simply":"the best"}]')
@@ -31,7 +31,7 @@ module ElasticAPM
     end
 
     it 'spans #generate' do
-      ElasticAPM.start disabled_injectors: []
+      ElasticAPM.start disabled_spies: []
 
       transaction = ElasticAPM.transaction 'T' do
         JSON.generate([{ simply: 'the_best' }])

--- a/spec/elastic_apm/spies/json_spec.rb
+++ b/spec/elastic_apm/spies/json_spec.rb
@@ -3,7 +3,7 @@
 require 'spec_helper'
 
 module ElasticAPM
-  RSpec.describe 'JSON spans', :with_fake_server do
+  RSpec.describe 'Spy: JSON', :with_fake_server do
     it 'spans #parse' do
       ElasticAPM.start disabled_spies: []
 

--- a/spec/elastic_apm/spies/mongo_spec.rb
+++ b/spec/elastic_apm/spies/mongo_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 require 'mongo'
 
 module ElasticAPM
-  RSpec.describe 'Injectors::MongoInjector' do
+  RSpec.describe 'Spy: MongoDB' do
     it 'instruments calls', :with_fake_server do
       ElasticAPM.start flush_interval: nil
 

--- a/spec/elastic_apm/spies/net_http_spec.rb
+++ b/spec/elastic_apm/spies/net_http_spec.rb
@@ -4,7 +4,7 @@ require 'spec_helper'
 require 'net/http'
 
 module ElasticAPM
-  RSpec.describe 'Injectors::NetHTTPInjector', :with_fake_server do
+  RSpec.describe 'Spy: NetHTTP', :with_fake_server do
     it 'spans http calls' do
       WebMock.stub_request(:get, %r{http://example.com/.*})
       ElasticAPM.start

--- a/spec/elastic_apm/spies/redis_spec.rb
+++ b/spec/elastic_apm/spies/redis_spec.rb
@@ -5,7 +5,7 @@ require 'spec_helper'
 require 'fakeredis/rspec'
 
 module ElasticAPM
-  RSpec.describe 'Injectors::RedisInjector', :with_fake_server do
+  RSpec.describe 'Spy: Redis', :with_fake_server do
     it 'spans queries' do
       redis = ::Redis.new
       ElasticAPM.start

--- a/spec/elastic_apm/spies/sequel_spec.rb
+++ b/spec/elastic_apm/spies/sequel_spec.rb
@@ -4,7 +4,7 @@ require 'spec_helper'
 require 'sequel'
 
 module ElasticAPM
-  RSpec.describe 'Injectors::SequelInjector', :with_fake_server do
+  RSpec.describe 'Spy: Sequel', :with_fake_server do
     it 'spans calls' do
       db =
         if RUBY_PLATFORM == 'java'

--- a/spec/elastic_apm/spies/sidekiq_spec.rb
+++ b/spec/elastic_apm/spies/sidekiq_spec.rb
@@ -6,7 +6,7 @@ require 'sidekiq'
 require 'sidekiq/manager'
 require 'sidekiq/testing'
 
-require 'elastic_apm/injectors/sidekiq'
+require 'elastic_apm/spies/sidekiq'
 
 begin
   require 'active_job'
@@ -14,7 +14,7 @@ rescue LoadError
 end
 
 module ElasticAPM
-  RSpec.describe Injectors::SidekiqInjector, :with_fake_server do
+  RSpec.describe 'Sidekiq', :with_fake_server do
     module SaveTransaction
       def self.included(kls)
         class << kls
@@ -59,7 +59,7 @@ module ElasticAPM
 
     before :all do
       Sidekiq::Testing.server_middleware do |chain|
-        chain.add Injectors::SidekiqInjector::Middleware
+        chain.add Spies::SidekiqSpy::Middleware
       end
 
       Sidekiq.logger = Logger.new(nil) # sssshh, we're testing

--- a/spec/elastic_apm/spies/sinatra_spec.rb
+++ b/spec/elastic_apm/spies/sinatra_spec.rb
@@ -3,7 +3,7 @@
 require 'spec_helper'
 
 module ElasticAPM
-  RSpec.describe 'Injectors::TiltInjector' do
+  RSpec.describe 'Spy: Sinatra' do
     # See Sinatra integration spec
   end
 end

--- a/spec/elastic_apm/spies/tilt_spec.rb
+++ b/spec/elastic_apm/spies/tilt_spec.rb
@@ -3,7 +3,7 @@
 require 'spec_helper'
 
 module ElasticAPM
-  RSpec.describe 'Injectors::SinatraInjector' do
+  RSpec.describe 'Spy: Tilt' do
     # See Sinatra integration spec
   end
 end

--- a/spec/elastic_apm/subscriber_spec.rb
+++ b/spec/elastic_apm/subscriber_spec.rb
@@ -34,9 +34,8 @@ module ElasticAPM
 
     describe 'AS::Notifications API' do
       it 'adds spans from notifications' do
-        config = Config.new
-        agent = Agent.new config
-        subject = Subscriber.new config, agent: agent
+        agent = Agent.new Config.new
+        subject = Subscriber.new agent
         transaction = agent.transaction 'Test'
 
         expect do

--- a/spec/elastic_apm/subscriber_spec.rb
+++ b/spec/elastic_apm/subscriber_spec.rb
@@ -2,6 +2,8 @@
 
 require 'spec_helper'
 
+require 'elastic_apm/subscriber'
+
 module ElasticAPM
   RSpec.describe Subscriber do
     describe '#register!' do


### PR DESCRIPTION
The word 'injector' felt too forced and made-up.
Very breaking change.

Also moves `Subscriber` init to Railtie to prepare for eventually making ActiveSupport optional.