### PR TITLE
Use concurrent-ruby's TimerTask instead of home built

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 - Added `ENV` version of the logging options ([#146](https://github.com/elastic/apm-agent-ruby/pull/146))
 - Added `config.ignore_url_patterns` ([#151](https://github.com/elastic/apm-agent-ruby/pull/151))
 
+### Changed
+
+- Use concurrent-ruby's TimerTask instead of `Thread#sleep`. Adds dependency on `concurrent-ruby`. ([#141](https://github.com/elastic/apm-agent-ruby/pull/141))
+
 ### Fixed
 
 - Remove newline on `hostname`

--- a/elastic-apm.gemspec
+++ b/elastic-apm.gemspec
@@ -18,5 +18,7 @@ Gem::Specification.new do |spec|
     f.match(%r{^(test|spec|features)/})
   end
 
+  spec.add_dependency('concurrent-ruby', '~> 1.0.0')
+
   spec.require_paths = ['lib']
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -15,6 +15,9 @@ require 'support/match_json_schema_matcher'
 require 'support/mock_time'
 require 'support/with_fake_server'
 
+require 'concurrent'
+Concurrent.use_stdlib_logger(Logger::DEBUG)
+
 require 'elastic-apm'
 
 Thread.abort_on_exception = true
@@ -35,7 +38,9 @@ RSpec.configure do |config|
   end
 
   def elastic_subscribers
-    return [] unless defined?(ActiveSupport)
+    unless defined?(::ActiveSupport) && defined?(ElasticAPM::Subscriber)
+      return []
+    end
 
     ActiveSupport::Notifications
       .notifier.instance_variable_get(:@subscribers)


### PR DESCRIPTION
1. Moves responsibility of checking pending transactions size back to agent.
2. Simplifies `TimedWorker`. Possibly even more than this pr?

Closes elastic/apm-agent-ruby#96 