### PR TITLE
check for Rails::Application instead of just ::Rails

### DIFF
--- a/lib/elastic_apm/config.rb
+++ b/lib/elastic_apm/config.rb
@@ -188,7 +188,7 @@ module ElasticAPM
     end
 
     def app_type?(app)
-      if defined?(::Rails) && app.is_a?(Rails::Application)
+      if defined?(Rails::Application) && app.is_a?(Rails::Application)
         return :rails
       end
 


### PR DESCRIPTION
Fix flawed check that would assume Rails::Application is defined if ::Rails is, which is not always the case. In a Sinatra app which uses some Rails libraries, this results in failure to boot.