### PR TITLE
Support multiple HTTP adapters and http-keepalive

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -22,6 +22,8 @@ gem 'webmock'
 gem 'yard'
 gem 'yarjuf'
 
+gem 'http'
+
 if RUBY_PLATFORM == 'java'
   gem 'jdbc-sqlite3'
 else

--- a/lib/elastic_apm/config.rb
+++ b/lib/elastic_apm/config.rb
@@ -34,8 +34,11 @@ module ElasticAPM
       http_compression: true,
       compression_minimum_size: 1024 * 5,
       compression_level: 6,
-      http_keepalive: false,
+
       http_adapter: :NetHttpAdapter,
+      http_adapter_options: {
+        keepalive: true
+      },
 
       source_lines_error_app_frames: 5,
       source_lines_span_app_frames: 5,
@@ -147,8 +150,8 @@ module ElasticAPM
     attr_accessor :http_compression
     attr_accessor :compression_minimum_size
     attr_accessor :compression_level
-    attr_accessor :http_keepalive
     attr_accessor :http_adapter
+    attr_accessor :http_adapter_options
 
     attr_accessor :source_lines_error_app_frames
     attr_accessor :source_lines_span_app_frames

--- a/lib/elastic_apm/config.rb
+++ b/lib/elastic_apm/config.rb
@@ -34,6 +34,8 @@ module ElasticAPM
       http_compression: true,
       compression_minimum_size: 1024 * 5,
       compression_level: 6,
+      http_keepalive: false,
+      http_adapter: :NetHttpAdapter,
 
       source_lines_error_app_frames: 5,
       source_lines_span_app_frames: 5,
@@ -145,6 +147,8 @@ module ElasticAPM
     attr_accessor :http_compression
     attr_accessor :compression_minimum_size
     attr_accessor :compression_level
+    attr_accessor :http_keepalive
+    attr_accessor :http_adapter
 
     attr_accessor :source_lines_error_app_frames
     attr_accessor :source_lines_span_app_frames

--- a/lib/elastic_apm/http.rb
+++ b/lib/elastic_apm/http.rb
@@ -7,8 +7,8 @@ require 'elastic_apm/system_info'
 require 'elastic_apm/process_info'
 require 'elastic_apm/filters'
 
-require_relative 'http_adapters/net_http_adapter'
-require_relative 'http_adapters/http_rb_adapter'
+require 'elastic_apm/http_adapters/net_http_adapter'
+require 'elastic_apm/http_adapters/http_rb_adapter'
 
 module ElasticAPM
   # @api private

--- a/lib/elastic_apm/http.rb
+++ b/lib/elastic_apm/http.rb
@@ -25,7 +25,7 @@ module ElasticAPM
       @base_payload = {
         service: ServiceInfo.build(config),
         process: ProcessInfo.build(config),
-        system: SystemInfo.build(config),
+        system: SystemInfo.build(config)
       }
       @filters = Filters.new(config)
     end
@@ -39,7 +39,7 @@ module ElasticAPM
       return if payload.nil?
 
       response = perform path, payload.to_json
-      return nil if response == ElasticAPM::HttpAdapters::AbstractHttpAdapter::DISABLED
+      return nil if response == HttpAdapters::AbstractHttpAdapter::DISABLED
       return response if response.success?
 
       error 'POST returned an unsuccessful status code (%d)', response.code
@@ -54,7 +54,7 @@ module ElasticAPM
       headers = {
         'Accept' => ACCEPT,
         'Content-Type' => CONTENT_TYPE,
-        'User-Agent' => USER_AGENT,
+        'User-Agent' => USER_AGENT
       }
       if (token = @config.secret_token)
         headers['Authorization'] = "Bearer #{token}"

--- a/lib/elastic_apm/http_adapters/abstract_adapter.rb
+++ b/lib/elastic_apm/http_adapters/abstract_adapter.rb
@@ -1,0 +1,31 @@
+module ElasticAPM
+  module HttpAdapters
+    # @api private
+    class AbstractHttpAdapter
+      DISABLED = "disabled".freeze
+
+      def initialize(conf)
+        @config = conf
+      end
+    end
+
+    # @api private
+    class Response
+      def initialize(response)
+        @response = response
+      end
+
+      def success?
+        (200..299).cover? @response.code
+      end
+
+      def code
+        @response.code
+      end
+
+      def body
+        @response.body
+      end
+    end
+  end
+end

--- a/lib/elastic_apm/http_adapters/abstract_adapter.rb
+++ b/lib/elastic_apm/http_adapters/abstract_adapter.rb
@@ -2,7 +2,7 @@ module ElasticAPM
   module HttpAdapters
     # @api private
     class AbstractHttpAdapter
-      DISABLED = "disabled".freeze
+      DISABLED = 'disabled'.freeze
 
       def initialize(conf)
         @config = conf

--- a/lib/elastic_apm/http_adapters/http_rb_adapter.rb
+++ b/lib/elastic_apm/http_adapters/http_rb_adapter.rb
@@ -1,40 +1,42 @@
 require 'elastic_apm/http_adapters/abstract_adapter'
+enable = false
 begin
   require 'http'
+  enable = true
+rescue LoadError
+end
 
-  module ElasticAPM
-    module HttpAdapters
-      # @api private
-      class HttpRbAdapter < AbstractHttpAdapter
-        def perform(uri, data, headers)
-          return DISABLED if @config.disable_send?
+module ElasticAPM
+  module HttpAdapters
+    # @api private
+    class HttpRbAdapter < AbstractHttpAdapter
+      def perform(uri, data, headers)
+        return DISABLED if @config.disable_send?
 
-          req = client(uri).headers(headers)
-          if @config.http_compression &&
-            data.bytesize > @config.compression_minimum_size
-            req = req.use(auto_deflate: { method: :deflate })
-          end
-          Response.new req.post(uri, body: data, ssl_context: get_context)
+        req = client(uri).headers(headers)
+        if @config.http_compression &&
+          data.bytesize > @config.compression_minimum_size
+          req = req.use(auto_deflate: { method: :deflate })
         end
+        Response.new req.post(uri, body: data, ssl_context: get_context)
+      end
 
-        private
+      private
 
-        def client(uri)
-          @client ||= begin
-            keepalive = @config.http_adapter_options[:keepalive]
-            keepalive ? ::HTTP.persistent(uri) : ::HTTP
-          end
+      def client(uri)
+        @client ||= begin
+          keepalive = @config.http_adapter_options[:keepalive]
+          keepalive ? ::HTTP.persistent(uri) : ::HTTP
         end
+      end
 
-        def get_context
-          ctx = OpenSSL::SSL::SSLContext.new
-          if @config.use_ssl? && @config.verify_server_cert?
-            ctx.verify_mode = OpenSSL::SSL::VERIFY_NONE
-          end
-          ctx
+      def get_context
+        ctx = OpenSSL::SSL::SSLContext.new
+        if @config.use_ssl? && @config.verify_server_cert?
+          ctx.verify_mode = OpenSSL::SSL::VERIFY_NONE
         end
+        ctx
       end
     end
   end
-rescue LoadError
-end
+end if enable

--- a/lib/elastic_apm/http_adapters/http_rb_adapter.rb
+++ b/lib/elastic_apm/http_adapters/http_rb_adapter.rb
@@ -1,0 +1,38 @@
+require_relative "./abstract_adapter"
+
+begin
+  require "http"
+rescue LoadError
+end
+
+module ElasticAPM
+  module HttpAdapters
+    # @api private
+    class HttpRbAdapter < AbstractHttpAdapter
+      def perform(uri, data, headers)
+        return DISABLED if @config.disable_send?
+
+        ctx = OpenSSL::SSL::SSLContext.new
+        if @config.use_ssl? && @config.verify_server_cert?
+          ctx.verify_mode = OpenSSL::SSL::VERIFY_NONE
+        end
+
+        req = client(uri).headers(headers)
+        if @config.http_compression && data.bytesize > @config.compression_minimum_size
+          req = req.use(auto_deflate: {method: :deflate})
+        end
+        Response.new req.post(uri, body: data, ssl_context: ctx)
+      end
+
+      private
+
+      def client(uri)
+        if @config.http_keepalive
+          @client ||= ::HTTP.persistent(uri)
+        else
+          @client ||= ::HTTP
+        end
+      end
+    end
+  end
+end if Kernel.const_defined?(:HTTP) && ::HTTP.const_defined?(:Chainable)

--- a/lib/elastic_apm/http_adapters/http_rb_adapter.rb
+++ b/lib/elastic_apm/http_adapters/http_rb_adapter.rb
@@ -1,5 +1,4 @@
 require_relative './abstract_adapter'
-
 begin
   require 'http'
 rescue LoadError
@@ -12,23 +11,26 @@ module ElasticAPM
       def perform(uri, data, headers)
         return DISABLED if @config.disable_send?
 
-        ctx = OpenSSL::SSL::SSLContext.new
-        if @config.use_ssl? && @config.verify_server_cert?
-          ctx.verify_mode = OpenSSL::SSL::VERIFY_NONE
-        end
-
         req = client(uri).headers(headers)
         if @config.http_compression &&
-            data.bytesize > @config.compression_minimum_size
+           data.bytesize > @config.compression_minimum_size
           req = req.use(auto_deflate: { method: :deflate })
         end
-        Response.new req.post(uri, body: data, ssl_context: ctx)
+        Response.new req.post(uri, body: data, ssl_context: get_context)
       end
 
       private
 
       def client(uri)
         @client ||= @config.http_keepalive ? ::HTTP.persistent(uri) : ::HTTP
+      end
+
+      def get_context
+        ctx = OpenSSL::SSL::SSLContext.new
+        if @config.use_ssl? && @config.verify_server_cert?
+          ctx.verify_mode = OpenSSL::SSL::VERIFY_NONE
+        end
+        ctx
       end
     end
   end

--- a/lib/elastic_apm/http_adapters/http_rb_adapter.rb
+++ b/lib/elastic_apm/http_adapters/http_rb_adapter.rb
@@ -1,7 +1,7 @@
-require_relative "./abstract_adapter"
+require_relative './abstract_adapter'
 
 begin
-  require "http"
+  require 'http'
 rescue LoadError
 end
 
@@ -18,8 +18,9 @@ module ElasticAPM
         end
 
         req = client(uri).headers(headers)
-        if @config.http_compression && data.bytesize > @config.compression_minimum_size
-          req = req.use(auto_deflate: {method: :deflate})
+        if @config.http_compression &&
+            data.bytesize > @config.compression_minimum_size
+          req = req.use(auto_deflate: { method: :deflate })
         end
         Response.new req.post(uri, body: data, ssl_context: ctx)
       end
@@ -27,11 +28,7 @@ module ElasticAPM
       private
 
       def client(uri)
-        if @config.http_keepalive
-          @client ||= ::HTTP.persistent(uri)
-        else
-          @client ||= ::HTTP
-        end
+        @client ||= @config.http_keepalive ? ::HTTP.persistent(uri) : ::HTTP
       end
     end
   end

--- a/lib/elastic_apm/http_adapters/http_rb_adapter.rb
+++ b/lib/elastic_apm/http_adapters/http_rb_adapter.rb
@@ -1,37 +1,40 @@
-require_relative './abstract_adapter'
+require 'elastic_apm/http_adapters/abstract_adapter'
 begin
   require 'http'
-rescue LoadError
-end
 
-module ElasticAPM
-  module HttpAdapters
-    # @api private
-    class HttpRbAdapter < AbstractHttpAdapter
-      def perform(uri, data, headers)
-        return DISABLED if @config.disable_send?
+  module ElasticAPM
+    module HttpAdapters
+      # @api private
+      class HttpRbAdapter < AbstractHttpAdapter
+        def perform(uri, data, headers)
+          return DISABLED if @config.disable_send?
 
-        req = client(uri).headers(headers)
-        if @config.http_compression &&
-           data.bytesize > @config.compression_minimum_size
-          req = req.use(auto_deflate: { method: :deflate })
+          req = client(uri).headers(headers)
+          if @config.http_compression &&
+            data.bytesize > @config.compression_minimum_size
+            req = req.use(auto_deflate: { method: :deflate })
+          end
+          Response.new req.post(uri, body: data, ssl_context: get_context)
         end
-        Response.new req.post(uri, body: data, ssl_context: get_context)
-      end
 
-      private
+        private
 
-      def client(uri)
-        @client ||= @config.http_keepalive ? ::HTTP.persistent(uri) : ::HTTP
-      end
-
-      def get_context
-        ctx = OpenSSL::SSL::SSLContext.new
-        if @config.use_ssl? && @config.verify_server_cert?
-          ctx.verify_mode = OpenSSL::SSL::VERIFY_NONE
+        def client(uri)
+          @client ||= begin
+            keepalive = @config.http_adapter_options[:keepalive]
+            keepalive ? ::HTTP.persistent(uri) : ::HTTP
+          end
         end
-        ctx
+
+        def get_context
+          ctx = OpenSSL::SSL::SSLContext.new
+          if @config.use_ssl? && @config.verify_server_cert?
+            ctx.verify_mode = OpenSSL::SSL::VERIFY_NONE
+          end
+          ctx
+        end
       end
     end
   end
-end if Kernel.const_defined?(:HTTP) && ::HTTP.const_defined?(:Chainable)
+rescue LoadError
+end

--- a/lib/elastic_apm/http_adapters/net_http_adapter.rb
+++ b/lib/elastic_apm/http_adapters/net_http_adapter.rb
@@ -1,7 +1,7 @@
-require_relative "./abstract_adapter"
+require_relative './abstract_adapter'
 
-require "zlib"
-require "net/http"
+require 'zlib'
+require 'net/http'
 
 module ElasticAPM
   module HttpAdapters
@@ -11,8 +11,9 @@ module ElasticAPM
         super
 
         if config.http_keepalive
-          $stderr.puts format(
-            '%sCannot use keepalive with the Net::HTTP adapter. Use the HttpRbAdapter for keepalive.',
+          warn format(
+            '%sCannot use keepalive with the Net::HTTP adapter. ' +
+            'Use the HttpRbAdapter for keepalive.',
             Log::PREFIX
           )
         end
@@ -21,9 +22,9 @@ module ElasticAPM
       def perform(path, data, headers)
         return DISABLED if @config.disable_send?
 
-        req = post(path) do |req|
-          headers.each { |k, v| req[k] = v }
-          prepare_request_body! req, data
+        req = post(path) do |r|
+          headers.each { |k, v| r[k] = v }
+          prepare_request_body! r, data
         end
 
         resp = http.start do |http|
@@ -45,11 +46,11 @@ module ElasticAPM
            data.bytesize > @config.compression_minimum_size
           deflated = Zlib.deflate data, @config.compression_level
 
-          req["Content-Encoding"] = "deflate"
-          req["Content-Length"] = deflated.bytesize.to_s
+          req['Content-Encoding'] = 'deflate'
+          req['Content-Length'] = deflated.bytesize.to_s
           req.body = deflated
         else
-          req["Content-Length"] = data.bytesize.to_s
+          req['Content-Length'] = data.bytesize.to_s
           req.body = data
         end
       end

--- a/lib/elastic_apm/http_adapters/net_http_adapter.rb
+++ b/lib/elastic_apm/http_adapters/net_http_adapter.rb
@@ -1,0 +1,86 @@
+require_relative "./abstract_adapter"
+
+require "zlib"
+require "net/http"
+
+module ElasticAPM
+  module HttpAdapters
+    # @api private
+    class NetHttpAdapter < AbstractHttpAdapter
+      def initialize(config)
+        super
+
+        if config.http_keepalive
+          $stderr.puts format(
+            '%sCannot use keepalive with the Net::HTTP adapter. Use the HttpRbAdapter for keepalive.',
+            Log::PREFIX
+          )
+        end
+      end
+
+      def perform(path, data, headers)
+        return DISABLED if @config.disable_send?
+
+        req = post(path) do |req|
+          headers.each { |k, v| req[k] = v }
+          prepare_request_body! req, data
+        end
+
+        resp = http.start do |http|
+          http.request req
+        end
+        Response.new(resp)
+      end
+
+      private
+
+      def post(path)
+        req = Net::HTTP::Post.new path
+        yield req if block_given?
+        req
+      end
+
+      def prepare_request_body!(req, data)
+        if @config.http_compression &&
+           data.bytesize > @config.compression_minimum_size
+          deflated = Zlib.deflate data, @config.compression_level
+
+          req["Content-Encoding"] = "deflate"
+          req["Content-Length"] = deflated.bytesize.to_s
+          req.body = deflated
+        else
+          req["Content-Length"] = data.bytesize.to_s
+          req.body = data
+        end
+      end
+
+      def http
+        return @http if @http
+
+        http = Net::HTTP.new server_uri.host, server_uri.port
+        http.use_ssl = @config.use_ssl?
+        http.verify_mode = verify_mode
+        http.read_timeout = @config.http_read_timeout
+        http.open_timeout = @config.http_open_timeout
+
+        if @config.debug_http
+          http.set_debug_output(@config.logger)
+        end
+
+        @http = http
+      end
+
+      def server_uri
+        @server_uri ||= URI(@config.server_url)
+      end
+
+      def verify_mode
+        if @config.use_ssl? && @config.verify_server_cert?
+          OpenSSL::SSL::VERIFY_PEER
+        else
+          OpenSSL::SSL::VERIFY_NONE
+        end
+      end
+    end
+  end
+end

--- a/lib/elastic_apm/http_adapters/net_http_adapter.rb
+++ b/lib/elastic_apm/http_adapters/net_http_adapter.rb
@@ -1,4 +1,4 @@
-require_relative './abstract_adapter'
+require 'elastic_apm/http_adapters/abstract_adapter'
 
 require 'zlib'
 require 'net/http'
@@ -7,18 +7,6 @@ module ElasticAPM
   module HttpAdapters
     # @api private
     class NetHttpAdapter < AbstractHttpAdapter
-      def initialize(config)
-        if config.http_keepalive
-          warn format(
-            '%sCannot use keepalive with the Net::HTTP adapter. ' \
-            'Use the HttpRbAdapter for keepalive.',
-            Log::PREFIX
-          )
-        end
-
-        super
-      end
-
       def perform(path, data, headers)
         return DISABLED if @config.disable_send?
 

--- a/lib/elastic_apm/http_adapters/net_http_adapter.rb
+++ b/lib/elastic_apm/http_adapters/net_http_adapter.rb
@@ -8,15 +8,15 @@ module ElasticAPM
     # @api private
     class NetHttpAdapter < AbstractHttpAdapter
       def initialize(config)
-        super
-
         if config.http_keepalive
           warn format(
-            '%sCannot use keepalive with the Net::HTTP adapter. ' +
+            '%sCannot use keepalive with the Net::HTTP adapter. ' \
             'Use the HttpRbAdapter for keepalive.',
             Log::PREFIX
           )
         end
+
+        super
       end
 
       def perform(path, data, headers)

--- a/spec/elastic_apm/http_spec.rb
+++ b/spec/elastic_apm/http_spec.rb
@@ -131,14 +131,6 @@ module ElasticAPM
           )
         end
       end
-
-      context 'when keepalive is set' do
-        let(:config) { { http_keepalive: true } }
-
-        it 'warns that keepalive is not available for the Net::HTTP adapter' do
-          expect { subject }.to output(/Cannot use keepalive/).to_stderr
-        end
-      end
     end
 
     context 'with the HttpRbAdapter' do
@@ -160,7 +152,7 @@ module ElasticAPM
         end
 
         context 'when keepalive is set' do
-          let(:config) { { http_keepalive: true } }
+          let(:config) { { http_adapter_options: { keepalive: true } } }
 
           it 'sets the appropriate headers' do
             subject.post('/v1/transactions', things: 1)

--- a/spec/elastic_apm/http_spec.rb
+++ b/spec/elastic_apm/http_spec.rb
@@ -2,118 +2,173 @@
 
 module ElasticAPM
   RSpec.describe Http do
-    describe '#post', :with_fake_server do
-      let(:config) { {} }
+    subject do
+      Http.new Config.new({
+        service_name: "app-1",
+        environment: "test",
+        http_adapter: adapter
+      }.merge(config))
+    end
+    let(:config) { {} }
 
-      subject do
-        Http.new Config.new({
-          service_name: 'app-1',
-          environment: 'test'
-        }.merge(config))
-      end
-
-      it 'aborts when payload is nil' do
-        subject.filters.add :niller, ->(_payload) { nil }
-        subject.post('/v1/transactions', never_me: 1)
-        expect(WebMock).to_not have_requested(:any, /.*/)
-      end
-
-      context 'with disable_send = true' do
-        let(:config) { { disable_send: true } }
-        it "doesn't send" do
-          subject.post('/v1/transactions', never_me: 1)
+    shared_examples_for "http" do
+      describe "#post", :with_fake_server do
+        it "aborts when payload is nil" do
+          subject.filters.add :niller, -> (_payload) { nil }
+          subject.post("/v1/transactions", never_me: 1)
           expect(WebMock).to_not have_requested(:any, /.*/)
         end
-      end
 
-      it 'sets the appropriate headers' do
-        subject.post('/v1/transactions', things: 1)
-
-        expect(WebMock).to have_requested(:post, %r{/v1/transactions}).with(
-          headers: {
-            'Accept' => 'application/json',
-            'Content-Type' => 'application/json',
-            'User-Agent' => "elastic-apm/ruby #{VERSION}",
-            'Content-Length' => /\d{1,}/
-          }
-        )
-      end
-
-      it 'includes bearer token if provided' do
-        http = Http.new Config.new(secret_token: 'abc123')
-        http.post('/v1/transactions')
-
-        expect(WebMock).to have_requested(:post, %r{/v1/transactions})
-          .with(headers: { 'Authorization' => 'Bearer abc123' })
-      end
-
-      it 'merges payload with system and service metadata' do
-        subject.post('/v1/transactions', transactions: [{ id: 1 }])
-
-        payload, = FakeServer.requests
-        expect(payload['system']).to be_a Hash
-        expect(payload['service']).to be_a Hash
-      end
-
-      it 'filters sensitive data' do
-        subject.post(
-          '/v1/transactions', transactions: [
-            { id: 1, context: { request: { headers: { ApiKey: 'OH NO!' } } } }
-          ]
-        )
-
-        payload, = FakeServer.requests
-        headers =
-          payload.dig('transactions', 0, 'context', 'request', 'headers')
-        expect(headers['ApiKey']).to eq '[FILTERED]'
-      end
-
-      context 'compression' do
-        before do
-          subject.post('/v1/transactions', things: 1)
-        end
-
-        context 'with payloads under the minimum compression size' do
-          let(:config) do
-            { compression_minimum_size: 1_024_000 }
-          end
-
-          it "doesn't compress the payload" do
-            expect(WebMock).to_not have_requested(:post, %r{/v1/transactions})
-              .with(headers: { 'Content-Encoding' => 'deflate' })
+        context "with disable_send = true" do
+          let(:config) { {disable_send: true} }
+          it "doesn't send" do
+            subject.post("/v1/transactions", never_me: 1)
+            expect(WebMock).to_not have_requested(:any, /.*/)
           end
         end
 
-        context 'with payloads over the minimum compression size' do
-          let(:config) do
-            { compression_minimum_size: 1 }
+        it "includes bearer token if provided" do
+          http = Http.new Config.new(secret_token: "abc123")
+          http.post("/v1/transactions")
+
+          expect(WebMock).to have_requested(:post, %r{/v1/transactions})
+                               .with(headers: {"Authorization" => "Bearer abc123"})
+        end
+
+        it "merges payload with system and service metadata" do
+          subject.post("/v1/transactions", transactions: [{id: 1}])
+
+          payload, = FakeServer.requests
+          expect(payload["system"]).to be_a Hash
+          expect(payload["service"]).to be_a Hash
+        end
+
+        it "filters sensitive data" do
+          subject.post(
+            "/v1/transactions", transactions: [
+                                  {id: 1, context: {request: {headers: {ApiKey: "OH NO!"}}}},
+                                ],
+          )
+
+          payload, = FakeServer.requests
+          headers =
+            payload.dig("transactions", 0, "context", "request", "headers")
+          expect(headers["ApiKey"]).to eq "[FILTERED]"
+        end
+
+        context "compression" do
+          before do
+            subject.post("/v1/transactions", things: 1)
           end
 
-          it 'compresses the payload' do
-            expect(WebMock).to have_requested(:post, %r{/v1/transactions})
-              .with(headers: { 'Content-Encoding' => 'deflate' })
-          end
-
-          context 'and compression disabled' do
+          context "with payloads under the minimum compression size" do
             let(:config) do
-              { compression_minimum_size: 1, http_compression: false }
+              {compression_minimum_size: 1_024_000}
             end
 
             it "doesn't compress the payload" do
               expect(WebMock).to_not have_requested(:post, %r{/v1/transactions})
-                .with(headers: { 'Content-Encoding' => 'deflate' })
+                                       .with(headers: {"Content-Encoding" => "deflate"})
+            end
+          end
+
+          context "with payloads over the minimum compression size" do
+            let(:config) do
+              {compression_minimum_size: 1}
+            end
+
+            it "compresses the payload" do
+              expect(WebMock).to have_requested(:post, %r{/v1/transactions})
+                                   .with(headers: {"Content-Encoding" => "deflate"})
+            end
+
+            context "and compression disabled" do
+              let(:config) do
+                {compression_minimum_size: 1, http_compression: false}
+              end
+
+              it "doesn't compress the payload" do
+                expect(WebMock).to_not have_requested(:post, %r{/v1/transactions})
+                                         .with(headers: {"Content-Encoding" => "deflate"})
+              end
             end
           end
         end
       end
+
+      context "verifying certs" do
+        it "explodes on bad cert" do
+          http = Http.new Config.new(server_url: "https://expired.badssl.com/")
+          WebMock.disable!
+          expect { http.post("/") }.to raise_error(OpenSSL::SSL::SSLError)
+          WebMock.enable!
+        end
+      end
     end
 
-    context 'verifying certs' do
-      it 'explodes on bad cert' do
-        http = Http.new Config.new(server_url: 'https://expired.badssl.com/')
-        WebMock.disable!
-        expect { http.post('/') }.to raise_error(OpenSSL::SSL::SSLError)
-        WebMock.enable!
+    context "with the HttpAdapter" do
+      let(:adapter) { :NetHttpAdapter }
+      it_behaves_like "http"
+
+      describe "#post", :with_fake_server do
+        it "sets the appropriate headers" do
+          subject.post("/v1/transactions", things: 1)
+
+          expect(WebMock).to have_requested(:post, %r{/v1/transactions}).with(
+            headers: {"Accept" => "application/json",
+                      "Accept-Encoding" => /deflate/,
+                      "Content-Length" => /\d+/,
+                      "Content-Type" => "application/json",
+                      "User-Agent" => "elastic-apm/ruby #{VERSION}"},
+          )
+        end
+      end
+
+      context "when keepalive is set" do
+        let(:config) { {http_keepalive: true} }
+
+        it "warns that keepalive is not available for the Net::HTTP adapter" do
+          expect($stderr).to receive(:puts).with(/Cannot use keepalive with the Net::HTTP adapter/)
+          subject
+        end
+      end
+    end
+
+    context "with the HttpRbAdapter" do
+      let(:adapter) { :HttpRbAdapter }
+      it_behaves_like "http"
+
+      describe "#post", :with_fake_server do
+        it "sets the appropriate headers" do
+          subject.post("/v1/transactions", things: 1)
+
+          expect(WebMock).to have_requested(:post, %r{/v1/transactions}).with(
+            headers: {
+              "Accept" => "application/json",
+              "Content-Type" => "application/json",
+              "Host" => "localhost:8200",
+              "User-Agent" => "elastic-apm/ruby #{VERSION}",
+            },
+          )
+        end
+
+        context "when keepalive is set" do
+          let(:config) { {http_keepalive: true} }
+
+          it "sets the appropriate headers" do
+            subject.post("/v1/transactions", things: 1)
+
+            expect(WebMock).to have_requested(:post, %r{/v1/transactions}).with(
+              headers: {
+                "Accept" => "application/json",
+                "Content-Type" => "application/json",
+                "Host" => "localhost:8200",
+                "User-Agent" => "elastic-apm/ruby #{VERSION}",
+                "Connection" => "Keep-Alive",
+              },
+            )
+          end
+        end
       end
     end
   end

--- a/spec/elastic_apm/http_spec.rb
+++ b/spec/elastic_apm/http_spec.rb
@@ -128,8 +128,7 @@ module ElasticAPM
         let(:config) { {http_keepalive: true} }
 
         it "warns that keepalive is not available for the Net::HTTP adapter" do
-          expect($stderr).to receive(:puts).with(/Cannot use keepalive with the Net::HTTP adapter/)
-          subject
+          expect { subject }.to output(/Cannot use keepalive with the Net::HTTP adapter/).to_stderr
         end
       end
     end

--- a/spec/elastic_apm/http_spec.rb
+++ b/spec/elastic_apm/http_spec.rb
@@ -4,167 +4,175 @@ module ElasticAPM
   RSpec.describe Http do
     subject do
       Http.new Config.new({
-        service_name: "app-1",
-        environment: "test",
+        service_name: 'app-1',
+        environment: 'test',
         http_adapter: adapter
       }.merge(config))
     end
     let(:config) { {} }
 
-    shared_examples_for "http" do
-      describe "#post", :with_fake_server do
-        it "aborts when payload is nil" do
-          subject.filters.add :niller, -> (_payload) { nil }
-          subject.post("/v1/transactions", never_me: 1)
+    shared_examples_for 'http' do
+      describe '#post', :with_fake_server do
+        it 'aborts when payload is nil' do
+          subject.filters.add :niller, ->(_payload) { nil }
+          subject.post('/v1/transactions', never_me: 1)
           expect(WebMock).to_not have_requested(:any, /.*/)
         end
 
-        context "with disable_send = true" do
-          let(:config) { {disable_send: true} }
+        context 'with disable_send = true' do
+          let(:config) { { disable_send: true } }
           it "doesn't send" do
-            subject.post("/v1/transactions", never_me: 1)
+            subject.post('/v1/transactions', never_me: 1)
             expect(WebMock).to_not have_requested(:any, /.*/)
           end
         end
 
-        it "includes bearer token if provided" do
-          http = Http.new Config.new(secret_token: "abc123")
-          http.post("/v1/transactions")
+        it 'includes bearer token if provided' do
+          http = Http.new Config.new(secret_token: 'abc123')
+          http.post('/v1/transactions')
 
           expect(WebMock).to have_requested(:post, %r{/v1/transactions})
-                               .with(headers: {"Authorization" => "Bearer abc123"})
+            .with(headers: { 'Authorization' => 'Bearer abc123' })
         end
 
-        it "merges payload with system and service metadata" do
-          subject.post("/v1/transactions", transactions: [{id: 1}])
+        it 'merges payload with system and service metadata' do
+          subject.post('/v1/transactions', transactions: [{ id: 1 }])
 
           payload, = FakeServer.requests
-          expect(payload["system"]).to be_a Hash
-          expect(payload["service"]).to be_a Hash
+          expect(payload['system']).to be_a Hash
+          expect(payload['service']).to be_a Hash
         end
 
-        it "filters sensitive data" do
+        it 'filters sensitive data' do
           subject.post(
-            "/v1/transactions", transactions: [
-                                  {id: 1, context: {request: {headers: {ApiKey: "OH NO!"}}}},
-                                ],
+            '/v1/transactions',
+            transactions: [
+              { id: 1,
+                context: {
+                  request: {
+                    headers: { ApiKey: 'OH NO!' }
+                  }
+                } }
+            ]
           )
 
           payload, = FakeServer.requests
           headers =
-            payload.dig("transactions", 0, "context", "request", "headers")
-          expect(headers["ApiKey"]).to eq "[FILTERED]"
+            payload.dig('transactions', 0, 'context', 'request', 'headers')
+          expect(headers['ApiKey']).to eq '[FILTERED]'
         end
 
-        context "compression" do
+        context 'compression' do
           before do
-            subject.post("/v1/transactions", things: 1)
+            subject.post('/v1/transactions', things: 1)
           end
 
-          context "with payloads under the minimum compression size" do
+          context 'with payloads under the minimum compression size' do
             let(:config) do
-              {compression_minimum_size: 1_024_000}
+              { compression_minimum_size: 1_024_000 }
             end
 
             it "doesn't compress the payload" do
               expect(WebMock).to_not have_requested(:post, %r{/v1/transactions})
-                                       .with(headers: {"Content-Encoding" => "deflate"})
+                .with(headers: { 'Content-Encoding' => 'deflate' })
             end
           end
 
-          context "with payloads over the minimum compression size" do
+          context 'with payloads over the minimum compression size' do
             let(:config) do
-              {compression_minimum_size: 1}
+              { compression_minimum_size: 1 }
             end
 
-            it "compresses the payload" do
+            it 'compresses the payload' do
               expect(WebMock).to have_requested(:post, %r{/v1/transactions})
-                                   .with(headers: {"Content-Encoding" => "deflate"})
+                .with(headers: { 'Content-Encoding' => 'deflate' })
             end
 
-            context "and compression disabled" do
+            context 'and compression disabled' do
               let(:config) do
-                {compression_minimum_size: 1, http_compression: false}
+                { compression_minimum_size: 1, http_compression: false }
               end
 
               it "doesn't compress the payload" do
-                expect(WebMock).to_not have_requested(:post, %r{/v1/transactions})
-                                         .with(headers: {"Content-Encoding" => "deflate"})
+                expect(WebMock).to_not(
+                  have_requested(:post, %r{/v1/transactions})
+                    .with(headers: { 'Content-Encoding' => 'deflate' })
+                )
               end
             end
           end
         end
       end
 
-      context "verifying certs" do
-        it "explodes on bad cert" do
-          http = Http.new Config.new(server_url: "https://expired.badssl.com/")
+      context 'verifying certs' do
+        it 'explodes on bad cert' do
+          http = Http.new Config.new(server_url: 'https://expired.badssl.com/')
           WebMock.disable!
-          expect { http.post("/") }.to raise_error(OpenSSL::SSL::SSLError)
+          expect { http.post('/') }.to raise_error(OpenSSL::SSL::SSLError)
           WebMock.enable!
         end
       end
     end
 
-    context "with the HttpAdapter" do
+    context 'with the HttpAdapter' do
       let(:adapter) { :NetHttpAdapter }
-      it_behaves_like "http"
+      it_behaves_like 'http'
 
-      describe "#post", :with_fake_server do
-        it "sets the appropriate headers" do
-          subject.post("/v1/transactions", things: 1)
+      describe '#post', :with_fake_server do
+        it 'sets the appropriate headers' do
+          subject.post('/v1/transactions', things: 1)
 
           expect(WebMock).to have_requested(:post, %r{/v1/transactions}).with(
-            headers: {"Accept" => "application/json",
-                      "Accept-Encoding" => /deflate/,
-                      "Content-Length" => /\d+/,
-                      "Content-Type" => "application/json",
-                      "User-Agent" => "elastic-apm/ruby #{VERSION}"},
+            headers: { 'Accept' => 'application/json',
+                       'Accept-Encoding' => /deflate/,
+                       'Content-Length' => /\d+/,
+                       'Content-Type' => 'application/json',
+                       'User-Agent' => "elastic-apm/ruby #{VERSION}" }
           )
         end
       end
 
-      context "when keepalive is set" do
-        let(:config) { {http_keepalive: true} }
+      context 'when keepalive is set' do
+        let(:config) { { http_keepalive: true } }
 
-        it "warns that keepalive is not available for the Net::HTTP adapter" do
-          expect { subject }.to output(/Cannot use keepalive with the Net::HTTP adapter/).to_stderr
+        it 'warns that keepalive is not available for the Net::HTTP adapter' do
+          expect { subject }.to output(/Cannot use keepalive/).to_stderr
         end
       end
     end
 
-    context "with the HttpRbAdapter" do
+    context 'with the HttpRbAdapter' do
       let(:adapter) { :HttpRbAdapter }
-      it_behaves_like "http"
+      it_behaves_like 'http'
 
-      describe "#post", :with_fake_server do
-        it "sets the appropriate headers" do
-          subject.post("/v1/transactions", things: 1)
+      describe '#post', :with_fake_server do
+        it 'sets the appropriate headers' do
+          subject.post('/v1/transactions', things: 1)
 
           expect(WebMock).to have_requested(:post, %r{/v1/transactions}).with(
             headers: {
-              "Accept" => "application/json",
-              "Content-Type" => "application/json",
-              "Host" => "localhost:8200",
-              "User-Agent" => "elastic-apm/ruby #{VERSION}",
-            },
+              'Accept' => 'application/json',
+              'Content-Type' => 'application/json',
+              'Host' => 'localhost:8200',
+              'User-Agent' => "elastic-apm/ruby #{VERSION}"
+            }
           )
         end
 
-        context "when keepalive is set" do
-          let(:config) { {http_keepalive: true} }
+        context 'when keepalive is set' do
+          let(:config) { { http_keepalive: true } }
 
-          it "sets the appropriate headers" do
-            subject.post("/v1/transactions", things: 1)
+          it 'sets the appropriate headers' do
+            subject.post('/v1/transactions', things: 1)
 
             expect(WebMock).to have_requested(:post, %r{/v1/transactions}).with(
               headers: {
-                "Accept" => "application/json",
-                "Content-Type" => "application/json",
-                "Host" => "localhost:8200",
-                "User-Agent" => "elastic-apm/ruby #{VERSION}",
-                "Connection" => "Keep-Alive",
-              },
+                'Accept' => 'application/json',
+                'Content-Type' => 'application/json',
+                'Host' => 'localhost:8200',
+                'User-Agent' => "elastic-apm/ruby #{VERSION}",
+                'Connection' => 'Keep-Alive'
+              }
             )
           end
         end


### PR DESCRIPTION
This PR refactors the HttpAdapter used in `ElasticAPM::Http` into an abstract base class, which is then implemented by subclasses. I refactored the call sites a bit so that the adapter-specific logic is encapsulated in each adapter.

This was done primarily to add support for HTTP keepalives. Net::HTTP doesn't provide them, and the cost of constantly opening connections to the APM server is not insignificant. I wanted keepalives to the APM server, and here we are.

It adds a soft dependency on the `http` gem - if it's present, the HttpRbAdapter is loaded, and is available to be used via the configuration object (`config.http_adapter = :HttpRbAdapter`). If it's not present, then it's not loaded. I don't love this pattern, but it's a low-touch way to get what we want. A better solution might be to rewrite the Http class to use Faraday, and then to permit the user to pass in a Faraday configuration using the client of their choice.

The suite passes and I've done basic testing in development mode - stuff gets through to the APM server - but I haven't banged on it super hard yet.