### PR TITLE
Correctly document `set_custom_context` method

### DIFF
--- a/docs/context.asciidoc
+++ b/docs/context.asciidoc
@@ -5,13 +5,13 @@
 [float]
 ==== Adding custom context
 
-You can add your own custom, nested JSON-compatible data to the current transaction using `ElasticAPM.add_custom_context(hash)` eg.:
+You can add your own custom, nested JSON-compatible data to the current transaction using `ElasticAPM.set_custom_context(hash)` eg.:
 
 [source,ruby]
 ----
 class ThingsController < ApplicationController
   before_action do
-    ElasticAPM.add_custom_context(company: current_user.company)
+    ElasticAPM.set_custom_context(company: current_user.company)
   end
 
   # ...


### PR DESCRIPTION
Hi,

the ElasticAPM documentation says that the method for adding custom context is `add_custom_context`, which doesn't exist. The correct method should be `set_custom_context`.