### PR TITLE
Restrict log_level to agent logs (#197)

### DIFF
--- a/lib/elastic_apm.rb
+++ b/lib/elastic_apm.rb
@@ -2,7 +2,7 @@
 
 require 'elastic_apm/version'
 require 'elastic_apm/internal_error'
-require 'elastic_apm/log'
+require 'elastic_apm/logging'
 
 # Core
 require 'elastic_apm/agent'

--- a/lib/elastic_apm/agent.rb
+++ b/lib/elastic_apm/agent.rb
@@ -12,7 +12,7 @@ module ElasticAPM
   # rubocop:disable Metrics/ClassLength
   # @api private
   class Agent
-    include Log
+    include Logging
 
     LOCK = Mutex.new
 
@@ -31,7 +31,7 @@ module ElasticAPM
         unless config.disable_environment_warning?
           puts format(
             '%sNot tracking anything in "%s" env',
-            Log::PREFIX, config.environment
+            Logging::PREFIX, config.environment
           )
         end
 

--- a/lib/elastic_apm/http.rb
+++ b/lib/elastic_apm/http.rb
@@ -12,7 +12,7 @@ require 'elastic_apm/filters'
 module ElasticAPM
   # @api private
   class Http
-    include Log
+    include Logging
 
     USER_AGENT = "elastic-apm/ruby #{VERSION}"
     ACCEPT = 'application/json'

--- a/lib/elastic_apm/instrumenter.rb
+++ b/lib/elastic_apm/instrumenter.rb
@@ -6,7 +6,7 @@ require 'elastic_apm/transaction'
 module ElasticAPM
   # @api private
   class Instrumenter
-    include Log
+    include Logging
 
     TRANSACTION_KEY = :__elastic_transaction_key
 

--- a/lib/elastic_apm/railtie.rb
+++ b/lib/elastic_apm/railtie.rb
@@ -26,7 +26,7 @@ module ElasticAPM
           app.middleware.insert 0, Middleware
         end
       rescue StandardError => e
-        Rails.logger.error "#{Log::PREFIX}Failed to start: #{e.message}"
+        Rails.logger.error "#{Logging::PREFIX}Failed to start: #{e.message}"
         Rails.logger.debug e.backtrace.join("\n")
       end
     end

--- a/lib/elastic_apm/subscriber.rb
+++ b/lib/elastic_apm/subscriber.rb
@@ -6,7 +6,7 @@ require 'elastic_apm/normalizers'
 module ElasticAPM
   # @api private
   class Subscriber
-    include Log
+    include Logging
 
     def initialize(agent)
       @agent = agent

--- a/lib/elastic_apm/transport/connection.rb
+++ b/lib/elastic_apm/transport/connection.rb
@@ -10,7 +10,7 @@ module ElasticAPM
   module Transport
     # @api private
     class Connection # rubocop:disable Metrics/ClassLength
-      include Log
+      include Logging
 
       class FailedToConnectError < InternalError; end
 

--- a/spec/elastic_apm/logging_spec.rb
+++ b/spec/elastic_apm/logging_spec.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+module ElasticAPM
+  RSpec.describe Logging do
+    class Tester
+      include Logging
+
+      def initialize(config)
+        @config = config
+      end
+    end
+
+    let(:config) do
+      Struct.new(:logger, :log_level).new(logger, log_level)
+    end
+
+    subject { Tester.new(config) }
+
+    context 'with a logger' do
+      let(:logger) { double(Logger) }
+      let(:log_level) { nil }
+
+      it 'logs messages' do
+        expect(logger).to receive(:warn).with('[ElasticAPM] Things')
+        subject.warn 'Things'
+      end
+
+      context 'with a level of warn' do
+        let(:log_level) { Logger::WARN }
+
+        it 'skips lower level messages' do
+          expect(logger).to receive(:warn).with('[ElasticAPM] Things')
+          subject.warn 'Things'
+
+          expect(logger).to_not receive(:debug)
+          subject.debug 'Debug things'
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Closes elastic/apm-agent-ruby#197 