### PR TITLE
Fix faraday call with url_prefix

### DIFF
--- a/lib/elastic_apm/spies/faraday.rb
+++ b/lib/elastic_apm/spies/faraday.rb
@@ -15,7 +15,11 @@ module ElasticAPM
               return run_request_without_apm(method, url, body, headers, &block)
             end
 
-            host = URI(url).host
+            host = if url_prefix.is_a?(URI) && url_prefix.host
+                     url_prefix.host
+                   else
+                     URI(url).host
+                   end
 
             name = "#{method.upcase} #{host}"
             type = "ext.faraday.#{method}"


### PR DESCRIPTION
This is fix for spy, when used relative faraday calls.

Related: https://github.com/elastic/apm-agent-ruby/issues/184

Case 1 ( url is nil ):
```rb
conn = Faraday::Connection.new('http://api.example.com/v1/some_resource/1')
response = conn.get
#          ArgumentError:
#            bad argument (expected URI object or URI string)
```

In this case url is nil, this means we calling `GET http://api.example.com/v1/some_resource/1` directly. Spy got crashed when try to parse url.

Case 2 ( url is a path ):
```rb
conn = Faraday::Connection.new('http://api.example.com')
response = conn.get('/v1/some_resource/1')
```

That's not raises an error, but we got a nil instead of host name

```
[1] pry(main)> URI('/v1/some_resource/1')
=> #<URI::Generic /v1/some_resource/1>
[2] pry(main)> URI('/v1/some_resource/1').host
=> nil
```

Workaround: Try to use host from `url_prefix`

When url filled:

```
[1] pry(main)> Faraday::Connection.new('http://api.example.com').url_prefix.host
=> "some.api.com"
[2] pry(main)> Faraday::Connection.new(url: 'http://api.example.com').url_prefix.host
=> "some.api.com"
```

When url is not filled:

```
[1] pry(main)> Faraday::Connection.new.url_prefix
=> #<URI::HTTP http:/>
[2] pry(main)> Faraday::Connection.new.url_prefix.host
=> nil
```
