### PR TITLE
Performance improvement suggestions

### DIFF
--- a/lib/elastic_apm/serializers/errors.rb
+++ b/lib/elastic_apm/serializers/errors.rb
@@ -30,7 +30,7 @@ module ElasticAPM
       # rubocop:enable Metrics/AbcSize, Metrics/MethodLength
 
       def build_all(errors)
-        { errors: Array(errors).map(&method(:build)) }
+        { errors: Array(errors).map { |e| build(e) } }
       end
 
       private

--- a/lib/elastic_apm/serializers/transactions.rb
+++ b/lib/elastic_apm/serializers/transactions.rb
@@ -13,7 +13,7 @@ module ElasticAPM
           result: transaction.result.to_s,
           duration: ms(transaction.duration),
           timestamp: micros_to_time(transaction.timestamp).utc.iso8601(3),
-          spans: transaction.spans.map(&method(:build_span)),
+          spans: transaction.spans.map { |s| build_span(s) },
           sampled: transaction.sampled,
           context: transaction.context.to_h
         }
@@ -27,7 +27,7 @@ module ElasticAPM
       # rubocop:enable Metrics/AbcSize, Metrics/MethodLength
 
       def build_all(transactions)
-        { transactions: Array(transactions).map(&method(:build)) }
+        { transactions: Array(transactions).map { |t| build(t) } }
       end
 
       private


### PR DESCRIPTION
These are probably tiny wins but everything counts. When we have the automated benchmarks we'll be able to track if any of these might win us some µs per transaction.

- [x] Avoid `Object#send` (https://github.com/JuanitoFatas/fast-ruby#call-vs-send-vs-method_missing-code)
- [ ] Avoid `&method` (https://github.com/JuanitoFatas/fast-ruby#normal-way-to-apply-method-vs-method-code)
- [ ] Avoid splat arguments (https://github.com/JuanitoFatas/fast-ruby#function-with-single-array-argument-vs-splat-arguments-code)
- [ ] Use `String#match?` over `=~` (https://github.com/JuanitoFatas/fast-ruby#stringmatch-vs-stringmatch-vs-stringstart_withstringend_with-code-start-code-end)

(to be continued…?)