### PR TITLE
Add option to set min duration for span stacktrace collection

### DIFF
--- a/docs/configuration.asciidoc
+++ b/docs/configuration.asciidoc
@@ -239,6 +239,25 @@ WARNING: Especially for spans, collecting source code can have a large impact on
 storage use in your Elasticsearch cluster.
 
 [float]
+[[config-span-frames-min-duration-ms]]
+==== `span_frames_min_duration`
+
+| ============
+| Environment                            | `Config` keys              | Default
+| `ELASTIC_APM_SPAN_FRAMES_MIN_DURATION` | `span_frames_min_duration` | `-1`
+| ============
+
+In its default settings, the APM agent will collect a stack trace with every recorded span.
+While this is very helpful to find the exact place in your code that causes the span,
+collecting this stack trace does have some overhead.
+
+With the default setting, `-1`, stack traces will be collected for all spans.
+Setting it to a positive value, e.g. `5`, will limit stack trace collection to spans
+with durations equal or longer than the given value in milliseconds, e.g. 5 milliseconds.
+
+To disable stack trace collection for spans completely, set the value to 0.
+
+[float]
 [[config-max-queue-size]]
 ==== `max_queue_size`
 

--- a/lib/elastic_apm/config.rb
+++ b/lib/elastic_apm/config.rb
@@ -37,6 +37,7 @@ module ElasticAPM
       source_lines_span_app_frames: 5,
       source_lines_error_library_frames: 0,
       source_lines_span_library_frames: 0,
+      span_frames_min_duration: -1,
 
       disabled_spies: %w[json],
 
@@ -73,6 +74,8 @@ module ElasticAPM
         [:int, 'source_lines_error_library_frames'],
       'ELASTIC_APM_SOURCE_LINES_SPAN_LIBRARY_FRAMES' =>
         [:int, 'source_lines_span_library_frames'],
+      'ELASTIC_APM_SPAN_FRAMES_MIN_DURATION' =>
+        [:int, 'span_frames_min_duration'],
 
       'ELASTIC_APM_CUSTOM_KEY_FILTERS' => [:list, 'custom_key_filters'],
 
@@ -133,6 +136,7 @@ module ElasticAPM
     attr_accessor :source_lines_span_app_frames
     attr_accessor :source_lines_error_library_frames
     attr_accessor :source_lines_span_library_frames
+    attr_accessor :span_frames_min_duration
 
     attr_accessor :disabled_spies
 

--- a/lib/elastic_apm/transaction.rb
+++ b/lib/elastic_apm/transaction.rb
@@ -106,9 +106,8 @@ module ElasticAPM
       span = next_span(name, type, context)
       spans << span
 
-      if backtrace
-        span.stacktrace =
-          @instrumenter.agent.stacktrace_builder.build(backtrace, type: :span)
+      if backtrace && span_frames_min_duration?
+        span.original_backtrace = backtrace
       end
 
       span.start
@@ -144,6 +143,10 @@ module ElasticAPM
         parent: current_span,
         context: context
       )
+    end
+
+    def span_frames_min_duration?
+      @instrumenter.agent.config.span_frames_min_duration != 0
     end
   end
   # rubocop:enable Metrics/ClassLength


### PR DESCRIPTION
Closes elastic/apm-agent-ruby#126