### PR TITLE
docs: update file structure and intro

### DIFF
--- a/docs/advanced.asciidoc
+++ b/docs/advanced.asciidoc
@@ -1,0 +1,8 @@
+[[advanced]]
+== Advanced Topics
+
+* <<context>>
+* <<custom-instrumentation>>
+
+include::./context.asciidoc[]
+include::./custom-instrumentation.asciidoc[]

--- a/docs/context.asciidoc
+++ b/docs/context.asciidoc
@@ -1,4 +1,3 @@
-[float]
 [[context]]
 === Adding additional context
 

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -2,42 +2,24 @@
 include::{asciidoc-dir}/../../shared/attributes.asciidoc[]
 
 ifdef::env-github[]
-NOTE: For the best reading experience, please view this documentation at
+NOTE: For the best reading experience,
+please view this documentation at
 https://www.elastic.co/guide/en/apm/agent/ruby[elastic.co]
 endif::[]
 
 = APM Ruby Agent Reference
 
-[[introduction]]
-== Introduction
-
-The Elastic APM Ruby Agent sends performance metrics and error logs to an
-Elastic APM Server.
-
-It has built-in support for <<getting-started-rails,Ruby on Rails>> and other
-<<getting-started-rack,Rack-compatible>> applications.
-
-This agent is one of several components you need to get started collecting APM
-data. See also:
-
- * {apm-server-ref}[APM Server]
-
-[[framework-support]]
-The Elastic APM Ruby Agent officially supports Ruby on Rails versions 4.x on
-onwards, see <<getting-started-rails,Getting started with Ruby on Rails>>.
-
-For Sinatra and other Rack compatible frameworks, see
-<<getting-started-rack,Getting started with Rack>>.
+include::./introduction.asciidoc[]
 
 include::./getting-started-rails.asciidoc[]
+
 include::./getting-started-rack.asciidoc[]
+
 include::./configuration.asciidoc[]
 
-[[advanced]]
-== Advanced Topics
-include::./context.asciidoc[]
-include::./custom-instrumentation.asciidoc[]
+include::./advanced.asciidoc[]
 
 include::./supported-technologies.asciidoc[]
+
 include::./api.asciidoc[]
 

--- a/docs/introduction.asciidoc
+++ b/docs/introduction.asciidoc
@@ -1,0 +1,33 @@
+[[introduction]]
+
+ifdef::env-github[]
+NOTE: For the best reading experience,
+please view this documentation at
+https://www.elastic.co/guide/en/apm/agent/ruby/current/introduction.html[elastic.co]
+endif::[]
+
+== Introduction
+
+Welcome to the APM Ruby Agent documentation.
+
+The Elastic APM Ruby Agent sends performance metrics and error logs to an
+Elastic APM Server.
+It has built-in support for <<getting-started-rails,Ruby on Rails>> and other
+<<getting-started-rack,Rack-compatible>> applications.
+
+[float]
+[[additional-components]]
+=== Additional Components
+
+APM Agents work in conjunction with the {apm-server-ref}/index.html[APM Server], {ref}/index.html[Elasticsearch], and {kibana-ref}/index.html[Kibana].
+Please view the {apm-get-started-ref}/index.html[APM Overview] for details on how these components work together. 
+
+[float]
+[[framework-support]]
+=== Framework Support
+
+The Elastic APM Ruby Agent officially supports Ruby on Rails versions 4.x on
+onwards, see <<getting-started-rails,Getting started with Ruby on Rails>>.
+
+For Sinatra and other Rack compatible frameworks, see
+<<getting-started-rack,Getting started with Rack>>.


### PR DESCRIPTION
* Updated `index.asciidoc` to move `introduction` and `advanced-topics` into their own files. 
* Updated agent `introduction.asciidoc` per elastic/apm-dev#387
* Changed formatting in `advanced-topics` to put "context" and "custom-instrumentation" on the same level