### PR TITLE
Add default_tags option

### DIFF
--- a/bench/report.rb
+++ b/bench/report.rb
@@ -50,7 +50,7 @@ payloads = titles.zip(averages, counts).map do |(title, avg, count)|
     transaction_count: count,
     executed_at: Time.new.iso8601,
     'git.commit' => git_sha,
-    'git.date' => git_date && Time.parse(git_date).iso8601,
+    'git.date' => String(git_date).strip != '' && Time.parse(git_date).iso8601,
     'git.subject' => git_msg,
     hostname: `hostname`.chomp,
     engine: RUBY_ENGINE,

--- a/lib/elastic_apm/config.rb
+++ b/lib/elastic_apm/config.rb
@@ -43,6 +43,8 @@ module ElasticAPM
 
       disabled_spies: %w[json],
 
+      default_tags: {},
+
       current_user_id_method: :id,
       current_user_email_method: :email,
       current_user_username_method: :username,
@@ -95,7 +97,9 @@ module ElasticAPM
       'ELASTIC_APM_TRANSACTION_MAX_SPANS' => [:int, 'transaction_max_spans'],
 
       'ELASTIC_APM_DISABLE_SEND' => [:bool, 'disable_send'],
-      'ELASTIC_APM_DISABLED_SPIES' => [:list, 'disabled_spies']
+      'ELASTIC_APM_DISABLED_SPIES' => [:list, 'disabled_spies'],
+
+      'ELASTIC_APM_DEFAULT_TAGS' => [:dict, 'default_tags']
     }.freeze
 
     def initialize(options = {})
@@ -161,6 +165,8 @@ module ElasticAPM
     attr_accessor :current_user_id_method
     attr_accessor :current_user_email_method
     attr_accessor :current_user_username_method
+
+    attr_accessor :default_tags
 
     attr_reader   :custom_key_filters
     attr_reader   :ignore_url_patterns
@@ -252,6 +258,7 @@ module ElasticAPM
           when :float then value.to_f
           when :bool then !%w[0 false].include?(value.strip.downcase)
           when :list then value.split(/[ ,]/)
+          when :dict then Hash[value.split('&').map { |kv| kv.split('=') }]
           else value
           end
 

--- a/lib/elastic_apm/context.rb
+++ b/lib/elastic_apm/context.rb
@@ -14,9 +14,9 @@ module ElasticAPM
     attr_accessor :request, :response, :user
     attr_reader :custom, :tags
 
-    def initialize
-      @custom = {}
-      @tags = {}
+    def initialize(custom: {}, tags: {})
+      @custom = custom
+      @tags = tags
     end
   end
 end

--- a/lib/elastic_apm/transaction.rb
+++ b/lib/elastic_apm/transaction.rb
@@ -29,6 +29,7 @@ module ElasticAPM
       @notifications = [] # for AS::Notifications
 
       @context = context || Context.new
+      @context.tags.merge!(instrumenter.config.default_tags)
 
       @sampled = sampled
 

--- a/spec/elastic_apm/config_spec.rb
+++ b/spec/elastic_apm/config_spec.rb
@@ -43,7 +43,12 @@ module ElasticAPM
           'test,production',
           %w[test production]
         ],
-        ['ELASTIC_APM_CUSTOM_KEY_FILTERS', 'Auth,Other', [/Auth/, /Other/]]
+        ['ELASTIC_APM_CUSTOM_KEY_FILTERS', 'Auth,Other', [/Auth/, /Other/]],
+        [
+          'ELASTIC_APM_DEFAULT_TAGS',
+          'test=something something&other=ok',
+          { 'test' => 'something something', 'other' => 'ok' }
+        ]
       ].each do |(key, val, expected)|
         val_before = ENV[key]
         ENV[key] = val

--- a/spec/elastic_apm/normalizers/action_controller_spec.rb
+++ b/spec/elastic_apm/normalizers/action_controller_spec.rb
@@ -15,8 +15,9 @@ module ElasticAPM
 
         describe '#normalize' do
           it 'sets transaction name from payload' do
+            instrumenter = double(Instrumenter, config: Config.new)
             subject = ProcessActionNormalizer.new nil
-            transaction = Transaction.new nil, 'Rack'
+            transaction = Transaction.new instrumenter, 'Rack'
 
             result = subject.normalize(
               transaction,

--- a/spec/elastic_apm/worker_spec.rb
+++ b/spec/elastic_apm/worker_spec.rb
@@ -3,9 +3,10 @@
 module ElasticAPM
   RSpec.describe Worker do
     describe 'a loop' do
+      let(:config) { Config.new flush_interval: 0.1 }
+      let(:instrumenter) { Instrumenter.new(Agent.new(config)) }
       let(:messages) { Queue.new }
       let(:transactions) { Queue.new }
-      let(:config) { Config.new flush_interval: 0.1 }
 
       around do |example|
         @thread = Thread.new do
@@ -73,7 +74,7 @@ module ElasticAPM
       end
 
       def build_transaction
-        Transaction.new(nil, nil)
+        Transaction.new(instrumenter, nil)
       end
 
       def build_error


### PR DESCRIPTION
Allows the user to add config-level tags that'll be included in every transaction.

See elastic/apm-agent-ruby#164 

Also includes some spec suite clean-up.