### PR TITLE
Add rake task instrumentation

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,6 +12,7 @@ gem 'json-schema'
 gem 'mongo'
 gem 'pry'
 gem 'rack-test'
+gem 'rake'
 gem 'redis', require: nil
 gem 'rspec'
 gem 'rubocop'

--- a/docs/configuration.asciidoc
+++ b/docs/configuration.asciidoc
@@ -390,6 +390,18 @@ Use this option to disable any of these.
 Get an array of enabled spies with `ElasticAPM.agent.config.enabled_spies`.
 
 [float]
+[[config-instrumented-rake-tasks]]
+==== `instrumented_rake_tasks`
+
+[options="header"]
+|============
+| Environment                           | `Config` key              | Default | Example
+| `ELASTIC_APM_INSTRUMENTED_RAKE_TASKS` | `instrumented_rake_tasks` | `[]`    | `['my_task']`
+|============
+
+Elastic APM can instrument your Rake tasks but given that they are used for a multitude of sometimes very different and not always relevant things, this is opt in.
+
+[float]
 [[config-default-tags]]
 ==== `default_tags`
 

--- a/lib/elastic_apm/config.rb
+++ b/lib/elastic_apm/config.rb
@@ -42,6 +42,7 @@ module ElasticAPM
       span_frames_min_duration: 5,
 
       disabled_spies: %w[json],
+      instrument_rake: false,
 
       default_tags: {},
 
@@ -98,6 +99,7 @@ module ElasticAPM
 
       'ELASTIC_APM_DISABLE_SEND' => [:bool, 'disable_send'],
       'ELASTIC_APM_DISABLED_SPIES' => [:list, 'disabled_spies'],
+      'ELASTIC_APM_INSTRUMENT_RAKE' => [:bool, 'instrument_rake'],
 
       'ELASTIC_APM_DEFAULT_TAGS' => [:dict, 'default_tags']
     }.freeze
@@ -157,6 +159,7 @@ module ElasticAPM
     attr_accessor :span_frames_min_duration
 
     attr_accessor :disabled_spies
+    attr_accessor :instrument_rake
 
     attr_accessor :view_paths
     attr_accessor :root_path
@@ -172,8 +175,9 @@ module ElasticAPM
     attr_reader   :ignore_url_patterns
 
     alias :disable_environment_warning? :disable_environment_warning
-    alias :verify_server_cert? :verify_server_cert
     alias :disable_send? :disable_send
+    alias :instrument_rake? :instrument_rake
+    alias :verify_server_cert? :verify_server_cert
 
     def app=(app)
       case app_type?(app)
@@ -225,6 +229,7 @@ module ElasticAPM
         sidekiq
         sinatra
         tilt
+        rake
       ]
     end
     # rubocop:enable Metrics/MethodLength

--- a/lib/elastic_apm/config.rb
+++ b/lib/elastic_apm/config.rb
@@ -42,7 +42,7 @@ module ElasticAPM
       span_frames_min_duration: 5,
 
       disabled_spies: %w[json],
-      instrument_rake: false,
+      instrumented_rake_tasks: [],
 
       default_tags: {},
 
@@ -99,7 +99,8 @@ module ElasticAPM
 
       'ELASTIC_APM_DISABLE_SEND' => [:bool, 'disable_send'],
       'ELASTIC_APM_DISABLED_SPIES' => [:list, 'disabled_spies'],
-      'ELASTIC_APM_INSTRUMENT_RAKE' => [:bool, 'instrument_rake'],
+      'ELASTIC_APM_INSTRUMENTED_RAKE_TASKS' =>
+        [:list, 'instrumented_rake_tasks'],
 
       'ELASTIC_APM_DEFAULT_TAGS' => [:dict, 'default_tags']
     }.freeze
@@ -159,7 +160,7 @@ module ElasticAPM
     attr_accessor :span_frames_min_duration
 
     attr_accessor :disabled_spies
-    attr_accessor :instrument_rake
+    attr_accessor :instrumented_rake_tasks
 
     attr_accessor :view_paths
     attr_accessor :root_path
@@ -176,7 +177,6 @@ module ElasticAPM
 
     alias :disable_environment_warning? :disable_environment_warning
     alias :disable_send? :disable_send
-    alias :instrument_rake? :instrument_rake
     alias :verify_server_cert? :verify_server_cert
 
     def app=(app)

--- a/lib/elastic_apm/spies/rake.rb
+++ b/lib/elastic_apm/spies/rake.rb
@@ -14,7 +14,7 @@ module ElasticAPM
           def execute(*args)
             agent = ElasticAPM.start
 
-            unless agent && agent.config.instrument_rake?
+            unless agent && agent.config.instrumented_rake_tasks.include?(name)
               return execute_without_apm(*args)
             end
 

--- a/lib/elastic_apm/spies/rake.rb
+++ b/lib/elastic_apm/spies/rake.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+module ElasticAPM
+  # @api private
+  module Spies
+    # @api private
+    class RakeSpy
+      # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
+      # rubocop:disable Metrics/CyclomaticComplexity
+      def install
+        ::Rake::Task.class_eval do
+          alias execute_without_apm execute
+
+          def execute(*args)
+            agent = ElasticAPM.start
+
+            unless agent && agent.config.instrument_rake?
+              return execute_without_apm(*args)
+            end
+
+            transaction = ElasticAPM.transaction("Rake::Task[#{name}]", 'Rake')
+
+            begin
+              result = execute_without_apm(*args)
+
+              transaction.submit('success') if transaction
+            rescue StandardError => e
+              transaction.submit(:error) if transaction
+              ElasticAPM.report(e)
+
+              raise
+            ensure
+              transaction.release if transaction
+              ElasticAPM.stop
+            end
+
+            result
+          end
+        end
+      end
+      # rubocop:enable Metrics/CyclomaticComplexity
+      # rubocop:enable Metrics/AbcSize, Metrics/MethodLength
+    end
+    register 'Rake::Task', 'rake', RakeSpy.new
+  end
+end

--- a/spec/elastic_apm/spies/rake_spec.rb
+++ b/spec/elastic_apm/spies/rake_spec.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'rake'
+
+module ElasticAPM
+  RSpec.describe 'Rake', :with_fake_server do
+    let(:task) do
+      Rake::Task.define_task(:test_task) do
+        'ok'
+      end
+    end
+
+    it 'wraps in transaction when enabled' do
+      ElasticAPM.start(instrument_rake: true)
+
+      task.invoke
+
+      expect(FakeServer.requests.length).to be 1
+    end
+
+    context 'when disabled' do
+      it 'wraps in transaction when enabled' do
+        ElasticAPM.start
+        task.invoke
+        expect(FakeServer.requests.length).to be 0
+      end
+    end
+  end
+end

--- a/spec/elastic_apm/spies/rake_spec.rb
+++ b/spec/elastic_apm/spies/rake_spec.rb
@@ -12,7 +12,7 @@ module ElasticAPM
     end
 
     it 'wraps in transaction when enabled' do
-      ElasticAPM.start(instrument_rake: true)
+      ElasticAPM.start(instrumented_rake_tasks: %w[test_task])
 
       task.invoke
 


### PR DESCRIPTION
Continued from #174.

Brings a new setting `instrument_rake` that defaults to `false`.

Some people use rake for running common tasks in production. In this case APM could help a lot with debugging and optimizing. But rake is used for a lot of other things as well, so we don't want to just go ahead and enable this on every task everytime.

This way a user can choose to

- completely omit the rake spy (`disabled_spies += ['rake']`)
- load the spy but don't instrument (default)
- load the spy and instrument everywhere (`instrumented_rake_tasks: ['my_task']` in config file)
- load everywhere but only instrument individual tasks (`$ ELASTIC_APM_INSTRUMENTED_RAKE_TASKS=some_task rake some_task`)

---

- [x] Spec
- [x] Docs