### PR TITLE
Start mongodb for specs.

### DIFF
--- a/spec/elastic_apm/spies/mongo_spec.rb
+++ b/spec/elastic_apm/spies/mongo_spec.rb
@@ -4,8 +4,18 @@ require 'mongo'
 
 module ElasticAPM
   RSpec.describe 'Spy: MongoDB' do
-    before do
+    around do |ex|
+      start_mongodb
+      ex.run
+      stop_mongodb
+    end
+
+    def stop_mongodb
       `docker-compose -f spec/docker-compose.yml down -v 2>&1`
+    end
+
+    def start_mongodb
+      stop_mongodb
       `docker-compose -f spec/docker-compose.yml up -d mongodb 2>&1`
     end
 

--- a/spec/elastic_apm/spies/mongo_spec.rb
+++ b/spec/elastic_apm/spies/mongo_spec.rb
@@ -4,6 +4,11 @@ require 'mongo'
 
 module ElasticAPM
   RSpec.describe 'Spy: MongoDB' do
+    before do
+      `docker-compose -f spec/docker-compose.yml down -v 2>&1`
+      `docker-compose -f spec/docker-compose.yml up -d mongodb 2>&1`
+    end
+
     it 'instruments calls', :with_fake_server do
       ElasticAPM.start flush_interval: nil
 
@@ -11,7 +16,8 @@ module ElasticAPM
         Mongo::Client.new(
           [ENV.fetch('MONGODB_URL', '127.0.0.1:27017')],
           database: 'elastic-apm-test',
-          logger: Logger.new(nil)
+          logger: Logger.new(nil),
+          server_selection_timeout: 5
         )
 
       transaction =


### PR DESCRIPTION
If no mongodb server is running, start a docker
container before running the mongodb specs.

Locally `rspec spec` was failing when I haven't had started an external mongodb server. This attempts to fix the unit tests, by firing up a mongodb docker container. 