### PR TITLE
Remove newline on hostname

### DIFF
--- a/lib/elastic_apm/system_info.rb
+++ b/lib/elastic_apm/system_info.rb
@@ -9,7 +9,7 @@ module ElasticAPM
 
     def build
       {
-        hostname: @config.hostname || `hostname`,
+        hostname: @config.hostname || `hostname`.chomp,
         architecture: platform.cpu,
         platform: platform.os
       }

--- a/spec/elastic_apm/system_info_spec.rb
+++ b/spec/elastic_apm/system_info_spec.rb
@@ -12,6 +12,12 @@ module ElasticAPM
           expect(subject[key]).to_not be_nil
         end
       end
+
+      context 'hostname' do
+        it 'has no newline at the end' do
+          expect(subject[:hostname]).not_to match(/\n\z/)
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
There's a newline due to the ruby backtick call on hostname.