### PR TITLE
Truncate keyword fields to maximum 1024 chars

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 
 ### Fixed
 
+- Truncate keyword fields to 1024 chars ([#240](https://github.com/elastic/apm-agent-ruby/pull/240))
 - Lazy boot worker threads on first event. Fixes apps using Puma's `preload_app!` ([#239](https://github.com/elastic/apm-agent-ruby/pull/239))
 
 ## 2.0.1 (2018-11-15)

--- a/lib/elastic_apm/agent.rb
+++ b/lib/elastic_apm/agent.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require 'elastic_apm/naively_hashable'
 require 'elastic_apm/context_builder'
 require 'elastic_apm/error_builder'
 require 'elastic_apm/stacktrace_builder'

--- a/lib/elastic_apm/context.rb
+++ b/lib/elastic_apm/context.rb
@@ -9,8 +9,6 @@ require 'elastic_apm/context/user'
 module ElasticAPM
   # @api private
   class Context
-    include NaivelyHashable
-
     attr_accessor :request, :response, :user
     attr_reader :custom, :tags
 

--- a/lib/elastic_apm/context/request.rb
+++ b/lib/elastic_apm/context/request.rb
@@ -4,8 +4,6 @@ module ElasticAPM
   class Context
     # @api private
     class Request
-      include NaivelyHashable
-
       attr_accessor :body, :cookies, :env, :headers, :http_version, :method,
         :socket, :url
     end

--- a/lib/elastic_apm/context/request/socket.rb
+++ b/lib/elastic_apm/context/request/socket.rb
@@ -7,8 +7,6 @@ module ElasticAPM
     class Request
       # @api private
       class Socket
-        include NaivelyHashable
-
         def initialize(req)
           @remote_addr = req.ip
           @encrypted = req.scheme == 'https'

--- a/lib/elastic_apm/context/request/url.rb
+++ b/lib/elastic_apm/context/request/url.rb
@@ -7,8 +7,6 @@ module ElasticAPM
     class Request
       # @api private
       class Url
-        include NaivelyHashable
-
         SKIPPED_PORTS = {
           'http' => 80,
           'https' => 443

--- a/lib/elastic_apm/context/response.rb
+++ b/lib/elastic_apm/context/response.rb
@@ -4,8 +4,6 @@ module ElasticAPM
   class Context
     # @api private
     class Response
-      include NaivelyHashable
-
       def initialize(
         status_code,
         headers: {},

--- a/lib/elastic_apm/context/user.rb
+++ b/lib/elastic_apm/context/user.rb
@@ -4,12 +4,10 @@ module ElasticAPM
   class Context
     # @api private
     class User
-      include NaivelyHashable
-
       def initialize(config, record)
         return unless record
 
-        @id = safe_get(record, config.current_user_id_method)
+        @id = safe_get(record, config.current_user_id_method)&.to_s
         @email = safe_get(record, config.current_user_email_method)
         @username = safe_get(record, config.current_user_username_method)
       end

--- a/lib/elastic_apm/context_builder.rb
+++ b/lib/elastic_apm/context_builder.rb
@@ -21,10 +21,10 @@ module ElasticAPM
       context.request = Context::Request.new unless context.request
       request = context.request
 
-      request.socket = Context::Request::Socket.new(req).to_h
+      request.socket = Context::Request::Socket.new(req)
       request.http_version = build_http_version rack_env
       request.method = req.request_method
-      request.url = Context::Request::Url.new(req).to_h
+      request.url = Context::Request::Url.new(req)
       request.headers, request.env = get_headers_and_env(rack_env)
       request.body = get_body(req)
 

--- a/lib/elastic_apm/metadata.rb
+++ b/lib/elastic_apm/metadata.rb
@@ -1,20 +1,18 @@
 # frozen_string_literal: true
 
+module ElasticAPM
+  # @api private
+  class Metadata
+    def initialize(config)
+      @service = ServiceInfo.new(config)
+      @process = ProcessInfo.new(config)
+      @system = SystemInfo.new(config)
+    end
+
+    attr_reader :service, :process, :system
+  end
+end
+
 require 'elastic_apm/metadata/service_info'
 require 'elastic_apm/metadata/system_info'
 require 'elastic_apm/metadata/process_info'
-
-module ElasticAPM
-  # @api private
-  module Metadata
-    def self.build(config)
-      {
-        metadata: {
-          service: Metadata::ServiceInfo.build(config),
-          process: Metadata::ProcessInfo.build(config),
-          system: Metadata::SystemInfo.build(config)
-        }
-      }.to_json
-    end
-  end
-end

--- a/lib/elastic_apm/metadata/process_info.rb
+++ b/lib/elastic_apm/metadata/process_info.rb
@@ -1,26 +1,18 @@
 # frozen_string_literal: true
 
 module ElasticAPM
-  module Metadata
+  class Metadata
     # @api private
     class ProcessInfo
       def initialize(config)
         @config = config
+
+        @argv = ARGV
+        @pid = $PID || Process.pid
+        @title = $PROGRAM_NAME
       end
 
-      def build
-        pid = $PID || Process.pid
-        return unless pid
-        {
-          argv: ARGV,
-          pid: pid,
-          title: $PROGRAM_NAME
-        }
-      end
-
-      def self.build(config)
-        new(config).build
-      end
+      attr_reader :argv, :pid, :title
     end
   end
 end

--- a/lib/elastic_apm/metadata/service_info.rb
+++ b/lib/elastic_apm/metadata/service_info.rb
@@ -1,56 +1,61 @@
 # frozen_string_literal: true
 
 module ElasticAPM
-  module Metadata
+  class Metadata
     # @api private
     class ServiceInfo
-      def initialize(config)
-        @config = config
-      end
-
-      # rubocop:disable Metrics/MethodLength
-      def build
-        base = {
-          name: @config.service_name,
-          environment: @config.environment,
-          agent: {
-            name: 'ruby',
-            version: VERSION
-          },
-          framework: nil,
-          language: {
-            name: 'ruby',
-            version: RUBY_VERSION
-          },
-          runtime: runtime,
-          version: @config.service_version || Util.git_sha
-        }
-
-        if @config.framework_name
-          base[:framework] = {
-            name: @config.framework_name,
-            version: @config.framework_version
-          }
+      # @api private
+      class Versioned
+        def initialize(name: nil, version: nil)
+          @name = name
+          @version = version
         end
 
-        base
+        attr_reader :name, :version
+      end
+      class Agent < Versioned; end
+      class Framework < Versioned; end
+      class Language < Versioned; end
+      class Runtime < Versioned; end
+
+      # rubocop:disable Metrics/MethodLength
+      def initialize(config)
+        @config = config
+
+        @name = @config.service_name
+        @environment = @config.environment
+        @agent = Agent.new(name: 'ruby', version: VERSION)
+        @framework = Framework.new(
+          name: @config.framework_name,
+          version: @config.framework_version
+        )
+        @language = Language.new(name: 'ruby', version: RUBY_VERSION)
+        @runtime = lookup_runtime
+        @version = @config.service_version || Util.git_sha
       end
       # rubocop:enable Metrics/MethodLength
 
-      def self.build(config)
-        new(config).build
-      end
+      attr_reader :name, :environment, :agent, :framework, :language, :runtime,
+        :version
 
       private
 
-      def runtime
+      # rubocop:disable Metrics/MethodLength
+      def lookup_runtime
         case RUBY_ENGINE
         when 'ruby'
-          { name: RUBY_ENGINE, version: RUBY_VERSION || RUBY_ENGINE_VERSION }
+          Runtime.new(
+            name: RUBY_ENGINE,
+            version: RUBY_VERSION || RUBY_ENGINE_VERSION
+          )
         when 'jruby'
-          { name: RUBY_ENGINE, version: JRUBY_VERSION || RUBY_ENGINE_VERSION }
+          Runtime.new(
+            name: RUBY_ENGINE,
+            version: JRUBY_VERSION || RUBY_ENGINE_VERSION
+          )
         end
       end
+      # rubocop:enable Metrics/MethodLength
     end
   end
 end

--- a/lib/elastic_apm/metadata/system_info.rb
+++ b/lib/elastic_apm/metadata/system_info.rb
@@ -1,29 +1,23 @@
 # frozen_string_literal: true
 
 module ElasticAPM
-  module Metadata
+  class Metadata
     # @api private
     class SystemInfo
       def initialize(config)
         @config = config
+
+        @hostname = @config.hostname || `hostname`.chomp
+        @architecture = gem_platform.cpu
+        @platform = gem_platform.os
       end
 
-      def build
-        {
-          hostname: @config.hostname || `hostname`.chomp,
-          architecture: platform.cpu,
-          platform: platform.os
-        }
-      end
-
-      def self.build(config)
-        new(config).build
-      end
+      attr_reader :hostname, :architecture, :platform
 
       private
 
-      def platform
-        @platform ||= Gem::Platform.local
+      def gem_platform
+        @gem_platform ||= Gem::Platform.local
       end
     end
   end

--- a/lib/elastic_apm/span/context.rb
+++ b/lib/elastic_apm/span/context.rb
@@ -4,8 +4,6 @@ module ElasticAPM
   class Span
     # @api private
     class Context
-      include NaivelyHashable
-
       def initialize(db: nil, http: nil)
         @db = db && Db.new(db)
         @http = http && Http.new(http)
@@ -15,8 +13,6 @@ module ElasticAPM
 
       # @api private
       class Db
-        include NaivelyHashable
-
         def initialize(instance: nil, statement: nil, type: nil, user: nil)
           @instance = instance
           @statement = statement
@@ -29,8 +25,6 @@ module ElasticAPM
 
       # @api private
       class Http
-        include NaivelyHashable
-
         def initialize(url: nil, status_code: nil, method: nil)
           @url = url
           @status_code = status_code

--- a/lib/elastic_apm/stacktrace/frame.rb
+++ b/lib/elastic_apm/stacktrace/frame.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'elastic_apm/naively_hashable'
+
 module ElasticAPM
   class Stacktrace
     # @api private

--- a/lib/elastic_apm/transport/base.rb
+++ b/lib/elastic_apm/transport/base.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
+require 'elastic_apm/metadata'
 require 'elastic_apm/transport/connection'
 require 'elastic_apm/transport/worker'
-
 require 'elastic_apm/transport/serializers'
 require 'elastic_apm/transport/filters'
 

--- a/lib/elastic_apm/transport/connection.rb
+++ b/lib/elastic_apm/transport/connection.rb
@@ -4,8 +4,6 @@ require 'http'
 require 'concurrent'
 require 'zlib'
 
-require 'elastic_apm/metadata'
-
 module ElasticAPM
   module Transport
     # @api private
@@ -30,8 +28,9 @@ module ElasticAPM
       }.freeze
       GZIP_HEADERS = HEADERS.merge('Content-Encoding' => 'gzip').freeze
 
-      def initialize(config)
+      def initialize(config, metadata)
         @config = config
+        @metadata = metadata.to_json
 
         @url = config.server_url + '/intake/v2/events'
 
@@ -43,8 +42,6 @@ module ElasticAPM
         end
 
         @client = HTTP.headers(headers).persistent(@url)
-
-        @metadata = Metadata.build(config)
 
         @mutex = Mutex.new
       end

--- a/lib/elastic_apm/transport/serializers.rb
+++ b/lib/elastic_apm/transport/serializers.rb
@@ -15,10 +15,22 @@ module ElasticAPM
           @config = config
         end
 
+        attr_reader :config
+
         private
 
         def ms(micros)
           micros.to_f / 1_000
+        end
+
+        def keyword_field(value)
+          Util.truncate(value)
+        end
+
+        def keyword_object(hash)
+          hash.tap do |h|
+            h.each { |k, v| hash[k] = keyword_field(v) }
+          end
         end
       end
 
@@ -28,10 +40,12 @@ module ElasticAPM
           @transaction = Serializers::TransactionSerializer.new(config)
           @span = Serializers::SpanSerializer.new(config)
           @error = Serializers::ErrorSerializer.new(config)
+          @metadata = Serializers::MetadataSerializer.new(config)
         end
 
-        attr_reader :transaction, :span, :error
+        attr_reader :transaction, :span, :error, :metadata
 
+        # rubocop:disable Metrics/MethodLength
         def serialize(resource)
           case resource
           when Transaction
@@ -40,10 +54,13 @@ module ElasticAPM
             span.build(resource)
           when Error
             error.build(resource)
+          when Metadata
+            metadata.build(resource)
           else
             raise UnrecognizedResource, resource.inspect
           end
         end
+        # rubocop:enable Metrics/MethodLength
       end
 
       def self.new(config)
@@ -53,6 +70,8 @@ module ElasticAPM
   end
 end
 
-require 'elastic_apm/transport/serializers/transaction_serializer'
-require 'elastic_apm/transport/serializers/span_serializer'
+require 'elastic_apm/transport/serializers/context_serializer'
 require 'elastic_apm/transport/serializers/error_serializer'
+require 'elastic_apm/transport/serializers/metadata_serializer'
+require 'elastic_apm/transport/serializers/span_serializer'
+require 'elastic_apm/transport/serializers/transaction_serializer'

--- a/lib/elastic_apm/transport/serializers/context_serializer.rb
+++ b/lib/elastic_apm/transport/serializers/context_serializer.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+
+module ElasticAPM
+  module Transport
+    module Serializers
+      # @api private
+      class ContextSerializer < Serializer
+        def build(context)
+          {
+            custom: context.custom,
+            tags: keyword_object(context.tags),
+            request: build_request(context.request),
+            response: build_response(context.response),
+            user: build_user(context.user)
+          }
+        end
+
+        private
+
+        # rubocop:disable Metrics/MethodLength
+        def build_request(request)
+          return unless request
+
+          {
+            body: request.body,
+            cookies: request.cookies,
+            env: request.env,
+            headers: request.headers,
+            http_version: keyword_field(request.http_version),
+            method: keyword_field(request.method),
+            socket: build_socket(request.socket),
+            url: request.url
+          }
+        end
+        # rubocop:enable Metrics/MethodLength
+
+        def build_response(response)
+          return unless response
+
+          {
+            status_code: response.status_code,
+            headers: response.headers,
+            headers_sent: response.headers_sent,
+            finished: response.finished
+          }
+        end
+
+        def build_user(user)
+          return unless user
+
+          {
+            id: keyword_field(user.id),
+            email: keyword_field(user.email),
+            username: keyword_field(user.username)
+          }
+        end
+
+        def build_socket(socket)
+          return unless socket
+
+          {
+            remote_addr: socket.remote_addr,
+            encrypted: socket.encrypted
+          }
+        end
+      end
+    end
+  end
+end

--- a/lib/elastic_apm/transport/serializers/error_serializer.rb
+++ b/lib/elastic_apm/transport/serializers/error_serializer.rb
@@ -5,6 +5,10 @@ module ElasticAPM
     module Serializers
       # @api private
       class ErrorSerializer < Serializer
+        def context_serializer
+          @context_serializer ||= ContextSerializer.new(config)
+        end
+
         # rubocop:disable Metrics/MethodLength
         def build(error)
           base = {
@@ -15,7 +19,7 @@ module ElasticAPM
 
             culprit: error.culprit,
             timestamp: error.timestamp,
-            context: error.context.to_h
+            context: context_serializer.build(error.context)
           }
 
           if (exception = error.exception)
@@ -35,9 +39,9 @@ module ElasticAPM
         def build_exception(exception)
           {
             message: exception.message,
-            type: exception.type,
-            module: exception.module,
-            code: exception.code,
+            type: keyword_field(exception.type),
+            module: keyword_field(exception.module),
+            code: keyword_field(exception.code),
             attributes: exception.attributes,
             stacktrace: exception.stacktrace.to_a,
             handled: exception.handled
@@ -47,9 +51,9 @@ module ElasticAPM
         def build_log(log)
           {
             message: log.message,
-            level: log.level,
-            logger_name: log.logger_name,
-            param_message: log.param_message,
+            level: keyword_field(log.level),
+            logger_name: keyword_field(log.logger_name),
+            param_message: keyword_field(log.param_message),
             stacktrace: log.stacktrace.to_a
           }
         end

--- a/lib/elastic_apm/transport/serializers/metadata_serializer.rb
+++ b/lib/elastic_apm/transport/serializers/metadata_serializer.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+module ElasticAPM
+  module Transport
+    module Serializers
+      # @api private
+      class MetadataSerializer < Serializer
+        def build(metadata)
+          {
+            metadata: {
+              service: build_service(metadata.service),
+              process: build_process(metadata.process),
+              system: build_system(metadata.system)
+            }
+          }
+        end
+
+        private
+
+        # rubocop:disable Metrics/MethodLength, Metrics/AbcSize
+        def build_service(service)
+          {
+            name: keyword_field(service.name),
+            environment: keyword_field(service.environment),
+            version: keyword_field(service.version),
+            agent: {
+              name: keyword_field(service.agent.name),
+              version: keyword_field(service.agent.version)
+            },
+            framework: {
+              name: keyword_field(service.framework.name),
+              version: keyword_field(service.framework.version)
+            },
+            language: {
+              name: keyword_field(service.language.name),
+              version: keyword_field(service.language.version)
+            },
+            runtime: {
+              name: keyword_field(service.runtime.name),
+              version: keyword_field(service.runtime.version)
+            }
+          }
+        end
+        # rubocop:enable Metrics/MethodLength, Metrics/AbcSize
+
+        def build_process(process)
+          {
+            pid: process.pid,
+            title: keyword_field(process.title),
+            argv: process.argv
+          }
+        end
+
+        def build_system(system)
+          {
+            hostname: keyword_field(system.hostname),
+            architecture: keyword_field(system.architecture),
+            platform: keyword_field(system.platform)
+          }
+        end
+      end
+    end
+  end
+end

--- a/lib/elastic_apm/transport/serializers/span_serializer.rb
+++ b/lib/elastic_apm/transport/serializers/span_serializer.rb
@@ -5,24 +5,68 @@ module ElasticAPM
     module Serializers
       # @api private
       class SpanSerializer < Serializer
-        # rubocop:disable Metrics/MethodLength
+        def initialize(config)
+          super
+
+          @context_serializer = ContextSerializer.new(config)
+        end
+
+        attr_reader :context_serializer
+
+        # rubocop:disable Metrics/MethodLength, Metrics/AbcSize
         def build(span)
           {
             span: {
               id: span.id,
               transaction_id: span.transaction_id,
               parent_id: span.parent_id,
-              name: span.name,
-              type: span.type,
+              name: keyword_field(span.name),
+              type: keyword_field(span.type),
               duration: ms(span.duration),
-              context: span.context&.to_h,
+              context: context_serializer.build(span.context),
               stacktrace: span.stacktrace.to_a,
               timestamp: span.timestamp,
               trace_id: span.trace_id
             }
           }
         end
-        # rubocop:enable Metrics/MethodLength
+        # rubocop:enable Metrics/MethodLength, Metrics/AbcSize
+
+        # @api private
+        class ContextSerializer < Serializer
+          def build(context)
+            return unless context
+
+            {
+              sync: context.sync,
+              db: build_db(context.db),
+              http: build_http(context.http)
+            }
+          end
+
+          private
+
+          def build_db(db)
+            return unless db
+
+            {
+              instance: db.instance,
+              statement: db.statement,
+              type: db.type,
+              user: db.user
+            }
+          end
+
+          def build_http(http)
+            return unless http
+
+            {
+              url: http.url,
+              status_code: http.status_code,
+              method: keyword_field(http.method)
+            }
+          end
+        end
       end
     end
   end

--- a/lib/elastic_apm/transport/serializers/transaction_serializer.rb
+++ b/lib/elastic_apm/transport/serializers/transaction_serializer.rb
@@ -5,20 +5,24 @@ module ElasticAPM
     module Serializers
       # @api private
       class TransactionSerializer < Serializer
-        # rubocop:disable Metrics/MethodLength
+        def context_serializer
+          @context_serializer ||= ContextSerializer.new(config)
+        end
+
+        # rubocop:disable Metrics/MethodLength, Metrics/AbcSize
         def build(transaction)
           {
             transaction: {
               id: transaction.id,
               trace_id: transaction.trace_id,
               parent_id: transaction.parent_id,
-              name: transaction.name,
-              type: transaction.type,
-              result: transaction.result.to_s,
+              name: keyword_field(transaction.name),
+              type: keyword_field(transaction.type),
+              result: keyword_field(transaction.result.to_s),
               duration: ms(transaction.duration),
               timestamp: transaction.timestamp,
               sampled: transaction.sampled?,
-              context: transaction.context.to_h,
+              context: context_serializer.build(transaction.context),
               span_count: {
                 started: transaction.started_spans,
                 dropped: transaction.dropped_spans
@@ -26,7 +30,7 @@ module ElasticAPM
             }
           }
         end
-        # rubocop:enable Metrics/MethodLength
+        # rubocop:enable Metrics/MethodLength, Metrics/AbcSize
       end
     end
   end

--- a/lib/elastic_apm/transport/worker.rb
+++ b/lib/elastic_apm/transport/worker.rb
@@ -24,9 +24,11 @@ module ElasticAPM
 
         @stopping = false
 
-        @connection = conn_adapter.new(config)
         @serializers = serializers
         @filters = filters
+
+        metadata = serializers.serialize(Metadata.new(config))
+        @connection = conn_adapter.new(config, metadata)
       end
 
       attr_reader :queue, :filters, :name, :connection, :serializers
@@ -39,7 +41,7 @@ module ElasticAPM
         @stopping
       end
 
-      # rubocop:disable Metrics/MethodLength, Metrics/AbcSize
+      # rubocop:disable Metrics/MethodLength
       def work_forever
         while (msg = queue.pop)
           case msg
@@ -59,7 +61,7 @@ module ElasticAPM
         warn 'Worker died with exception: %s', e.inspect
         debug e.backtrace.join("\n")
       end
-      # rubocop:enable Metrics/MethodLength, Metrics/AbcSize
+      # rubocop:enable Metrics/MethodLength
 
       private
 

--- a/lib/elastic_apm/util.rb
+++ b/lib/elastic_apm/util.rb
@@ -24,5 +24,12 @@ module ElasticAPM
     def self.reverse_merge!(first, second)
       first.merge!(second) { |_, old, _| old }
     end
+
+    def self.truncate(value, max_length: 1024)
+      return unless value
+      return value if value.length <= max_length
+
+      value[0...(max_length - 1)] + '…'
+    end
   end
 end

--- a/spec/elastic_apm/context/user_spec.rb
+++ b/spec/elastic_apm/context/user_spec.rb
@@ -4,20 +4,20 @@ module ElasticAPM
   RSpec.describe Context::User do
     it 'sets values from passed object' do
       PossiblyUser = Struct.new(:id, :email, :username)
-      record = PossiblyUser.new(1, 'a@a', 'monkeyface')
+      record = PossiblyUser.new(1, 'a@a', 'abe')
 
       user = described_class.new(Config.new, record)
-      expect(user.to_h).to eq(
-        id: 1,
-        email: 'a@a',
-        username: 'monkeyface'
-      )
+      expect(user.id).to eq '1'
+      expect(user.email).to eq 'a@a'
+      expect(user.username).to eq 'abe'
     end
 
     it "doesn't explode with missing methods" do
       expect do
         user = described_class.new(Config.new, Object.new)
-        expect(user.to_h).to eq(id: nil, email: nil, username: nil)
+        expect(user.id).to be_nil
+        expect(user.email).to be_nil
+        expect(user.username).to be_nil
       end.to_not raise_exception
     end
   end

--- a/spec/elastic_apm/context_builder_spec.rb
+++ b/spec/elastic_apm/context_builder_spec.rb
@@ -17,15 +17,16 @@ module ElasticAPM
 
         expect(request).to be_a(Context::Request)
         expect(request.method).to eq 'POST'
-        expect(request.url).to eq(
-          protocol: 'http',
-          hostname: 'example.org',
-          port: '80',
-          pathname: '/somewhere/in/there',
-          search: 'q=yes',
-          hash: nil,
-          full: 'http://example.org/somewhere/in/there?q=yes'
-        )
+
+        expect(request.url).to be_a Context::Request::Url
+        expect(request.url.protocol).to eq 'http'
+        expect(request.url.hostname).to eq 'example.org'
+        expect(request.url.port).to eq '80'
+        expect(request.url.pathname).to eq '/somewhere/in/there'
+        expect(request.url.search).to eq 'q=yes'
+        expect(request.url.hash).to eq nil
+        expect(request.url.full).to eq 'http://example.org/somewhere/in/there?q=yes'
+
         expect(request.headers).to eq(
           'Content-Type' => 'application/json'
         )

--- a/spec/elastic_apm/context_spec.rb
+++ b/spec/elastic_apm/context_spec.rb
@@ -6,11 +6,5 @@ module ElasticAPM
       expect(subject.tags).to eq({})
       expect(subject.custom).to eq({})
     end
-
-    describe '#to_h' do
-      it 'converts to a hash' do
-        expect(subject.to_h).to be_a Hash
-      end
-    end
   end
 end

--- a/spec/elastic_apm/instrumenter_spec.rb
+++ b/spec/elastic_apm/instrumenter_spec.rb
@@ -238,11 +238,10 @@ module ElasticAPM
         subject.set_user(User.new(1, 'a@a', 'abe'))
         subject.end_transaction
 
-        expect(transaction.context.user.to_h).to match(
-          id: 1,
-          email: 'a@a',
-          username: 'abe'
-        )
+        user = transaction.context.user
+        expect(user.id).to eq '1'
+        expect(user.email).to eq 'a@a'
+        expect(user.username).to eq 'abe'
       end
     end
   end

--- a/spec/elastic_apm/metadata/process_info_spec.rb
+++ b/spec/elastic_apm/metadata/process_info_spec.rb
@@ -1,20 +1,14 @@
 # frozen_string_literal: true
 
 module ElasticAPM
-  module Metadata
-    RSpec.describe ProcessInfo do
-      describe '#build' do
-        subject { described_class.new(Config.new).build }
+  RSpec.describe Metadata::ProcessInfo do
+    describe '#initialize' do
+      subject { described_class.new(Config.new) }
 
-        it { should be_a Hash }
-
-        it 'knows about the process' do
-          expect(subject).to match(
-            argv: Array,
-            pid: Integer,
-            title: /rspec/
-          )
-        end
+      it 'knows about the process' do
+        expect(subject.argv).to be_a Array
+        expect(subject.pid).to be_a Integer
+        expect(subject.title).to match(/rspec/)
       end
     end
   end

--- a/spec/elastic_apm/metadata/service_info_spec.rb
+++ b/spec/elastic_apm/metadata/service_info_spec.rb
@@ -3,26 +3,22 @@
 require 'spec_helper'
 
 module ElasticAPM
-  module Metadata
-    RSpec.describe ServiceInfo do
-      describe '#build' do
-        subject { described_class.new(Config.new).build }
+  RSpec.describe Metadata::ServiceInfo do
+    describe '#initialize' do
+      subject { described_class.new(Config.new) }
 
-        it { should be_a Hash }
+      it 'knows the runtime (mri)', unless: RSpec::Support::Ruby.jruby? do
+        expect(subject.runtime.name).to eq 'ruby'
+        expect(subject.runtime.version).to_not be_nil
+      end
 
-        it 'knows the runtime (mri)', unless: RSpec::Support::Ruby.jruby? do
-          expect(subject[:runtime][:name]).to eq 'ruby'
-          expect(subject[:runtime][:version]).to_not be_nil
-        end
+      it 'knows the runtime (JRuby)', if: RSpec::Support::Ruby.jruby? do
+        expect(subject.runtime.name).to eq 'jruby'
+        expect(subject.runtime.version).to_not be_nil
+      end
 
-        it 'knows the runtime (JRuby)', if: RSpec::Support::Ruby.jruby? do
-          expect(subject[:runtime][:name]).to eq 'jruby'
-          expect(subject[:runtime][:version]).to_not be_nil
-        end
-
-        it 'has a version from git' do
-          expect(subject[:version]).to match(/[a-z0-9]{16}/) # git sha
-        end
+      it 'has a version from git' do
+        expect(subject.version).to match(/[a-z0-9]{16}/) # git sha
       end
     end
   end

--- a/spec/elastic_apm/metadata/system_info_spec.rb
+++ b/spec/elastic_apm/metadata/system_info_spec.rb
@@ -1,23 +1,19 @@
 # frozen_string_literal: true
 
 module ElasticAPM
-  module Metadata
-    RSpec.describe SystemInfo do
-      describe '#build' do
-        subject { described_class.new(Config.new).build }
+  RSpec.describe Metadata::SystemInfo do
+    describe '#initialize' do
+      subject { described_class.new(Config.new) }
 
-        it { should be_a Hash }
-
-        it 'has values' do
-          %i[hostname architecture platform].each do |key|
-            expect(subject[key]).to_not be_nil
-          end
+      it 'has values' do
+        %i[hostname architecture platform].each do |key|
+          expect(subject.send(key)).to_not be_nil
         end
+      end
 
-        context 'hostname' do
-          it 'has no newline at the end' do
-            expect(subject[:hostname]).not_to match(/\n\z/)
-          end
+      context 'hostname' do
+        it 'has no newline at the end' do
+          expect(subject.hostname).not_to match(/\n\z/)
         end
       end
     end

--- a/spec/elastic_apm/spies/mongo_spec.rb
+++ b/spec/elastic_apm/spies/mongo_spec.rb
@@ -40,12 +40,12 @@ module ElasticAPM
       expect(span.name).to eq 'listCollections'
       expect(span.type).to eq 'db.mongodb.query'
       expect(span.duration).to_not be_nil
-      expect(span.context.db.to_h).to eq(
-        instance: 'elastic-apm-test',
-        type: 'mongodb',
-        statement: nil,
-        user: nil
-      )
+
+      db = span.context.db
+      expect(db.instance).to eq 'elastic-apm-test'
+      expect(db.type).to eq 'mongodb'
+      expect(db.statement).to be nil
+      expect(db.user).to be nil
 
       client.close
 

--- a/spec/elastic_apm/transport/connection_spec.rb
+++ b/spec/elastic_apm/transport/connection_spec.rb
@@ -6,7 +6,8 @@ module ElasticAPM
   module Transport
     RSpec.describe Connection do
       let(:config) { Config.new(http_compression: false) }
-      subject { described_class.new config }
+      let(:metadata) { Serializers.new(config).serialize(Metadata.new(config)) }
+      subject { described_class.new(config, metadata) }
 
       describe '#initialize' do
         it { should_not be_connected }
@@ -112,10 +113,9 @@ module ElasticAPM
 
         context 'and gzip off' do
           let(:config) { Config.new(http_compression: false) }
-          let(:metadata) { Metadata.build(config) }
 
           before do
-            config.api_request_size = metadata.bytesize + 1
+            config.api_request_size = metadata.to_json.bytesize + 1
           end
 
           it 'closes requests when reached' do

--- a/spec/elastic_apm/transport/serializers/error_serializer_spec.rb
+++ b/spec/elastic_apm/transport/serializers/error_serializer_spec.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'spec_helper'
+
 module ElasticAPM
   module Transport
     module Serializers
@@ -27,7 +29,13 @@ module ElasticAPM
                   id: String,
                   culprit: '/',
                   timestamp: 694_224_000_000_000,
-                  context: { custom: {}, tags: {} },
+                  context: {
+                    custom: {},
+                    tags: {},
+                    request: nil,
+                    response: nil,
+                    user: nil
+                  },
                   exception: {
                     message: 'ZeroDivisionError: divided by 0',
                     type: 'ZeroDivisionError',
@@ -65,7 +73,13 @@ module ElasticAPM
               expect(result).to match(
                 error: {
                   id: String,
-                  context: { custom: {}, tags: {} },
+                  context: {
+                    custom: {},
+                    tags: {},
+                    request: nil,
+                    response: nil,
+                    user: nil
+                  },
                   culprit: nil,
                   log: {
                     message: 'Things',

--- a/spec/elastic_apm/transport/serializers/metadata_serializer_spec.rb
+++ b/spec/elastic_apm/transport/serializers/metadata_serializer_spec.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+module ElasticAPM
+  module Transport
+    module Serializers
+      RSpec.describe MetadataSerializer do
+        subject { described_class.new Config.new }
+
+        describe '#build' do
+          let(:metadata) { Metadata.new Config.new }
+          let(:result) { subject.build(metadata) }
+
+          it 'is a bunch of hashes' do
+            expect(result[:metadata]).to be_a Hash
+            expect(result[:metadata][:service]).to be_a Hash
+            expect(result[:metadata][:process]).to be_a Hash
+            expect(result[:metadata][:system]).to be_a Hash
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/elastic_apm/transport/serializers/span_serializer_spec.rb
+++ b/spec/elastic_apm/transport/serializers/span_serializer_spec.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'spec_helper'
+
 module ElasticAPM
   module Transport
     module Serializers

--- a/spec/elastic_apm/transport/serializers/transaction_serializer_spec.rb
+++ b/spec/elastic_apm/transport/serializers/transaction_serializer_spec.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'spec_helper'
+
 module ElasticAPM
   module Transport
     module Serializers
@@ -33,7 +35,13 @@ module ElasticAPM
                   "name": 'GET /something',
                   "type": 'request',
                   "result": '200',
-                  "context": { custom: {}, tags: {} },
+                  "context": {
+                    custom: {},
+                    tags: {},
+                    request: nil,
+                    response: nil,
+                    user: nil
+                  },
                   "duration": 100.0,
                   "timestamp": 694_224_000_000_000,
                   "trace_id": transaction.trace_id,

--- a/spec/elastic_apm/transport/serializers_spec.rb
+++ b/spec/elastic_apm/transport/serializers_spec.rb
@@ -24,6 +24,34 @@ module ElasticAPM
             .to raise_error(Serializers::UnrecognizedResource)
         end
       end
+
+      describe '#keyword_field' do
+        class TruncateSerializer < Serializers::Serializer
+          def serialize(obj)
+            { test: keyword_field(obj[:test]) }
+          end
+        end
+
+        it 'truncates values to 1024 chars' do
+          obj = { test: 'X' * 2000 }
+          thing = TruncateSerializer.new(Config.new).serialize(obj)
+          expect(thing[:test]).to match(/X{1023}…/)
+        end
+      end
+
+      describe '#keyword_object' do
+        class TruncateSerializer < Serializers::Serializer
+          def serialize(obj)
+            keyword_object(obj)
+          end
+        end
+
+        it 'truncates values to 1024 chars' do
+          obj = { test: 'X' * 2000 }
+          thing = TruncateSerializer.new(Config.new).serialize(obj)
+          expect(thing[:test]).to match(/X{1023}…/)
+        end
+      end
     end
   end
 end

--- a/spec/elastic_apm/util_spec.rb
+++ b/spec/elastic_apm/util_spec.rb
@@ -9,9 +9,25 @@ module ElasticAPM
       end
     end
 
-    describe '#ms', mock_time: true do
+    describe '.ms', mock_time: true do
       it 'returns current µs since unix epoch' do
         expect(Util.micros).to eq 694_224_000_000_000
+      end
+    end
+
+    describe '.truncate' do
+      it 'returns nil on nil' do
+        expect(Util.truncate(nil)).to be nil
+      end
+
+      it 'return string if shorter than max' do
+        expect(Util.truncate('poof')).to eq 'poof'
+      end
+
+      it 'returns a truncated string' do
+        result = Util.truncate('X' * 2000)
+        expect(result).to match(/\AX{1023}…\z/)
+        expect(result.length).to be 1024
       end
     end
   end

--- a/spec/integration/rails_spec.rb
+++ b/spec/integration/rails_spec.rb
@@ -164,7 +164,7 @@ if defined?(Rails)
 
         context = @mock_intake.transactions.first['context']
         user = context['user']
-        expect(user['id']).to eq 1
+        expect(user['id']).to eq '1'
         expect(user['email']).to eq 'person@example.com'
       end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -25,6 +25,8 @@ RSpec.configure do |config|
   config.example_status_persistence_file_path = '.rspec_status'
   config.disable_monkey_patching!
 
+  config.fail_fast = ENV.fetch('CI', false)
+
   config.expect_with :rspec do |c|
     c.syntax = :expect
   end


### PR DESCRIPTION
Fixes elastic/apm-agent-ruby#224 