### PR TITLE
Ensure that authentication/authorization material is also ignored

### DIFF
--- a/lib/elastic_apm/transport/filters/secrets_filter.rb
+++ b/lib/elastic_apm/transport/filters/secrets_filter.rb
@@ -9,6 +9,7 @@ module ElasticAPM
 
         KEY_FILTERS = [
           /passw(or)?d/i,
+          /auth/i,
           /^pw$/,
           /secret/i,
           /token/i,


### PR DESCRIPTION
The agent shouldn't be sending along Authorization or Authentication headers, keys, or params.