### PR TITLE
Rename Traceparent class to TraceContext, also attach to Spans

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Changed
+
+- Rename `Traceparent` object to `TraceContext` ([#271](https://github.com/elastic/apm-agent-ruby/pull/271))
+
 ## 2.1.2 (2018-12-07)
 
 ### Fixed

--- a/docs/api.asciidoc
+++ b/docs/api.asciidoc
@@ -76,7 +76,7 @@ Arguments:
   * `type`: A `type` for your transaction eg. `db.postgresql.sql`.
   * `context:`: An optional <<api-context,Context>> used to enrich the
   transaction with information about the current request.
-  * `traceparent:`: An optional `Traceparent` object for Distributed Tracing.
+  * `trace_context:`: An optional `TraceContext` object for Distributed Tracing.
 
 Returns the transaction.
 
@@ -111,7 +111,7 @@ Arguments:
   * `type`: A `type` for your transaction eg. `db.postgresql.sql`.
   * `context:`: An optional <<api-context,Context>> used to enrich the
   transaction with information about the current request.
-  * `traceparent:`: An optional `Traceparent` object for Distributed Tracing.
+  * `trace_context:`: An optional `TraceContext` object for Distributed Tracing.
   * `&block`: A block to wrap. Optionally yields the transaction.
 
 Returns the return value of the given block.

--- a/lib/elastic_apm.rb
+++ b/lib/elastic_apm.rb
@@ -124,7 +124,12 @@ module ElasticAPM # rubocop:disable Metrics/ModuleLength
     # @param context [Context] An optional [Context]
     # @yield [Transaction]
     # @return result of block
-    def with_transaction(name = nil, type = nil, context: nil, trace_context: nil)
+    def with_transaction(
+      name = nil,
+      type = nil,
+      context: nil,
+      trace_context: nil
+    )
       unless block_given?
         raise ArgumentError,
           'expected a block. Do you want `start_transaction\' instead?'

--- a/lib/elastic_apm.rb
+++ b/lib/elastic_apm.rb
@@ -84,6 +84,7 @@ module ElasticAPM # rubocop:disable Metrics/ModuleLength
 
     deprecate :transaction, :with_transaction
 
+    # rubocop:disable Metrics/MethodLength
     # Start a new transaction
     #
     # @param name [String] A description of the transaction, eg
@@ -96,8 +97,15 @@ module ElasticAPM # rubocop:disable Metrics/ModuleLength
       name = nil,
       type = nil,
       context: nil,
-      trace_context: nil
+      trace_context: nil,
+      traceparent: nil
     )
+      if traceparent
+        trace_context ||= traceparent
+        warn "[ElasticAPM] [DEPRECATED] `start_transaction' with" \
+          "`traceparent:' has been renamed. Use `trace_context:' instead."
+      end
+
       agent&.start_transaction(
         name,
         type,
@@ -105,6 +113,7 @@ module ElasticAPM # rubocop:disable Metrics/ModuleLength
         trace_context: trace_context
       )
     end
+    # rubocop:enable Metrics/MethodLength
 
     # Ends the current transaction with `result`
     #
@@ -128,11 +137,18 @@ module ElasticAPM # rubocop:disable Metrics/ModuleLength
       name = nil,
       type = nil,
       context: nil,
-      trace_context: nil
+      trace_context: nil,
+      traceparent: nil
     )
       unless block_given?
         raise ArgumentError,
           'expected a block. Do you want `start_transaction\' instead?'
+      end
+
+      if traceparent
+        trace_context ||= traceparent
+        warn "[ElasticAPM] [DEPRECATED] `start_transaction' with " \
+          "`traceparent:' has been renamed. Use `trace_context:' instead."
       end
 
       return yield(nil) unless agent

--- a/lib/elastic_apm.rb
+++ b/lib/elastic_apm.rb
@@ -147,7 +147,7 @@ module ElasticAPM # rubocop:disable Metrics/ModuleLength
 
       if traceparent
         trace_context ||= traceparent
-        warn "[ElasticAPM] [DEPRECATED] `start_transaction' with " \
+        warn "[ElasticAPM] [DEPRECATED] `with_transaction' with " \
           "`traceparent:' has been renamed. Use `trace_context:' instead."
       end
 

--- a/lib/elastic_apm.rb
+++ b/lib/elastic_apm.rb
@@ -96,13 +96,13 @@ module ElasticAPM # rubocop:disable Metrics/ModuleLength
       name = nil,
       type = nil,
       context: nil,
-      traceparent: nil
+      trace_context: nil
     )
       agent&.start_transaction(
         name,
         type,
         context: context,
-        traceparent: traceparent
+        trace_context: trace_context
       )
     end
 
@@ -124,7 +124,7 @@ module ElasticAPM # rubocop:disable Metrics/ModuleLength
     # @param context [Context] An optional [Context]
     # @yield [Transaction]
     # @return result of block
-    def with_transaction(name = nil, type = nil, context: nil, traceparent: nil)
+    def with_transaction(name = nil, type = nil, context: nil, trace_context: nil)
       unless block_given?
         raise ArgumentError,
           'expected a block. Do you want `start_transaction\' instead?'
@@ -138,7 +138,7 @@ module ElasticAPM # rubocop:disable Metrics/ModuleLength
             name,
             type,
             context: context,
-            traceparent: traceparent
+            trace_context: trace_context
           )
         yield transaction
       ensure

--- a/lib/elastic_apm/agent.rb
+++ b/lib/elastic_apm/agent.rb
@@ -106,13 +106,13 @@ module ElasticAPM
       name = nil,
       type = nil,
       context: nil,
-      traceparent: nil
+      trace_context: nil
     )
       instrumenter.start_transaction(
         name,
         type,
         context: context,
-        traceparent: traceparent
+        trace_context: trace_context
       )
     end
 

--- a/lib/elastic_apm/instrumenter.rb
+++ b/lib/elastic_apm/instrumenter.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require 'elastic_apm/trace_context'
 require 'elastic_apm/span'
 require 'elastic_apm/transaction'
 
@@ -78,7 +79,7 @@ module ElasticAPM
       name = nil,
       type = nil,
       context: nil,
-      traceparent: nil
+      trace_context: nil
     )
       return nil unless config.instrument?
 
@@ -87,14 +88,14 @@ module ElasticAPM
           "Transactions may not be nested.\nAlready inside #{transaction}"
       end
 
-      sampled = traceparent ? traceparent.recorded? : random_sample?
+      sampled = trace_context ? trace_context.recorded? : random_sample?
 
       transaction =
         Transaction.new(
           name,
           type,
           context: context,
-          traceparent: traceparent,
+          trace_context: trace_context,
           sampled: sampled
         )
 

--- a/lib/elastic_apm/middleware.rb
+++ b/lib/elastic_apm/middleware.rb
@@ -1,8 +1,6 @@
 #
 # frozen_string_literal: true
 
-require 'elastic_apm/traceparent'
-
 module ElasticAPM
   # @api private
   class Middleware
@@ -53,13 +51,13 @@ module ElasticAPM
     def start_transaction(env)
       ElasticAPM.start_transaction 'Rack', 'request',
         context: ElasticAPM.build_context(env),
-        traceparent: traceparent(env)
+        trace_context: trace_context(env)
     end
 
-    def traceparent(env)
+    def trace_context(env)
       return unless (header = env['HTTP_ELASTIC_APM_TRACEPARENT'])
-      Traceparent.parse(header)
-    rescue Traceparent::InvalidTraceparentHeader
+      TraceContext.parse(header)
+    rescue TraceContext::InvalidTraceparentHeader
       warn "Couldn't parse invalid traceparent header: #{header.inspect}"
       nil
     end

--- a/lib/elastic_apm/span.rb
+++ b/lib/elastic_apm/span.rb
@@ -16,7 +16,8 @@ module ElasticAPM
       transaction: nil,
       parent: nil,
       context: nil,
-      stacktrace_builder: nil
+      stacktrace_builder: nil,
+      trace_context: nil
     )
       @name = name
       @type = type || DEFAULT_TYPE
@@ -26,12 +27,16 @@ module ElasticAPM
       self.transaction = transaction
       self.parent = parent
 
+      @trace_context =
+        trace_context ||
+        TraceContext.from(transaction: transaction, span: self)
+
       @context = context
       @stacktrace_builder = stacktrace_builder
     end
     # rubocop:enable Metrics/ParameterLists
 
-    attr_accessor :name, :type, :original_backtrace, :parent
+    attr_accessor :name, :type, :original_backtrace, :parent, :trace_context
     attr_reader :id, :context, :stacktrace, :duration,
       :timestamp, :transaction_id, :trace_id
 

--- a/lib/elastic_apm/spies/faraday.rb
+++ b/lib/elastic_apm/spies/faraday.rb
@@ -26,11 +26,10 @@ module ElasticAPM
 
             ElasticAPM.with_span name, type do |span|
               ElasticAPM::Spies::NetHTTPSpy.disable_in do
-                id = span&.id || transaction.id
+                trace_context = span&.trace_context || transaction.trace_context
 
                 run_request_without_apm(method, url, body, headers) do |req|
-                  req['Elastic-Apm-Traceparent'] =
-                    transaction.traceparent.to_header(span_id: id)
+                  req['Elastic-Apm-Traceparent'] = trace_context.to_header
 
                   yield req if block_given?
                 end

--- a/lib/elastic_apm/spies/http.rb
+++ b/lib/elastic_apm/spies/http.rb
@@ -5,7 +5,7 @@ module ElasticAPM
   module Spies
     # @api private
     class HTTPSpy
-      # rubocop:disable Metrics/MethodLength, Metrics/AbcSize
+      # rubocop:disable Metrics/MethodLength
       def install
         ::HTTP::Client.class_eval do
           alias perform_without_apm perform
@@ -22,17 +22,14 @@ module ElasticAPM
             type = "ext.http_rb.#{method}"
 
             ElasticAPM.with_span name, type do |span|
-              id = span&.id || transaction.id
-
-              req['Elastic-Apm-Traceparent'] =
-                transaction.traceparent.to_header(span_id: id)
-
+              trace_context = span&.trace_context || transaction.trace_context
+              req['Elastic-Apm-Traceparent'] = trace_context.to_header
               perform_without_apm(req, options)
             end
           end
         end
       end
-      # rubocop:enable Metrics/MethodLength, Metrics/AbcSize
+      # rubocop:enable Metrics/MethodLength
     end
 
     register 'HTTP', 'http', HTTPSpy.new

--- a/lib/elastic_apm/spies/net_http.rb
+++ b/lib/elastic_apm/spies/net_http.rb
@@ -49,11 +49,8 @@ module ElasticAPM
             type = "ext.net_http.#{method}"
 
             ElasticAPM.with_span name, type do |span|
-              id = span&.id || transaction.id
-
-              req['Elastic-Apm-Traceparent'] =
-                transaction.traceparent.to_header(span_id: id)
-
+              trace_context = span&.trace_context || transaction.trace_context
+              req['Elastic-Apm-Traceparent'] = trace_context.to_header
               request_without_apm(req, body, &block)
             end
           end

--- a/lib/elastic_apm/transaction.rb
+++ b/lib/elastic_apm/transaction.rb
@@ -16,7 +16,7 @@ module ElasticAPM
       sampled: true,
       context: nil,
       tags: nil,
-      traceparent: nil
+      trace_context: nil
     )
       @name = name
       @type = type || DEFAULT_TYPE
@@ -28,11 +28,11 @@ module ElasticAPM
 
       @id = SecureRandom.hex(8)
 
-      if traceparent
-        @traceparent = traceparent
-        @parent_id = traceparent.span_id
+      if trace_context
+        @trace_context = trace_context
+        @parent_id = trace_context.span_id
       else
-        @traceparent = Traceparent.from_transaction(self)
+        @trace_context = TraceContext.from(transaction: self)
       end
 
       @started_spans = 0
@@ -45,7 +45,7 @@ module ElasticAPM
     attr_accessor :name, :type, :result
 
     attr_reader :id, :context, :duration, :started_spans, :dropped_spans,
-      :timestamp, :traceparent, :notifications, :parent_id
+      :timestamp, :trace_context, :notifications, :parent_id
 
     def sampled?
       @sampled
@@ -62,7 +62,7 @@ module ElasticAPM
     deprecate :done?, :stopped?
 
     def trace_id
-      traceparent&.trace_id
+      trace_context&.trace_id
     end
 
     # life cycle

--- a/spec/elastic_apm/agent_spec.rb
+++ b/spec/elastic_apm/agent_spec.rb
@@ -41,7 +41,7 @@ module ElasticAPM
         {
           current_transaction: nil,
           current_span: nil,
-          start_transaction: [nil, nil, { context: nil, traceparent: nil }],
+          start_transaction: [nil, nil, { context: nil, trace_context: nil }],
           end_transaction: [nil],
           start_span: [nil, nil, { backtrace: nil, context: nil }],
           end_span: nil,

--- a/spec/elastic_apm/middleware_spec.rb
+++ b/spec/elastic_apm/middleware_spec.rb
@@ -48,7 +48,7 @@ module ElasticAPM
         .with(MiddlewareTestError, handled: false)
     end
 
-    it 'attaches a new traceparent', :intercept do
+    it 'attaches a new trace_context', :intercept do
       ElasticAPM.start
 
       app = Middleware.new(->(_) { [200, {}, ['ok']] })
@@ -58,9 +58,9 @@ module ElasticAPM
 
       ElasticAPM.stop
 
-      traceparent = @intercepted.transactions.first.traceparent
-      expect(traceparent).to_not be_nil
-      expect(traceparent).to be_recorded
+      trace_context = @intercepted.transactions.first.trace_context
+      expect(trace_context).to_not be_nil
+      expect(trace_context).to be_recorded
     end
 
     describe 'Distributed Tracing', :intercept do
@@ -73,7 +73,7 @@ module ElasticAPM
       let(:app) { Middleware.new(->(_) { [200, {}, ['ok']] }) }
 
       context 'with valid header' do
-        it 'recognizes traceparent', :intercept do
+        it 'recognizes trace_context', :intercept do
           app.call(
             Rack::MockRequest.env_for(
               '/',
@@ -82,16 +82,16 @@ module ElasticAPM
             )
           )
 
-          traceparent = @intercepted.transactions.first.traceparent
-          expect(traceparent.version).to eq '00'
-          expect(traceparent.trace_id).to eq '0af7651916cd43dd8448eb211c80319c'
-          expect(traceparent.span_id).to eq 'b7ad6b7169203331'
-          expect(traceparent).to_not be_recorded
+          trace_context = @intercepted.transactions.first.trace_context
+          expect(trace_context.version).to eq '00'
+          expect(trace_context.trace_id).to eq '0af7651916cd43dd8448eb211c80319c'
+          expect(trace_context.span_id).to eq 'b7ad6b7169203331'
+          expect(trace_context).to_not be_recorded
         end
       end
 
       context 'with an invalid header' do
-        it 'skips traceparent, makes new', :intercept do
+        it 'skips trace_context, makes new', :intercept do
           app.call(
             Rack::MockRequest.env_for(
               '/',
@@ -100,21 +100,21 @@ module ElasticAPM
             )
           )
 
-          traceparent = @intercepted.transactions.first.traceparent
-          expect(traceparent.trace_id)
+          trace_context = @intercepted.transactions.first.trace_context
+          expect(trace_context.trace_id)
             .to_not eq '0af7651916cd43dd8448eb211c80319c'
-          expect(traceparent.span_id).to be nil
+          expect(trace_context.span_id).to_not match(/INVALID/)
         end
       end
 
       context 'with a blank header' do
-        it 'skips traceparent, makes new', :intercept do
+        it 'skips trace_context, makes new', :intercept do
           app.call(
             Rack::MockRequest.env_for('/', 'HTTP_ELASTIC_APM_TRACEPARENT' => '')
           )
 
-          traceparent = @intercepted.transactions.first.traceparent
-          expect(traceparent.trace_id)
+          trace_context = @intercepted.transactions.first.trace_context
+          expect(trace_context.trace_id)
             .to_not eq '0af7651916cd43dd8448eb211c80319c'
         end
       end

--- a/spec/elastic_apm/middleware_spec.rb
+++ b/spec/elastic_apm/middleware_spec.rb
@@ -84,7 +84,8 @@ module ElasticAPM
 
           trace_context = @intercepted.transactions.first.trace_context
           expect(trace_context.version).to eq '00'
-          expect(trace_context.trace_id).to eq '0af7651916cd43dd8448eb211c80319c'
+          expect(trace_context.trace_id)
+            .to eq '0af7651916cd43dd8448eb211c80319c'
           expect(trace_context.span_id).to eq 'b7ad6b7169203331'
           expect(trace_context).to_not be_recorded
         end

--- a/spec/elastic_apm/spies/faraday_spec.rb
+++ b/spec/elastic_apm/spies/faraday_spec.rb
@@ -49,7 +49,7 @@ module ElasticAPM
         WebMock.stub_request(:get, %r{http://example.com/.*}).with do |req|
           header = req.headers['Elastic-Apm-Traceparent']
           expect(header).to_not be nil
-          expect { Traceparent.parse(header) }.to_not raise_error
+          expect { TraceContext.parse(header) }.to_not raise_error
         end
 
       ElasticAPM.start

--- a/spec/elastic_apm/spies/http_spec.rb
+++ b/spec/elastic_apm/spies/http_spec.rb
@@ -26,7 +26,7 @@ module ElasticAPM
         WebMock.stub_request(:get, %r{http://example.com/.*}).with do |req|
           header = req.headers['Elastic-Apm-Traceparent']
           expect(header).to_not be nil
-          expect { Traceparent.parse(header) }.to_not raise_error
+          expect { TraceContext.parse(header) }.to_not raise_error
         end
 
       ElasticAPM.start

--- a/spec/elastic_apm/spies/net_http_spec.rb
+++ b/spec/elastic_apm/spies/net_http_spec.rb
@@ -27,7 +27,7 @@ module ElasticAPM
         WebMock.stub_request(:get, %r{http://example.com/.*}).with do |req|
           header = req.headers['Elastic-Apm-Traceparent']
           expect(header).to_not be nil
-          expect { Traceparent.parse(header) }.to_not raise_error
+          expect { TraceContext.parse(header) }.to_not raise_error
         end
 
       ElasticAPM.start

--- a/spec/elastic_apm/transaction_spec.rb
+++ b/spec/elastic_apm/transaction_spec.rb
@@ -8,12 +8,12 @@ module ElasticAPM
       its(:id) { should_not be_nil }
       its(:type) { should be 'custom' }
       it { should be_sampled }
-      its(:traceparent) { should be_a Traceparent }
+      its(:trace_context) { should be_a TraceContext }
       its(:context) { should be_a Context }
       its(:started_spans) { should be 0 }
       its(:dropped_spans) { should be 0 }
       its(:notifications) { should be_empty }
-      its(:trace_id) { should be subject.traceparent.trace_id }
+      its(:trace_id) { should be subject.trace_context.trace_id }
 
       context 'with tags from context and args' do
         it 'merges tags' do
@@ -60,9 +60,9 @@ module ElasticAPM
       end
 
       it 'keeps and returns current if set' do
-        traceparent = Traceparent.new
-        traceparent.span_id = 'things'
-        subject = Transaction.new traceparent: traceparent
+        trace_context = TraceContext.new
+        trace_context.span_id = 'things'
+        subject = Transaction.new trace_context: trace_context
 
         parent_id = subject.ensure_parent_id
 

--- a/spec/elastic_apm_spec.rb
+++ b/spec/elastic_apm_spec.rb
@@ -162,6 +162,8 @@ RSpec.describe ElasticAPM do
 
     describe '.transaction' do
       it 'redirects to new apis' do
+        expect(ElasticAPM).to receive(:warn).with(/DEPRECATED/).twice
+
         expect(ElasticAPM).to receive(:start_transaction) { true }
         ElasticAPM.transaction
 
@@ -172,11 +174,27 @@ RSpec.describe ElasticAPM do
 
     describe '.span' do
       it 'redirects to new apis' do
+        expect(ElasticAPM).to receive(:warn).with(/DEPRECATED/).twice
+
         expect(ElasticAPM).to receive(:start_span) { true }
         ElasticAPM.span('Name')
 
         expect(ElasticAPM).to receive(:with_span) { true }
         ElasticAPM.span('Name') { 'ok' }
+      end
+    end
+
+    describe '.start_transaction with traceparent' do
+      it 'warns and falls back' do
+        ElasticAPM.start
+        expect(ElasticAPM).to receive(:warn).with(/DEPRECATED/)
+
+        trace_context = ElasticAPM::TraceContext.new
+        transaction = ElasticAPM.start_transaction traceparent: trace_context
+
+        expect(transaction.trace_context).to be trace_context
+
+        ElasticAPM.stop
       end
     end
   end


### PR DESCRIPTION
To align with other agents, W3C and OpenTracing