### PR TITLE
Keep current spans as a stack in Instrumenter

### DIFF
--- a/lib/elastic_apm/instrumenter.rb
+++ b/lib/elastic_apm/instrumenter.rb
@@ -140,12 +140,15 @@ module ElasticAPM
         return
       end
 
+      parent = current_span || transaction
+
       span = Span.new(
         name,
         type,
-        transaction: transaction,
-        parent_id: current_span&.id || transaction.id,
-        context: context
+        transaction_id: transaction.id,
+        parent_id: parent.id,
+        context: context,
+        trace_context: parent.trace_context
       )
 
       if backtrace && span_frames_min_duration?

--- a/lib/elastic_apm/instrumenter.rb
+++ b/lib/elastic_apm/instrumenter.rb
@@ -17,7 +17,7 @@ module ElasticAPM
     class Current
       def initialize
         self.transaction = nil
-        self.span = nil
+        self.spans = []
       end
 
       def transaction
@@ -28,12 +28,12 @@ module ElasticAPM
         Thread.current[TRANSACTION_KEY] = transaction
       end
 
-      def span
+      def spans
         Thread.current[SPAN_KEY]
       end
 
-      def span=(span)
-        Thread.current[SPAN_KEY] = span
+      def spans=(spans)
+        Thread.current[SPAN_KEY] = spans
       end
     end
 
@@ -54,7 +54,7 @@ module ElasticAPM
       debug 'Stopping instrumenter'
 
       self.current_transaction = nil
-      self.current_span = nil
+      current_spans.pop until current_spans.empty?
 
       @subscriber.unregister! if @subscriber
     end
@@ -119,15 +119,16 @@ module ElasticAPM
 
     # spans
 
-    def current_span
-      @current.span
+    def current_spans
+      @current.spans
     end
 
-    def current_span=(span)
-      @current.span = span
+    def current_span
+      current_spans.last
     end
 
     # rubocop:disable Metrics/MethodLength, Metrics/CyclomaticComplexity
+    # rubocop:disable Metrics/AbcSize
     def start_span(name, type = nil, backtrace: nil, context: nil)
       return unless (transaction = current_transaction)
       return unless transaction.sampled?
@@ -143,7 +144,7 @@ module ElasticAPM
         name,
         type,
         transaction: transaction,
-        parent: current_span || transaction,
+        parent_id: current_span&.id || transaction.id,
         context: context
       )
 
@@ -151,19 +152,17 @@ module ElasticAPM
         span.original_backtrace = backtrace
       end
 
-      self.current_span = span
+      current_spans.push span
 
       span.start
     end
+    # rubocop:enable Metrics/AbcSize
     # rubocop:enable Metrics/MethodLength, Metrics/CyclomaticComplexity
 
     def end_span
-      return unless (span = current_span)
+      return unless (span = current_spans.pop)
 
       span.done
-
-      self.current_span =
-        span.parent&.is_a?(Span) && span.parent || nil
 
       enqueue.call span
 

--- a/lib/elastic_apm/span.rb
+++ b/lib/elastic_apm/span.rb
@@ -14,7 +14,7 @@ module ElasticAPM
       name,
       type = nil,
       transaction: nil,
-      parent: nil,
+      parent_id: nil,
       context: nil,
       stacktrace_builder: nil,
       trace_context: nil
@@ -23,9 +23,8 @@ module ElasticAPM
       @type = type || DEFAULT_TYPE
 
       @id = SecureRandom.hex(8)
-
-      self.transaction = transaction
-      self.parent = parent
+      @parent_id = parent_id
+      @transaction_id = transaction&.id
 
       @trace_context =
         trace_context ||
@@ -36,17 +35,12 @@ module ElasticAPM
     end
     # rubocop:enable Metrics/ParameterLists
 
-    attr_accessor :name, :type, :original_backtrace, :parent, :trace_context
+    attr_accessor :name, :type, :original_backtrace, :parent_id, :trace_context
     attr_reader :id, :context, :stacktrace, :duration,
-      :timestamp, :transaction_id, :trace_id
+      :timestamp, :transaction_id
 
-    def transaction=(transaction)
-      @transaction_id = transaction&.id
-      @trace_id = transaction&.trace_id
-    end
-
-    def parent_id
-      @parent&.id || transaction_id
+    def trace_id
+      trace_context&.trace_id
     end
 
     # life cycle

--- a/lib/elastic_apm/span.rb
+++ b/lib/elastic_apm/span.rb
@@ -13,7 +13,7 @@ module ElasticAPM
     def initialize(
       name,
       type = nil,
-      transaction: nil,
+      transaction_id: nil,
       parent_id: nil,
       context: nil,
       stacktrace_builder: nil,
@@ -24,11 +24,9 @@ module ElasticAPM
 
       @id = SecureRandom.hex(8)
       @parent_id = parent_id
-      @transaction_id = transaction&.id
+      @transaction_id = transaction_id
 
-      @trace_context =
-        trace_context ||
-        TraceContext.from(transaction: transaction, span: self)
+      @trace_context = trace_context&.child(self)
 
       @context = context
       @stacktrace_builder = stacktrace_builder

--- a/lib/elastic_apm/trace_context.rb
+++ b/lib/elastic_apm/trace_context.rb
@@ -16,13 +16,13 @@ module ElasticAPM
 
     alias :recorded? :recorded
 
-    def self.from(transaction:, span: nil)
+    def self.for_transaction(transaction)
       new.tap do |t|
         t.trace_id =
           transaction&.trace_context&.trace_id ||
           SecureRandom.hex(16)
         t.recorded = transaction && transaction.sampled?
-        t.span_id = span&.id || transaction.id
+        t.span_id = transaction.id
       end
     end
 
@@ -55,6 +55,10 @@ module ElasticAPM
 
     def hex_flags
       format('%02x', flags.to_i(2))
+    end
+
+    def child(span)
+      dup.tap { |tc| tc.span_id = span.id }
     end
 
     def to_header

--- a/lib/elastic_apm/trace_context.rb
+++ b/lib/elastic_apm/trace_context.rb
@@ -18,7 +18,9 @@ module ElasticAPM
 
     def self.from(transaction:, span: nil)
       new.tap do |t|
-        t.trace_id = SecureRandom.hex(16)
+        t.trace_id =
+          transaction&.trace_context&.trace_id ||
+          SecureRandom.hex(16)
         t.recorded = transaction && transaction.sampled?
         t.span_id = span&.id || transaction.id
       end

--- a/lib/elastic_apm/transaction.rb
+++ b/lib/elastic_apm/transaction.rb
@@ -32,7 +32,7 @@ module ElasticAPM
         @trace_context = trace_context
         @parent_id = trace_context.span_id
       else
-        @trace_context = TraceContext.from(transaction: self)
+        @trace_context = TraceContext.for_transaction(self)
       end
 
       @started_spans = 0

--- a/spec/elastic_apm/instrumenter_spec.rb
+++ b/spec/elastic_apm/instrumenter_spec.rb
@@ -119,7 +119,7 @@ module ElasticAPM
           expect(span).to be_a Span
           expect(span).to be_started
           expect(span.transaction_id).to eq transaction.id
-          expect(span.parent).to eq transaction
+          expect(span.parent_id).to eq transaction.id
           expect(subject.current_span).to eq span
         end
 
@@ -128,7 +128,7 @@ module ElasticAPM
             parent = subject.start_span 'Level 1'
             child = subject.start_span 'Level 2'
 
-            expect(child.parent).to be parent
+            expect(child.parent_id).to be parent.id
           end
         end
 

--- a/spec/elastic_apm/span_spec.rb
+++ b/spec/elastic_apm/span_spec.rb
@@ -9,7 +9,6 @@ module ElasticAPM
       its(:type) { should be 'custom' }
       its(:transaction_id) { should be_nil }
       its(:timestamp) { should be_nil }
-      its(:trace_id) { should be_nil }
       its(:parent_id) { should be_nil }
       its(:context) { should be_nil }
 
@@ -22,13 +21,6 @@ module ElasticAPM
 
         its(:transaction_id) { should be transaction.id }
         its(:timestamp) { should be transaction.timestamp }
-        its(:trace_id) { should be transaction.trace_id }
-      end
-
-      context 'with a parent' do
-        let(:span) { Span.new 'Span' }
-        subject { described_class.new 'Span', parent: span }
-        its(:parent_id) { should be span.id }
       end
     end
 

--- a/spec/elastic_apm/span_spec.rb
+++ b/spec/elastic_apm/span_spec.rb
@@ -9,25 +9,29 @@ module ElasticAPM
       its(:type) { should be 'custom' }
       its(:transaction_id) { should be_nil }
       its(:timestamp) { should be_nil }
+      its(:trace_id) { should be_nil }
       its(:parent_id) { should be_nil }
       its(:context) { should be_nil }
 
-      context 'with a transaction' do
-        let(:transaction) { Transaction.new }
+      context 'with a trace context' do
+        it 'creates a child trace context' do
+          trace_context =
+            TraceContext.parse("00-#{'1' * 32}-#{'2' * 16}-01")
+          span = Span.new 'Spannest name', trace_context: trace_context
 
-        subject do
-          described_class.new 'Spannest name', transaction: transaction
+          expect(span.trace_context.version).to eq trace_context.version
+          expect(span.trace_context.trace_id).to eq trace_context.trace_id
+          expect(span.trace_context.span_id).to_not eq trace_context.span_id
+          expect(span.trace_context.span_id).to match(/.{16}/)
+          expect(span.trace_context.flags).to eq trace_context.flags
         end
-
-        its(:transaction_id) { should be transaction.id }
-        its(:timestamp) { should be transaction.timestamp }
       end
     end
 
     describe '#start', :mock_time do
       let(:transaction) { Transaction.new }
 
-      subject { described_class.new('Span', transaction: transaction) }
+      subject { described_class.new('Span') }
 
       it 'has a relative and absolute start time', :mock_time do
         transaction.start
@@ -40,7 +44,7 @@ module ElasticAPM
     describe '#stopped', :mock_time do
       let(:transaction) { Transaction.new }
 
-      subject { described_class.new('Span', transaction: transaction) }
+      subject { described_class.new('Span') }
 
       it 'sets duration' do
         transaction.start
@@ -54,7 +58,6 @@ module ElasticAPM
     end
 
     describe '#done', :mock_time do
-      let(:transaction) { Transaction.new }
       let(:duration) { 100 }
       let(:span_frames_min_duration) { '5ms' }
       let(:config) do
@@ -64,13 +67,11 @@ module ElasticAPM
       subject do
         described_class.new(
           'Span',
-          transaction: transaction,
           stacktrace_builder: StacktraceBuilder.new(config)
         )
       end
 
       before do
-        transaction.start
         subject.original_backtrace = caller
         subject.start
         travel duration

--- a/spec/elastic_apm/trace_context_spec.rb
+++ b/spec/elastic_apm/trace_context_spec.rb
@@ -4,23 +4,15 @@ require 'spec_helper'
 
 module ElasticAPM
   RSpec.describe TraceContext do
-    describe '.from' do
+    describe '.for_transaction' do
       let(:transaction) { Transaction.new }
 
-      subject { described_class.from transaction: transaction }
+      subject { described_class.for_transaction transaction }
 
       its(:version) { should be '00' }
       its(:trace_id) { should match(/.{16}/) }
       its(:span_id) { should be transaction.id }
       it { should be_recorded }
-
-      context 'with a span' do
-        let(:span) { Span.new 'things' }
-
-        subject { described_class.from transaction: transaction, span: span }
-
-        its(:span_id) { should be span.id }
-      end
     end
 
     describe '.parse' do

--- a/spec/elastic_apm/transport/serializers/span_serializer_spec.rb
+++ b/spec/elastic_apm/transport/serializers/span_serializer_spec.rb
@@ -11,7 +11,7 @@ module ElasticAPM
         describe '#build', :mock_time do
           let(:transaction) { Transaction.new.start }
           let :span do
-            Span.new('Span', transaction: transaction).tap do |span|
+            Span.new('Span', transaction_id: transaction.id).tap do |span|
               span.start
               travel 100
               span.stop


### PR DESCRIPTION
Removes parent from the individual span