### PR TITLE
(🚧 ) Refactor Transaction and Span initialization

### DIFF
--- a/lib/elastic_apm/agent.rb
+++ b/lib/elastic_apm/agent.rb
@@ -66,7 +66,7 @@ module ElasticAPM
 
       @context_builder = ContextBuilder.new(self)
       @error_builder = ErrorBuilder.new(self)
-      @stacktrace_builder = StacktraceBuilder.new(self)
+      @stacktrace_builder = StacktraceBuilder.new(config)
     end
 
     attr_reader :config, :transport, :messages, :pending_transactions,

--- a/lib/elastic_apm/error_builder.rb
+++ b/lib/elastic_apm/error_builder.rb
@@ -7,6 +7,7 @@ module ElasticAPM
       @agent = agent
     end
 
+    # rubocop:disable Metrics/MethodLength
     def build_exception(exception, handled: true)
       error = Error.new
       error.exception = Error::Exception.new(exception, handled: handled)
@@ -25,6 +26,7 @@ module ElasticAPM
 
       error
     end
+    # rubocop:enable Metrics/MethodLength
 
     def build_log(message, backtrace: nil, **attrs)
       error = Error.new

--- a/lib/elastic_apm/instrumenter.rb
+++ b/lib/elastic_apm/instrumenter.rb
@@ -128,7 +128,7 @@ module ElasticAPM
       @current.span = span
     end
 
-    # rubocop:disable Metrics/MethodLength
+    # rubocop:disable Metrics/MethodLength, Metrics/CyclomaticComplexity
     def start_span(name, type = nil, backtrace: nil, context: nil)
       return unless (transaction = current_transaction)
       return unless transaction.sampled?
@@ -156,7 +156,7 @@ module ElasticAPM
 
       span.start
     end
-    # rubocop:enable Metrics/MethodLength
+    # rubocop:enable Metrics/MethodLength, Metrics/CyclomaticComplexity
 
     def end_span
       return unless (span = current_span)

--- a/lib/elastic_apm/instrumenter.rb
+++ b/lib/elastic_apm/instrumenter.rb
@@ -163,7 +163,8 @@ module ElasticAPM
 
       span.done
 
-      self.current_span = span.parent if span.parent&.is_a?(Span)
+      self.current_span =
+        span.parent&.is_a?(Span) && span.parent || nil
 
       agent.enqueue span
     end

--- a/lib/elastic_apm/span.rb
+++ b/lib/elastic_apm/span.rb
@@ -71,6 +71,10 @@ module ElasticAPM
       !!duration
     end
 
+    def running?
+      relative_start && !stopped?
+    end
+
     # relations
 
     def inspect

--- a/lib/elastic_apm/span.rb
+++ b/lib/elastic_apm/span.rb
@@ -9,6 +9,7 @@ module ElasticAPM
   class Span
     DEFAULT_TYPE = 'custom'
 
+    # rubocop:disable Metrics/ParameterLists
     def initialize(
       name,
       type = nil,
@@ -28,6 +29,7 @@ module ElasticAPM
       @context = context
       @stacktrace_builder = stacktrace_builder
     end
+    # rubocop:enable Metrics/ParameterLists
 
     attr_accessor :name, :type, :original_backtrace, :parent
     attr_reader :id, :context, :stacktrace, :duration,

--- a/lib/elastic_apm/stacktrace_builder.rb
+++ b/lib/elastic_apm/stacktrace_builder.rb
@@ -12,8 +12,8 @@ module ElasticAPM
     RUBY_VERS_REGEX = %r{ruby(/gems)?[-/](\d+\.)+\d}
     JRUBY_ORG_REGEX = %r{org/jruby}
 
-    def initialize(agent)
-      @config = agent.config
+    def initialize(config)
+      @config = config
       @cache = Util::LruCache.new(2048, &method(:build_frame))
     end
 

--- a/lib/elastic_apm/transaction.rb
+++ b/lib/elastic_apm/transaction.rb
@@ -7,7 +7,7 @@ module ElasticAPM
   class Transaction
     DEFAULT_TYPE = 'custom'
 
-    # rubocop:disable Metrics/ParameterLists
+    # rubocop:disable Metrics/ParameterLists, Metrics/MethodLength
     def initialize(
       name = nil,
       type = nil,
@@ -38,7 +38,7 @@ module ElasticAPM
 
       @notifications = [] # for AS::Notifications
     end
-    # rubocop:enable Metrics/ParameterLists
+    # rubocop:enable Metrics/ParameterLists, Metrics/MethodLength
 
     attr_accessor :name, :type, :result
 

--- a/lib/elastic_apm/transaction.rb
+++ b/lib/elastic_apm/transaction.rb
@@ -25,7 +25,13 @@ module ElasticAPM
       Util.reverse_merge!(@context.tags, tags) if tags
 
       @id = SecureRandom.hex(8)
-      @traceparent = traceparent || Traceparent.from_transaction(self)
+
+      if traceparent
+        @traceparent = traceparent
+        @parent_id = traceparent.span_id
+      else
+        @traceparent = Traceparent.from_transaction(self)
+      end
 
       @started_spans = 0
       @dropped_spans = 0
@@ -37,7 +43,7 @@ module ElasticAPM
     attr_accessor :name, :type, :result
 
     attr_reader :id, :context, :duration, :started_spans, :dropped_spans,
-      :timestamp, :traceparent, :notifications
+      :timestamp, :traceparent, :notifications, :parent_id
 
     def sampled?
       @sampled

--- a/lib/elastic_apm/transport/serializers/error_serializer.rb
+++ b/lib/elastic_apm/transport/serializers/error_serializer.rb
@@ -5,7 +5,7 @@ module ElasticAPM
     module Serializers
       # @api private
       class ErrorSerializer < Serializer
-        # rubocop:disable Metrics/MethodLength
+        # rubocop:disable Metrics/MethodLength, Metrics/AbcSize
         def build(error)
           base = {
             id: error.id,
@@ -28,7 +28,7 @@ module ElasticAPM
 
           { error: base }
         end
-        # rubocop:enable Metrics/MethodLength
+        # rubocop:enable Metrics/MethodLength, Metrics/AbcSize
 
         private
 

--- a/lib/elastic_apm/transport/serializers/transaction_serializer.rb
+++ b/lib/elastic_apm/transport/serializers/transaction_serializer.rb
@@ -17,7 +17,7 @@ module ElasticAPM
               result: transaction.result.to_s,
               duration: ms(transaction.duration),
               timestamp: micros_to_time(transaction.timestamp).utc.iso8601(3),
-              sampled: transaction.sampled,
+              sampled: transaction.sampled?,
               context: transaction.context.to_h,
               span_count: {
                 started: transaction.started_spans,

--- a/lib/elastic_apm/util.rb
+++ b/lib/elastic_apm/util.rb
@@ -19,5 +19,9 @@ module ElasticAPM
     def self.hex_to_bit(str)
       str.hex.to_s(2).rjust(str.size * 4, '0')
     end
+
+    def self.reverse_merge!(first, second)
+      first.merge!(second) { |_, old, _| old }
+    end
   end
 end

--- a/spec/elastic_apm/instrumenter_spec.rb
+++ b/spec/elastic_apm/instrumenter_spec.rb
@@ -53,28 +53,21 @@ module ElasticAPM
     end
 
     describe '#span' do
-      context 'with span_frames_min_duration' do
-        let(:config) do
-          Config.new(span_frames_min_duration: 10, disable_send: true)
-        end
-
-        it 'collects stacktraces', :mock_time do
+      context 'collecting stacktrace', :intercept do
+        it 'knows when to' do
           subject.start_transaction
 
-          span1 = subject.start_span 'Things', backtrace: caller
-          travel 100
-          subject.end_span
+          span_with_backtrace =
+            subject.start_span 'Things', backtrace: caller
+          expect(span_with_backtrace.original_backtrace).to_not be_nil
+          span_with_backtrace.done
 
-          travel 100
-
-          span2 = subject.start_span 'Short things', backtrace: caller
-          travel 5
-          subject.end_span
+          span_without_backtrace =
+            subject.start_span 'Short things'
+          expect(span_without_backtrace.original_backtrace).to be_nil
+          span_without_backtrace.done
 
           subject.end_transaction
-
-          expect(span1.stacktrace).to_not be_nil
-          expect(span2.stacktrace).to be_nil
         end
       end
     end

--- a/spec/elastic_apm/span_spec.rb
+++ b/spec/elastic_apm/span_spec.rb
@@ -2,51 +2,110 @@
 
 module ElasticAPM
   RSpec.describe Span do
-    let(:transactionish) do
-      Struct
-        .new(:id, :timestamp, :instrumenter, :trace_id)
-        .new('id', Util.micros, nil, '__trace_id')
+    subject { described_class.new 'Spannest name' }
+
+    describe '#initialize' do
+      its(:name) { should be 'Spannest name' }
+      its(:type) { should be 'custom' }
+      its(:transaction_id) { should be_nil }
+      its(:timestamp) { should be_nil }
+      its(:trace_id) { should be_nil }
+      its(:parent_id) { should be_nil }
+      its(:context) { should be_nil }
+
+      context 'with a transaction' do
+        let(:transaction) { Transaction.new }
+
+        subject do
+          described_class.new 'Spannest name', transaction: transaction
+        end
+
+        its(:transaction_id) { should be transaction.id }
+        its(:timestamp) { should be transaction.timestamp }
+        its(:trace_id) { should be transaction.trace_id }
+      end
+
+      context 'with a parent' do
+        let(:span) { Span.new 'Span' }
+        subject { described_class.new 'Span', parent: span }
+        its(:parent_id) { should be span.id }
+      end
     end
 
     describe '#start', :mock_time do
-      it 'has a relative and absolute start time', :mock_time do
-        span = Span.new(transactionish, nil, 'test-1')
-        travel 100
-        span.start
+      let(:transaction) { Transaction.new }
 
-        expect(span.relative_start).to eq 100_000
-        expect(span.timestamp).to eq Util.micros - 100_000
+      subject { described_class.new('Span', transaction: transaction) }
+
+      it 'has a relative and absolute start time', :mock_time do
+        transaction.start
+        travel 100
+        expect(subject.start).to be subject
+        expect(subject.relative_start).to eq 100_000
+      end
+
+      context 'when missing transaction' do
+        subject { described_class.new 'Span' }
+
+        it 'raises a RuntimeError' do
+          expect { subject.start }.to raise_error(RuntimeError)
+        end
+      end
+    end
+
+    describe '#stopped', :mock_time do
+      let(:transaction) { Transaction.new }
+
+      subject { described_class.new('Span', transaction: transaction) }
+
+      it 'sets duration' do
+        transaction.start
+        subject.start
+        travel 100
+        subject.stop
+
+        expect(subject).to be_stopped
+        expect(subject.duration).to be 100_000
       end
     end
 
     describe '#done', :mock_time do
-      it 'sets duration' do
-        subject = Span.new(transactionish, nil, 'test-1')
-
-        expect(subject).to_not be_done
-
-        subject.start
-        travel 100
-        subject.done
-
-        expect(subject).to be_done
-        expect(subject.duration).to eq 100_000
+      let(:transaction) { Transaction.new }
+      let(:duration) { 100 }
+      let(:span_frames_min_duration) { 5 }
+      let(:config) do
+        Config.new(span_frames_min_duration: span_frames_min_duration)
       end
-    end
 
-    describe '#running?' do
-      it 'is when started and not done' do
-        subject = Span.new(transactionish, nil, 'test-1')
+      subject do
+        described_class.new(
+          'Span',
+          transaction: transaction,
+          stacktrace_builder: StacktraceBuilder.new(config)
+        )
+      end
 
-        expect(subject).to_not be_running
-
+      before do
+        transaction.start
+        subject.original_backtrace = caller
         subject.start
-
-        expect(subject).to be_running
-
+        travel duration
         subject.done
+      end
 
-        expect(subject).to_not be_running
+      it { should be_stopped }
+      its(:duration) { should be 100_000 }
+      its(:stacktrace) { should be_a Stacktrace }
+
+      context 'when shorter than min for stacktrace' do
+        let(:span_frames_min_duration) { 1000 }
+        its(:stacktrace) { should be_nil }
+      end
+
+      context 'when short, but min duration is off' do
+        let(:duration) { 0 }
+        let(:span_frames_min_duration) { -1 }
+        its(:stacktrace) { should be_a Stacktrace }
       end
     end
   end

--- a/spec/elastic_apm/stacktrace_builder_spec.rb
+++ b/spec/elastic_apm/stacktrace_builder_spec.rb
@@ -2,8 +2,8 @@
 
 module ElasticAPM
   RSpec.describe StacktraceBuilder do
-    let(:agent) { Agent.new Config.new }
-    subject { described_class.new(agent) }
+    let(:config) { Config.new }
+    subject { described_class.new(config) }
 
     describe '.build' do
       context 'mri', unless: RSpec::Support::Ruby.jruby? do

--- a/spec/elastic_apm/subscriber_spec.rb
+++ b/spec/elastic_apm/subscriber_spec.rb
@@ -62,7 +62,7 @@ if enable
           agent.end_transaction
 
           expect(span).to_not be_running
-          expect(span).to be_done
+          expect(span).to be_stopped
         end
 
         it 'ignores unknown notifications' do

--- a/spec/elastic_apm/transport/serializers/error_serializer_spec.rb
+++ b/spec/elastic_apm/transport/serializers/error_serializer_spec.rb
@@ -37,6 +37,7 @@ module ElasticAPM
                     stacktrace: error.exception.stacktrace.to_a, # so lazy
                     handled: true
                   },
+                  parent_id: nil,
                   trace_id: nil,
                   transaction_id: nil
                 }
@@ -75,7 +76,8 @@ module ElasticAPM
                   },
                   timestamp: Time.utc(1992, 1, 1).iso8601(3),
                   trace_id: nil,
-                  transaction_id: nil
+                  transaction_id: nil,
+                  parent_id: nil
                 }
               )
             end

--- a/spec/elastic_apm_spec.rb
+++ b/spec/elastic_apm_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe ElasticAPM do
 
         ElasticAPM.end_transaction
         expect(ElasticAPM.current_transaction).to be_nil
-        expect(transaction).to be_done
+        expect(transaction).to be_stopped
 
         ElasticAPM.flush
 
@@ -82,7 +82,7 @@ RSpec.describe ElasticAPM do
 
         ElasticAPM.end_span
         expect(ElasticAPM.current_span).to be_nil
-        expect(span).to be_done
+        expect(span).to be_stopped
       end
     end
 


### PR DESCRIPTION
Basically dumbing down `Transaction` and `Span` so they don't know about the Agent nor an Instrumenter. This makes them much easier to work with in our specs but also easier to reason about generally.