### PR TITLE
docs: use shared attributes

### DIFF
--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -1,3 +1,6 @@
+:branch: current
+include::{asciidoc-dir}/../../shared/attributes.asciidoc[]
+
 ifdef::env-github[]
 NOTE: For the best reading experience, please view this documentation at https://www.elastic.co/guide/en/apm/agent/ruby[elastic.co]
 endif::[]
@@ -13,7 +16,7 @@ It has built-in support for <<getting-started-rails,Ruby on Rails>> and other <<
 
 This agent is one of several components you need to get started collecting APM data. See also:
 
- * https://www.elastic.co/guide/en/apm/server/current/index.html[APM Server]
+ * {apm-server-ref}[APM Server]
 
 [[framework-support]]
 The Elastic APM Ruby Agent officially supports <<getting-started-rails,Ruby on Rails>> versions 4.x on onwards.


### PR DESCRIPTION
Use the shared attributes provided
by elastic/docs for linking to other
product docs, forums, etc.