### PR TITLE
Lazy boot transport workers

### DIFF
--- a/lib/elastic_apm/transport/base.rb
+++ b/lib/elastic_apm/transport/base.rb
@@ -25,7 +25,6 @@ module ElasticAPM
       attr_reader :config, :queue, :workers, :filters
 
       def start
-        ensure_worker_count
       end
 
       def stop

--- a/spec/elastic_apm/transport/base_spec.rb
+++ b/spec/elastic_apm/transport/base_spec.rb
@@ -14,20 +14,14 @@ module ElasticAPM
       end
 
       describe '#start' do
-        let(:config) { Config.new(pool_size: 2) }
-
-        it 'boots workers' do
-          subject.start
-          expect(subject.workers.length).to be 2
-          subject.stop
-        end
       end
 
       describe '#stop' do
         let(:config) { Config.new(pool_size: 2) }
 
-        xit 'stops all workers' do
+        it 'stops all workers' do
           subject.start
+          subject.submit Transaction.new
           subject.stop
           expect(subject.workers.length).to be 0
         end


### PR DESCRIPTION
Puma with `preload_app!` enabled will boot workers before booting its threads leaving the the threads out of reach of each other.

Fixes elastic/apm-agent-ruby#237 