### PR TITLE
Add extra logger and message when failing to configure

### DIFF
--- a/lib/elastic_apm/config.rb
+++ b/lib/elastic_apm/config.rb
@@ -3,6 +3,7 @@
 require 'logger'
 require 'yaml'
 
+require 'elastic_apm/util/prefixed_logger'
 require 'elastic_apm/config/duration'
 require 'elastic_apm/config/size'
 
@@ -107,8 +108,6 @@ module ElasticAPM
       yield self if block_given?
 
       build_logger if logger.nil?
-    rescue NoMethodError => e
-      raise ConfigError, "No such option `#{e.name.to_s.delete('=')}'"
     end
 
     attr_accessor :config_file
@@ -148,10 +147,10 @@ module ElasticAPM
     attr_accessor :transaction_sample_rate
     attr_accessor :verify_server_cert
 
-    attr_reader   :custom_key_filters
-    attr_reader   :ignore_url_patterns
-    attr_reader   :span_frames_min_duration
-    attr_reader   :span_frames_min_duration_us
+    attr_reader :custom_key_filters
+    attr_reader :ignore_url_patterns
+    attr_reader :span_frames_min_duration
+    attr_reader :span_frames_min_duration_us
 
     attr_accessor :view_paths
     attr_accessor :root_path
@@ -160,6 +159,10 @@ module ElasticAPM
     alias :http_compression? :http_compression
     alias :instrument? :instrument
     alias :verify_server_cert? :verify_server_cert
+
+    def alert_logger
+      @alert_logger ||= PrefixedLogger.new($stdout, prefix: Logging::PREFIX)
+    end
 
     def app=(app)
       case app_type?(app)
@@ -239,12 +242,22 @@ module ElasticAPM
     ].freeze
 
     def respond_to_missing?(name)
-      DEPRECATED_OPTIONS.include? name
+      return true if DEPRECATED_OPTIONS.include? name
+      return true if name.to_s.end_with?('=')
+      false
     end
 
     def method_missing(name, *args)
-      return super unless DEPRECATED_OPTIONS.include?(name)
-      warn "The option `#{name}' has been removed."
+      if DEPRECATED_OPTIONS.include?(name)
+        alert_logger.warn "The option `#{name}' has been removed."
+        return
+      end
+
+      if name.to_s.end_with?('=')
+        raise ConfigError, "No such option `#{name.to_s.delete('=')}'"
+      end
+
+      super
     end
 
     private
@@ -285,11 +298,21 @@ module ElasticAPM
 
     def set_from_args(options)
       assign(options)
+    rescue ConfigError => e
+      alert_logger.warn format(
+        'Failed to configure from arguments: %s',
+        e.message
+      )
     end
 
     def set_from_config_file
       return unless File.exist?(config_file)
       assign(YAML.load_file(config_file) || {})
+    rescue ConfigError => e
+      alert_logger.warn format(
+        'Failed to configure from config file: %s',
+        e.message
+      )
     end
 
     def set_sinatra(app)

--- a/lib/elastic_apm/config.rb
+++ b/lib/elastic_apm/config.rb
@@ -7,6 +7,8 @@ require 'elastic_apm/config/duration'
 require 'elastic_apm/config/size'
 
 module ElasticAPM
+  class ConfigError < StandardError; end
+
   # rubocop:disable Metrics/ClassLength
   # @api private
   class Config
@@ -105,6 +107,8 @@ module ElasticAPM
       yield self if block_given?
 
       build_logger if logger.nil?
+    rescue NoMethodError => e
+      raise ConfigError, "No such option `#{e.name.to_s.delete('=')}'"
     end
 
     attr_accessor :config_file

--- a/lib/elastic_apm/railtie.rb
+++ b/lib/elastic_apm/railtie.rb
@@ -25,22 +25,14 @@ module ElasticAPM
 
           app.middleware.insert 0, Middleware
         end
-      rescue ConfigError => e
-        alert_logger.error "#{Logging::PREFIX}Failed to configure: #{e.message}"
       rescue StandardError => e
-        alert_logger.error "#{Logging::PREFIX}Failed to start: #{e.message}"
-        alert_logger.debug e.backtrace.join("\n")
+        config.alert_logger.error format('Failed to start: %s', e.message)
+        config.alert_logger.debug e.backtrace.join("\n")
       end
     end
 
     config.after_initialize do
       require 'elastic_apm/spies/action_dispatch'
-    end
-
-    private
-
-    def alert_logger
-      @alert_logger ||= Logger.new($stdout)
     end
   end
 end

--- a/lib/elastic_apm/railtie.rb
+++ b/lib/elastic_apm/railtie.rb
@@ -25,14 +25,22 @@ module ElasticAPM
 
           app.middleware.insert 0, Middleware
         end
+      rescue ConfigError => e
+        alert_logger.error "#{Logging::PREFIX}Failed to configure: #{e.message}"
       rescue StandardError => e
-        Rails.logger.error "#{Logging::PREFIX}Failed to start: #{e.message}"
-        Rails.logger.debug e.backtrace.join("\n")
+        alert_logger.error "#{Logging::PREFIX}Failed to start: #{e.message}"
+        alert_logger.debug e.backtrace.join("\n")
       end
     end
 
     config.after_initialize do
       require 'elastic_apm/spies/action_dispatch'
+    end
+
+    private
+
+    def alert_logger
+      @alert_logger ||= Logger.new($stdout)
     end
   end
 end

--- a/lib/elastic_apm/util/prefixed_logger.rb
+++ b/lib/elastic_apm/util/prefixed_logger.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module ElasticAPM
+  # @api private
+  class PrefixedLogger < Logger
+    def initialize(logdev, prefix: '', **args)
+      super(logdev, **args)
+
+      @prefix = prefix
+    end
+
+    attr_reader :prefix
+
+    def add(severity, message = nil, progname = nil)
+      super(severity, format('%s%s', prefix, message), progname)
+    end
+  end
+end

--- a/spec/elastic_apm/config_spec.rb
+++ b/spec/elastic_apm/config_spec.rb
@@ -156,5 +156,11 @@ module ElasticAPM
           .to raise_error(NoMethodError)
       end
     end
+
+    describe 'unknown options' do
+      it 'raises an exception' do
+        expect { Config.new(unknown_key: true) }.to raise_error(ConfigError)
+      end
+    end
   end
 end

--- a/spec/elastic_apm/config_spec.rb
+++ b/spec/elastic_apm/config_spec.rb
@@ -147,19 +147,25 @@ module ElasticAPM
 
     describe 'deprecations' do
       it 'warns about removed options' do
-        expect(subject).to receive(:warn).with(/has been removed/)
-        subject.flush_interval = 123
-      end
+        expect_any_instance_of(PrefixedLogger)
+          .to receive(:warn).with(/has been removed/)
 
-      it "doesn't intercept unlisted, missing methods" do
-        expect { subject.very_missing_method = 123 }
-          .to raise_error(NoMethodError)
+        subject.flush_interval = 123
       end
     end
 
     describe 'unknown options' do
-      it 'raises an exception' do
-        expect { Config.new(unknown_key: true) }.to raise_error(ConfigError)
+      before { expect_any_instance_of(PrefixedLogger).to receive(:warn) }
+
+      context 'from args' do
+        it 'logs to the alert logger' do
+          Config.new(unknown_key: true)
+        end
+      end
+      context 'from config_file' do
+        it 'logs to the alert logger' do
+          Config.new(config_file: 'spec/fixtures/unknown_option.yml')
+        end
       end
     end
   end

--- a/spec/fixtures/unknown_option.yml
+++ b/spec/fixtures/unknown_option.yml
@@ -1,0 +1,2 @@
+---
+unknown_option_in_config_file: 123


### PR DESCRIPTION
`Rails.logger` isn't writing to `stdout` at the point of starting and configuring the agent in the railtie. Any exceptions come across while doing so might very well go by unseen because the developer doesn't see anything in their terminal.

This works around this by adding another `Logger` instance in the railtie that's sure to write to `stdout`. 

Consider: Should we write to both?

Fixes #251 