### PR TITLE
Loosen concurrent-ruby version dependency

### DIFF
--- a/elastic-apm.gemspec
+++ b/elastic-apm.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
     f.match(%r{^(test|spec|features)/})
   end
 
-  spec.add_dependency('concurrent-ruby', '~> 1.0.0')
+  spec.add_dependency('concurrent-ruby', '~> 1.0')
 
   spec.require_paths = ['lib']
 end


### PR DESCRIPTION
Since the release of concurrent-ruby 1.1.x last week, bundler has been insisting on downgrading elastic-apm to 0.7.4 in a rails project I am working. 

Bundler seems to prefer a newer concurrent-ruby to a newer elastic-apm unless I force an elastic-apm version constraint. Loosening elastic-apm's constraint to 1.x should fix this and allow the latest of both gems.

Since elastic-apm only seems to have a very light dependency on concurrent-ruby for the timer task, I think loosening the requirement should be safe. Alternatively, the version constraint could be updated to 1.1.x.