### PR TITLE
Instrument Resque Jobs

### DIFF
--- a/lib/elastic_apm/agent.rb
+++ b/lib/elastic_apm/agent.rb
@@ -103,7 +103,6 @@ module ElasticAPM
     def enqueue_transaction(transaction)
       boot_worker unless worker_running?
 
-      puts "Thread:#{Thread.current.object_id}"
       pending_transactions.push(transaction)
     end
 
@@ -178,7 +177,6 @@ module ElasticAPM
 
     def boot_worker
       debug 'Booting worker'
-      puts "Booting Thread:#{Thread.current.object_id}"
 
       @worker_thread = Thread.new do
         TimedWorker.new(
@@ -191,9 +189,6 @@ module ElasticAPM
     end
 
     def kill_worker
-      puts "Thread:#{Thread.current.object_id}"
-      puts "Worker running? #{!!worker_running?} Kill it!"
-      puts @pending_transactions.length
       messages << TimedWorker::StopMsg.new
 
       if @worker_thread && !@worker_thread.join(5) # 5 secs

--- a/lib/elastic_apm/config.rb
+++ b/lib/elastic_apm/config.rb
@@ -179,6 +179,7 @@ module ElasticAPM
         mongo
         net_http
         redis
+        resque
         sequel
         sidekiq
         sinatra

--- a/lib/elastic_apm/http.rb
+++ b/lib/elastic_apm/http.rb
@@ -34,8 +34,6 @@ module ElasticAPM
       payload.merge! @base_payload
       filters.apply(payload)
 
-      puts payload.to_json
-
       request = prepare_request path, payload.to_json
       response = @adapter.perform request
 

--- a/lib/elastic_apm/timed_worker.rb
+++ b/lib/elastic_apm/timed_worker.rb
@@ -84,6 +84,7 @@ module ElasticAPM
       @adapter.post('/v1/errors', payload)
     end
 
+    # rubocop:disable Metrics/MethodLength
     def collect_and_send_transactions
       puts "WANNA SEND"
       return if pending_transactions.empty?
@@ -100,7 +101,10 @@ module ElasticAPM
         debug e.backtrace.join("\n")
         nil
       end
+
+      @last_sent_transactions = Time.now
     end
+    # rubocop:enable Metrics/MethodLength
 
     def collect_batched_transactions
       batch = []

--- a/lib/elastic_apm/timed_worker.rb
+++ b/lib/elastic_apm/timed_worker.rb
@@ -38,9 +38,6 @@ module ElasticAPM
 
     def run_forever
       loop do
-        puts '#' * 90
-        puts "RAN! #{pending_transactions.length}"
-        puts '#' * 90
         run_once
         sleep 0.0001 # SLEEP_INTERVAL
       end
@@ -48,7 +45,6 @@ module ElasticAPM
 
     def run_once
       collect_and_send_transactions if should_flush_transactions?
-      puts "Should flush?: #{!!should_flush_transactions?}"
       process_messages
     end
 
@@ -64,11 +60,6 @@ module ElasticAPM
           post_error msg
         when StopMsg
           should_exit = true
-
-          puts '#' * 90
-          puts 'EXITING'
-          pp pending_transactions
-          puts '#' * 90
 
           # empty collected transactions before exiting
           collect_and_send_transactions
@@ -86,9 +77,7 @@ module ElasticAPM
 
     # rubocop:disable Metrics/MethodLength
     def collect_and_send_transactions
-      puts "WANNA SEND"
       return if pending_transactions.empty?
-      puts "!!!!!!! SENDING"
 
       transactions = collect_batched_transactions
 

--- a/spec/elastic_apm/spies/resque_spec.rb
+++ b/spec/elastic_apm/spies/resque_spec.rb
@@ -9,8 +9,6 @@ require 'elastic_apm/spies/resque'
 
 module ElasticAPM
   class TestJob
-    extend ElasticAPM::Spies::ResqueSpy::Hooks
-
     @queue = :default
 
     def self.perform
@@ -21,25 +19,37 @@ module ElasticAPM
   end
 
   RSpec.describe 'Resque', :with_fake_server do
-    it 'instruments jobs' do
-      # ENV['VERBOSE'] = '1'
-      puts "Thread:#{Thread.current.object_id}"
+    shared_examples_for :resque_worker_with_apm do |fork|
+      before do
+        allow_any_instance_of(::Resque::Worker)
+          .to receive(:fork_per_job?) { fork }
+      end
 
-      worker = Resque::Worker.new 'default'
-      worker.prepare
-      worker.log 'Starting'
+      it 'instruments jobs once' do
+        worker = Resque::Worker.new 'default'
+        worker.prepare
+        worker.log 'Starting'
 
-      worker.startup
-      Resque.enqueue(TestJob)
+        worker.startup
+        Resque.enqueue(TestJob)
 
-      worker.work_one_job
+        worker.work_one_job
 
-      expect(ElasticAPM.agent).to_not be_nil
+        expect(ElasticAPM.agent).to_not be_nil
 
-      ElasticAPM.stop
-      wait_for_requests_to_finish 1
+        ElasticAPM.stop
+        wait_for_requests_to_finish 1
 
-      expect(FakeServer.requests.length).to be 1
+        expect(FakeServer.requests.length).to be 1
+      end
+    end
+
+    context 'environment allows forking' do
+      it_behaves_like :resque_worker_with_apm, true
+    end
+
+    context 'environment does not allow forking' do
+      it_behaves_like :resque_worker_with_apm, false
     end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -15,6 +15,7 @@ require 'support/mock_time'
 require 'support/with_fake_server'
 
 require 'elastic-apm'
+require 'elastic_apm/subscriber'
 
 Thread.abort_on_exception = true
 


### PR DESCRIPTION
This supports instrumenting Jobs processed by Resque::Workers independent of if they can fork a new child process or not. 
The implementation ensures the instrumentation happens in the worker process and not in the child process, to keep the default behaviour of sending transactions in batches and to avoid killing the instrumentation thread with killing the child process, although it might not have finished. 
