### PR TITLE
Add support for Faraday

### DIFF
--- a/lib/elastic_apm/config.rb
+++ b/lib/elastic_apm/config.rb
@@ -198,6 +198,7 @@ module ElasticAPM
         action_dispatch
         delayed_job
         elasticsearch
+        faraday
         http
         json
         mongo

--- a/lib/elastic_apm/spies/faraday.rb
+++ b/lib/elastic_apm/spies/faraday.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+module ElasticAPM
+  # @api private
+  module Spies
+    # @api private
+    class FaradaySpy
+      # rubocop:disable Metrics/MethodLength
+      def install
+        ::Faraday::Connection.class_eval do
+          alias run_request_without_apm run_request
+
+          def run_request(method, url, body, headers, &block)
+            unless (transaction = ElasticAPM.current_transaction)
+              return run_request_without_apm(method, url, body, headers, &block)
+            end
+
+            host = URI(url).host
+
+            name = "#{method.upcase} #{host}"
+            type = "ext.faraday.#{method}"
+
+            ElasticAPM.with_span name, type do |span|
+              ElasticAPM::Spies::NetHTTPSpy.disable_in do
+                run_request_without_apm(method, url, body, headers) do |req|
+                  req['Elastic-Apm-Traceparent'] =
+                    transaction.traceparent.to_header(span_id: span.id)
+
+                  yield req
+                end
+              end
+            end
+          end
+        end
+      end
+      # rubocop:enable Metrics/MethodLength
+    end
+
+    register 'Faraday', 'faraday', FaradaySpy.new
+  end
+end

--- a/lib/elastic_apm/spies/faraday.rb
+++ b/lib/elastic_apm/spies/faraday.rb
@@ -26,7 +26,7 @@ module ElasticAPM
                   req['Elastic-Apm-Traceparent'] =
                     transaction.traceparent.to_header(span_id: span.id)
 
-                  yield req
+                  yield req if block_given?
                 end
               end
             end

--- a/lib/elastic_apm/spies/net_http.rb
+++ b/lib/elastic_apm/spies/net_http.rb
@@ -5,20 +5,26 @@ module ElasticAPM
   module Spies
     # @api private
     class NetHTTPSpy
+      KEY = :__elastic_apm_net_http_disabled
+
       # rubocop:disable Metrics/MethodLength, Metrics/AbcSize
       class << self
+        def disabled=(disabled)
+          Thread.current[KEY] = disabled
+        end
+
+        def disabled?
+          Thread.current[KEY] ||= false
+        end
+
         def disable_in
-          @disabled = true
+          self.disabled = true
 
           begin
             yield
           ensure
-            @disabled = false
+            self.disabled = false
           end
-        end
-
-        def disabled?
-          @disabled ||= false
         end
       end
 

--- a/spec/elastic_apm/spies/faraday_spec.rb
+++ b/spec/elastic_apm/spies/faraday_spec.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+require 'faraday'
+
+module ElasticAPM
+  RSpec.describe 'Spy: Faraday' do
+    let(:client) do
+      Faraday.new(url: 'http://example.com')
+    end
+
+    it 'spans http calls', :intercept do
+      WebMock.stub_request(:get, %r{http://example.com/.*})
+      ElasticAPM.start
+
+      ElasticAPM.with_transaction 'Faraday test' do
+        client.get('http://example.com/page.html')
+      end
+
+      span, = @intercepted.spans
+
+      expect(span).to_not be nil
+      expect(span.name).to eq 'GET example.com'
+      expect(span.type).to eq 'ext.faraday.get'
+
+      ElasticAPM.stop
+      WebMock.reset!
+    end
+
+    it 'adds traceparent header' do
+      req_stub =
+        WebMock.stub_request(:get, %r{http://example.com/.*}).with do |req|
+          header = req.headers['Elastic-Apm-Traceparent']
+          expect(header).to_not be nil
+          expect { Traceparent.parse(header) }.to_not raise_error
+        end
+
+      ElasticAPM.start
+
+      ElasticAPM.with_transaction 'Faraday test' do
+        client.get('http://example.com/page.html')
+      end
+
+      expect(req_stub).to have_been_requested
+
+      ElasticAPM.stop
+      WebMock.reset!
+    end
+  end
+end

--- a/spec/elastic_apm/spies/net_http_spec.rb
+++ b/spec/elastic_apm/spies/net_http_spec.rb
@@ -43,5 +43,32 @@ module ElasticAPM
       ElasticAPM.stop
       WebMock.reset!
     end
+
+    it 'can be disabled', :intercept do
+      WebMock.stub_request(:any, %r{http://example.com/.*})
+      ElasticAPM.start
+
+      ElasticAPM.with_transaction 'Net::HTTP test' do
+        ElasticAPM::Spies::NetHTTPSpy.disable_in do
+          Net::HTTP.start('example.com') do |http|
+            http.get '/'
+          end
+        end
+
+        Net::HTTP.start('example.com') do |http|
+          http.post '/', 'a=1'
+        end
+      end
+
+      expect(@intercepted.transactions.length).to be 1
+      expect(@intercepted.spans.length).to be 1
+
+      span, = @intercepted.spans
+      expect(span.name).to eq 'POST example.com'
+      expect(span.type).to eq 'ext.net_http.POST'
+
+      ElasticAPM.stop
+      WebMock.reset!
+    end
   end
 end

--- a/spec/elastic_apm/spies/net_http_spec.rb
+++ b/spec/elastic_apm/spies/net_http_spec.rb
@@ -48,6 +48,8 @@ module ElasticAPM
       WebMock.stub_request(:any, %r{http://example.com/.*})
       ElasticAPM.start
 
+      expect(ElasticAPM::Spies::NetHTTPSpy).to_not be_disabled
+
       ElasticAPM.with_transaction 'Net::HTTP test' do
         ElasticAPM::Spies::NetHTTPSpy.disable_in do
           Net::HTTP.start('example.com') do |http|


### PR DESCRIPTION
Adds instrumentation and Distributed Tracing support to external HTTP requests by Faraday.

Also adds a `disable_in` method to the  `Net::HTTP` spy. This is so we don't get several spans for the same request as Faraday uses `Net::HTTP`under the covers by default.