### PR TITLE
Add Transport::Worker

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -42,6 +42,10 @@ else
   gem framework
 end
 
+unless version == 'master'
+  gem 'delayed_job', require: nil
+end
+
 group :bench do
   gem 'ruby-prof', require: nil, platforms: %i[ruby]
   gem 'stackprof', require: nil, platforms: %i[ruby]

--- a/lib/elastic_apm/config.rb
+++ b/lib/elastic_apm/config.rb
@@ -20,12 +20,15 @@ module ElasticAPM
       environment: ENV['RAILS_ENV'] || ENV['RACK_ENV'],
       instrument: true,
 
-      log_level: Logger::INFO,
+      log_level: Logger::DEBUG,
       log_path: nil,
 
       api_request_size: '750kb',
       api_request_time: '10s',
-      api_buffer_size: 10,
+      api_buffer_size: 256,
+
+      pool_size: 1,
+
       disable_send: false,
       verify_server_cert: true,
       http_compression: true,
@@ -70,6 +73,8 @@ module ElasticAPM
       'ELASTIC_APM_DISABLE_SEND' => [:bool, 'disable_send'],
       'ELASTIC_APM_VERIFY_SERVER_CERT' => [:bool, 'verify_server_cert'],
 
+      'ELASTIC_APM_POOL_SIZE' => [:int, 'pool_size'],
+
       'ELASTIC_APM_CUSTOM_KEY_FILTERS' => [:list, 'custom_key_filters'],
       'ELASTIC_APM_DEFAULT_TAGS' => [:dict, 'default_tags'],
       'ELASTIC_APM_DISABLED_SPIES' => [:list, 'disabled_spies'],
@@ -113,7 +118,7 @@ module ElasticAPM
 
       yield self if block_given?
 
-      build_logger if logger.nil? || log_path
+      build_logger if logger.nil?
     end
 
     attr_accessor :config_file
@@ -139,6 +144,7 @@ module ElasticAPM
     attr_accessor :api_buffer_size
     attr_accessor :api_request_size
     attr_accessor :api_request_time
+    attr_accessor :pool_size
     attr_accessor :disable_send
     attr_accessor :http_compression
     attr_accessor :verify_server_cert
@@ -317,7 +323,7 @@ module ElasticAPM
     end
 
     def build_logger
-      logger = Logger.new(log_path == '-' ? $stdout : log_path)
+      logger = Logger.new(log_path == '-' ? STDOUT : log_path)
       logger.level = log_level
 
       self.logger = logger

--- a/lib/elastic_apm/config/duration.rb
+++ b/lib/elastic_apm/config/duration.rb
@@ -5,7 +5,7 @@ module ElasticAPM
     # @api private
     class Duration
       MULTIPLIERS = { 'ms' => 0.001, 'm' => 60 }.freeze
-      REGEX = /^(-)?(\d+)(m|ms|s)?$/i
+      REGEX = /^(-)?(\d+)(m|ms|s)?$/i.freeze
 
       def initialize(seconds)
         @seconds = seconds

--- a/lib/elastic_apm/config/size.rb
+++ b/lib/elastic_apm/config/size.rb
@@ -9,7 +9,7 @@ module ElasticAPM
         'mb' => 1024 * 1_000,
         'gb' => 1024 * 100_000
       }.freeze
-      REGEX = /^(\d+)(b|kb|mb|gb)?$/i
+      REGEX = /^(\d+)(b|kb|mb|gb)?$/i.freeze
 
       def initialize(bytes)
         @bytes = bytes

--- a/lib/elastic_apm/metadata.rb
+++ b/lib/elastic_apm/metadata.rb
@@ -12,7 +12,7 @@ module ElasticAPM
         metadata: {
           service: Metadata::ServiceInfo.build(config),
           process: Metadata::ProcessInfo.build(config),
-          system:  Metadata::SystemInfo.build(config)
+          system: Metadata::SystemInfo.build(config)
         }
       }.to_json
     end

--- a/lib/elastic_apm/span.rb
+++ b/lib/elastic_apm/span.rb
@@ -73,8 +73,12 @@ module ElasticAPM
       !!duration
     end
 
+    def started?
+      !!relative_start
+    end
+
     def running?
-      relative_start && !stopped?
+      started? && !stopped?
     end
 
     # relations

--- a/lib/elastic_apm/span_helpers.rb
+++ b/lib/elastic_apm/span_helpers.rb
@@ -27,7 +27,7 @@ module ElasticAPM
               return __without_apm_#{method}(*args, &block)
             end
 
-            ElasticAPM.span "#{name}", "#{type}" do
+            ElasticAPM.with_span "#{name}", "#{type}" do
               __without_apm_#{method}(*args, &block)
             end
           end

--- a/lib/elastic_apm/spies/delayed_job.rb
+++ b/lib/elastic_apm/spies/delayed_job.rb
@@ -24,10 +24,10 @@ module ElasticAPM
         job_name = name_from_payload(job.payload_object)
         transaction = ElasticAPM.start_transaction(job_name, TYPE)
         job.invoke_job_without_apm(*args, &block)
-        transaction.done :success
+        transaction.done 'success'
       rescue ::Exception => e
         ElasticAPM.report(e, handled: false)
-        transaction.done :error
+        transaction.done 'error'
         raise
       ensure
         ElasticAPM.end_transaction

--- a/lib/elastic_apm/stacktrace_builder.rb
+++ b/lib/elastic_apm/stacktrace_builder.rb
@@ -6,11 +6,11 @@ require 'elastic_apm/util/lru_cache'
 module ElasticAPM
   # @api private
   class StacktraceBuilder
-    JAVA_FORMAT = /^(.+)\.([^\.]+)\(([^\:]+)\:(\d+)\)$/
-    RUBY_FORMAT = /^(.+?):(\d+)(?::in `(.+?)')?$/
+    JAVA_FORMAT = /^(.+)\.([^\.]+)\(([^\:]+)\:(\d+)\)$/.freeze
+    RUBY_FORMAT = /^(.+?):(\d+)(?::in `(.+?)')?$/.freeze
 
-    RUBY_VERS_REGEX = %r{ruby(/gems)?[-/](\d+\.)+\d}
-    JRUBY_ORG_REGEX = %r{org/jruby}
+    RUBY_VERS_REGEX = %r{ruby(/gems)?[-/](\d+\.)+\d}.freeze
+    JRUBY_ORG_REGEX = %r{org/jruby}.freeze
 
     def initialize(config)
       @config = config

--- a/lib/elastic_apm/traceparent.rb
+++ b/lib/elastic_apm/traceparent.rb
@@ -6,7 +6,7 @@ module ElasticAPM
     class InvalidTraceparentHeader < StandardError; end
 
     VERSION = '00'
-    HEX_REGEX = /[^[:xdigit:]]/
+    HEX_REGEX = /[^[:xdigit:]]/.freeze
 
     def initialize
       @version = VERSION

--- a/lib/elastic_apm/transport/filters.rb
+++ b/lib/elastic_apm/transport/filters.rb
@@ -14,14 +14,11 @@ module ElasticAPM
       # @api private
       class Container
         def initialize(config)
-          @config = config
           @filters = {
             request_body: RequestBodyFilter.new(config),
             secrets: SecretsFilter.new(config)
           }
         end
-
-        attr_reader :config
 
         def add(key, filter)
           @filters[key] = filter
@@ -31,7 +28,7 @@ module ElasticAPM
           @filters.delete(key)
         end
 
-        def apply(payload)
+        def apply!(payload)
           @filters.reduce(payload) do |result, (_key, filter)|
             result = filter.call(result)
             break if result.nil?

--- a/lib/elastic_apm/transport/worker.rb
+++ b/lib/elastic_apm/transport/worker.rb
@@ -1,0 +1,74 @@
+# frozen_string_literal: true
+
+module ElasticAPM
+  module Transport
+    # @api private
+    class Worker
+      include Logging
+
+      # @api private
+      class StopMessage; end
+
+      # @api private
+      class FlushMessage; end
+
+      def initialize(
+        config,
+        queue,
+        serializers:,
+        filters:,
+        conn_adapter: Connection
+      )
+        @config = config
+        @queue = queue
+
+        @stopping = false
+
+        @connection = conn_adapter.new(config)
+        @serializers = serializers
+        @filters = filters
+      end
+
+      attr_reader :queue, :filters, :name, :connection, :serializers
+
+      def stop
+        @stopping = true
+      end
+
+      def stopping?
+        @stopping
+      end
+
+      # rubocop:disable Metrics/MethodLength, Metrics/AbcSize
+      def work_forever
+        while (msg = queue.pop)
+          info '<' * (queue.length + 1)
+          case msg
+          when StopMessage
+            stop
+          else
+            process msg
+          end
+
+          next unless stopping?
+
+          debug 'Stopping worker -- %s', self
+          @connection.flush
+          break
+        end
+      rescue Exception => e
+        warn 'Worker died with exception: %s', e.inspect
+        debug e.backtrace.join("\n")
+      end
+      # rubocop:enable Metrics/MethodLength, Metrics/AbcSize
+
+      private
+
+      def process(resource)
+        serialized = serializers.serialize(resource)
+        @filters.apply!(serialized)
+        @connection.write(serialized.to_json)
+      end
+    end
+  end
+end

--- a/spec/.jenkins_ruby.yml
+++ b/spec/.jenkins_ruby.yml
@@ -1,6 +1,5 @@
 RUBY_VERSION:
-  - ruby-2.5.1
-  - ruby-2.5.0
+  - ruby-2.5
   - ruby-2.4
   - ruby-2.3
   - jruby-9.1

--- a/spec/elastic_apm/error_builder_spec.rb
+++ b/spec/elastic_apm/error_builder_spec.rb
@@ -15,7 +15,7 @@ module ElasticAPM
         expect(error.exception.handled).to be true
       end
 
-      it 'inherits context from current transaction', :mock_intake do
+      it 'inherits context from current transaction', :intercept do
         env = Rack::MockRequest.env_for(
           '/somewhere/in/there?q=yes',
           method: 'POST'
@@ -31,11 +31,9 @@ module ElasticAPM
 
         ElasticAPM.stop
 
-        wait_for_requests_to_finish 1
-
-        error_payload = @mock_intake.errors.last
-        request = error_payload.dig('context', 'request')
-        expect(request['method']).to eq 'POST'
+        error = @intercepted.errors.last
+        request = error.context.request
+        expect(request.method).to eq 'POST'
       end
     end
 

--- a/spec/elastic_apm/spies/sidekiq_spec.rb
+++ b/spec/elastic_apm/spies/sidekiq_spec.rb
@@ -54,7 +54,7 @@ module ElasticAPM
 
       expect(ElasticAPM.agent).to_not be_nil
 
-      manager.stop(Time.now)
+      manager.stop(::Process.clock_gettime(::Process::CLOCK_MONOTONIC))
 
       expect(ElasticAPM.agent).to be_nil
       expect(manager).to be_stopped

--- a/spec/elastic_apm/transport/connection_spec.rb
+++ b/spec/elastic_apm/transport/connection_spec.rb
@@ -19,7 +19,7 @@ module ElasticAPM
           subject.write('{"msg": "hey!"}')
           expect(subject).to be_connected
 
-          subject.close!
+          subject.flush
           expect(subject).to_not be_connected
 
           expect(stub).to have_been_requested
@@ -34,7 +34,7 @@ module ElasticAPM
           stub = build_stub(to_return: { status: 500, body: errors.to_json })
 
           subject.write('{}')
-          subject.close!
+          subject.flush
 
           expect(stub).to have_been_requested.once
         end
@@ -58,7 +58,7 @@ module ElasticAPM
           build_stub
 
           subject.write('{}')
-          subject.close!
+          subject.flush
 
           expect(subject).to_not be_connected
 
@@ -91,7 +91,7 @@ module ElasticAPM
           build_stub
 
           subject.write('{}')
-          subject.close!
+          subject.flush
 
           expect(subject).to_not be_connected
 
@@ -136,25 +136,9 @@ module ElasticAPM
           end
 
           subject.write('{}')
-          subject.close!
+          subject.flush
 
           expect(stub).to have_been_requested
-        end
-      end
-
-      context 'thread safety' do
-        let(:config) { Config.new http_compression: false }
-
-        it 'handles threads ok' do
-          stub = build_stub
-
-          (1..32).map do |i|
-            Thread.new { subject.write(%({"thread": #{i}})) }
-          end.each(&:join)
-
-          subject.close!
-
-          expect(stub).to have_been_requested.once
         end
       end
 

--- a/spec/elastic_apm/transport/filters_spec.rb
+++ b/spec/elastic_apm/transport/filters_spec.rb
@@ -25,10 +25,10 @@ module ElasticAPM
         end
       end
 
-      describe '#apply' do
+      describe '#apply!' do
         it 'applies all filters to payload' do
           subject.add(:purger, ->(_payload) { {} })
-          result = subject.apply(things: 1)
+          result = subject.apply!(things: 1)
           expect(result).to eq({})
         end
 
@@ -38,7 +38,7 @@ module ElasticAPM
           subject.add(:niller, ->(_payload) { nil })
           subject.add(:untouched, untouched)
 
-          result = subject.apply(things: 1)
+          result = subject.apply!(things: 1)
 
           expect(result).to be_nil
           expect(untouched).to_not have_received(:call)

--- a/spec/elastic_apm/transport/serializers_spec.rb
+++ b/spec/elastic_apm/transport/serializers_spec.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+module ElasticAPM
+  module Transport
+    RSpec.describe Serializers do
+      subject { described_class.new(Config.new) }
+
+      it 'initializes with config' do
+        expect(subject).to be_a Serializers::Container
+        expect(subject.transaction).to be_a Serializers::TransactionSerializer
+        expect(subject.span).to be_a Serializers::SpanSerializer
+        expect(subject.error).to be_a Serializers::ErrorSerializer
+      end
+
+      describe '#serialize' do
+        it 'serializes known objects' do
+          expect(subject.serialize(Transaction.new)).to be_a Hash
+          expect(subject.serialize(Span.new('Name'))).to be_a Hash
+          expect(subject.serialize(Error.new)).to be_a Hash
+        end
+
+        it 'explodes on unknown objects' do
+          expect { subject.serialize(Object.new) }
+            .to raise_error(Serializers::UnrecognizedResource)
+        end
+      end
+    end
+  end
+end

--- a/spec/elastic_apm/transport/worker_spec.rb
+++ b/spec/elastic_apm/transport/worker_spec.rb
@@ -1,0 +1,72 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+module ElasticAPM
+  module Transport
+    RSpec.describe Worker do
+      let(:config) { Config.new }
+      let(:queue) { Queue.new }
+      let(:serializers) { Serializers.new config }
+      let(:filters) { Filters.new config }
+      subject do
+        described_class.new(
+          config,
+          queue,
+          serializers: serializers,
+          filters: filters
+        )
+      end
+
+      describe '#initialize' do
+        its(:filters) { should be_a Filters::Container }
+        its(:serializers) { should be_a Serializers::Container }
+        its(:connection) { should be_a Connection }
+      end
+
+      describe '#work_forever' do
+        class MockConnection
+          def initialize(*_args)
+            @calls = []
+          end
+
+          attr_reader :calls
+
+          def write(*args)
+            calls << args
+          end
+
+          def flush; end
+        end
+
+        subject do
+          described_class.new(
+            config,
+            queue,
+            serializers: serializers,
+            filters: filters,
+            conn_adapter: MockConnection
+          )
+        end
+
+        it 'applies filters, writes resources to the connection' do
+          expect(subject.filters).to receive(:apply!)
+
+          queue.push Transaction.new
+          Thread.new { subject.work_forever }.join 0.1
+
+          expect(subject.connection.calls.length).to be 1
+        end
+
+        it 'can be stopped with a message' do
+          expect(subject.connection).to receive(:flush)
+
+          thread = Thread.new { subject.work_forever }
+          queue.push Worker::StopMessage.new
+
+          Timeout.timeout(1) { loop while thread.alive? }
+        end
+      end
+    end
+  end
+end

--- a/spec/elastic_apm_spec.rb
+++ b/spec/elastic_apm_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe ElasticAPM do
       end
     end
 
-    describe '.end_transaction', :mock_intake do
+    describe '.end_transaction', :intercept do
       it 'ends current transaction' do
         transaction = ElasticAPM.start_transaction 'Test'
         expect(ElasticAPM.current_transaction).to_not be_nil
@@ -35,10 +35,8 @@ RSpec.describe ElasticAPM do
         expect(ElasticAPM.current_transaction).to be_nil
         expect(transaction).to be_stopped
 
-        ElasticAPM.flush
-
-        transaction = @mock_intake.transactions.first
-        expect(transaction['name']).to eq 'Test'
+        transaction, = @intercepted.transactions
+        expect(transaction.name).to eq 'Test'
       end
     end
 

--- a/spec/scripts/cleanup.sh
+++ b/spec/scripts/cleanup.sh
@@ -1,6 +1,9 @@
 #!/usr/bin/env bash
 set -x
 
+echo "Cleanup no longer needed"
+exit 0
+
 docker stop $(docker ps -a -q)
 docker rm -v $(docker ps -q -a)
 docker volume prune -f

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-ENV['APM_TESTING'] = '1'
 ENV['RAILS_ENV'] = ENV['RACK_ENV'] = 'test'
 ENV['ELASTIC_APM_ENABLED_ENVIRONMENTS'] = 'test'
 
@@ -13,11 +12,9 @@ WebMock.hide_stubbing_instructions!
 
 Dir['spec/support/*.rb'].each { |file| require "./#{file}" }
 
-require 'concurrent'
-Concurrent.use_stdlib_logger(Logger::DEBUG)
-
 require 'elastic-apm'
 
+Concurrent.use_stdlib_logger(Logger::DEBUG)
 Thread.abort_on_exception = true
 
 RSpec.configure do |config|
@@ -25,11 +22,8 @@ RSpec.configure do |config|
     config.filter_run_excluding(type: 'json_schema')
   end
 
-  # config.fail_fast = true unless ENV['CI']
-
   config.example_status_persistence_file_path = '.rspec_status'
   config.disable_monkey_patching!
-  # config.backtrace_exclusion_patterns = [%r{/(gems|bundler)/}]
 
   config.expect_with :rspec do |c|
     c.syntax = :expect

--- a/spec/support/mock_intake.rb
+++ b/spec/support/mock_intake.rb
@@ -30,12 +30,9 @@ class Intake
     [202, {}, ['ok']]
   end
 
-  # rubocop:disable Metrics/MethodLength
   def parse_request_body(request)
-    encoding = request.env['HTTP_CONTENT_ENCODING']
-
     body =
-      if encoding =~ /gzip/
+      if request.env['HTTP_CONTENT_ENCODING'] =~ /gzip/
         gunzip(request.body.read)
       else
         request.body.read
@@ -43,11 +40,8 @@ class Intake
 
     body
       .split("\n")
-      .map do |json|
-        JSON.parse(json)
-      end
+      .map { |json| JSON.parse(json) }
   end
-  # rubocop:enable Metrics/MethodLength
 
   private
 
@@ -85,29 +79,45 @@ RSpec.configure do |config|
   end
 
   # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
-  def wait_for_requests_to_finish(request_count)
+  def wait_for(expected)
     raise 'No request stub – did you forget :mock_intake?' unless @request_stub
 
     Timeout.timeout(5) do
       loop do
-        missing = request_count - @mock_intake.requests.length
+        sleep 0.01
+
+        missing = expected.reduce(0) do |total, (kind, count)|
+          total + (count - @mock_intake.send(kind).length)
+        end
+
         next if missing > 0
 
         unless missing == 0
           puts format(
-            'Expected %d requests. Got %d',
-            request_count,
-            @mock_intake.requests.length
+            'Expected %s. Got %s',
+            expected,
+            missing
           )
+          print_received
         end
 
         break true
       end
     end
   rescue Timeout::Error
-    puts format('Died waiting for %d requests', request_count)
-    puts "--- Received: ---\n#{@mock_intake.requests.inspect}"
+    puts format('Died waiting for %s', expected)
+    puts '--- Received: ---'
+    print_received
     raise
   end
   # rubocop:enable Metrics/AbcSize, Metrics/MethodLength
+
+  def print_received
+    pp(
+      transactions: @mock_intake.transactions.map { |o| o['name'] },
+      spans: @mock_intake.spans.map { |o| o['name'] },
+      errors: @mock_intake.errors.map { |o| o['culprit'] },
+      metadatas: @mock_intake.metadatas.count
+    )
+  end
 end


### PR DESCRIPTION
This adds a worker running in a separate thread that has 2 responsibilites:

1. Serialize objects off the main thread
2. Serve the resulting payloads to the Connection

**NB**: Haven't tested this in a real app yet. Doing that now.

---

- [x] Re-add filters
- [x] Pull synchronize as much as possible from `Connection`
- [ ] Docs