### PR TITLE
Generate traces by default in `start_span`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 
 - Rename `Traceparent` object to `TraceContext` ([#271](https://github.com/elastic/apm-agent-ruby/pull/271))
 
+### Fixed
+
+- An issue where Spans would not get Stacktraces attached ([#282](https://github.com/elastic/apm-agent-ruby/pull/282))
+
 ## 2.1.2 (2018-12-07)
 
 ### Fixed

--- a/lib/elastic_apm/agent.rb
+++ b/lib/elastic_apm/agent.rb
@@ -54,7 +54,9 @@ module ElasticAPM
       @error_builder = ErrorBuilder.new(self)
 
       @transport = Transport::Base.new(config)
-      @instrumenter = Instrumenter.new(config, stacktrace_builder) { |event| enqueue event }
+      @instrumenter = Instrumenter.new(config, stacktrace_builder) do |event|
+        enqueue event
+      end
     end
 
     attr_reader :config, :transport, :instrumenter,

--- a/lib/elastic_apm/agent.rb
+++ b/lib/elastic_apm/agent.rb
@@ -54,9 +54,9 @@ module ElasticAPM
       @error_builder = ErrorBuilder.new(self)
 
       @transport = Transport::Base.new(config)
-      @instrumenter = Instrumenter.new(config, stacktrace_builder) do |event|
-        enqueue event
-      end
+      @instrumenter = Instrumenter.new(
+        config, stacktrace_builder: stacktrace_builder
+      ) { |event| enqueue event }
     end
 
     attr_reader :config, :transport, :instrumenter,

--- a/lib/elastic_apm/agent.rb
+++ b/lib/elastic_apm/agent.rb
@@ -49,12 +49,12 @@ module ElasticAPM
     def initialize(config)
       @config = config
 
-      @transport = Transport::Base.new(config)
-      @instrumenter = Instrumenter.new(config) { |event| enqueue event }
-
       @stacktrace_builder = StacktraceBuilder.new(config)
       @context_builder = ContextBuilder.new(config)
       @error_builder = ErrorBuilder.new(self)
+
+      @transport = Transport::Base.new(config)
+      @instrumenter = Instrumenter.new(config, stacktrace_builder) { |event| enqueue event }
     end
 
     attr_reader :config, :transport, :instrumenter,

--- a/lib/elastic_apm/instrumenter.rb
+++ b/lib/elastic_apm/instrumenter.rb
@@ -38,14 +38,15 @@ module ElasticAPM
       end
     end
 
-    def initialize(config, &enqueue)
+    def initialize(config, stacktrace_builder, &enqueue)
       @config = config
+      @stacktrace_builder = stacktrace_builder
       @enqueue = enqueue
 
       @current = Current.new
     end
 
-    attr_reader :config, :enqueue
+    attr_reader :config, :stacktrace_builder, :enqueue
 
     def start
       debug 'Starting instrumenter'
@@ -149,7 +150,8 @@ module ElasticAPM
         transaction_id: transaction.id,
         parent_id: parent.id,
         context: context,
-        trace_context: parent.trace_context
+        trace_context: parent.trace_context,
+        stacktrace_builder: stacktrace_builder
       )
 
       if backtrace && span_frames_min_duration?

--- a/lib/elastic_apm/instrumenter.rb
+++ b/lib/elastic_apm/instrumenter.rb
@@ -38,7 +38,7 @@ module ElasticAPM
       end
     end
 
-    def initialize(config, stacktrace_builder, &enqueue)
+    def initialize(config, stacktrace_builder:, &enqueue)
       @config = config
       @stacktrace_builder = stacktrace_builder
       @enqueue = enqueue

--- a/spec/elastic_apm/instrumenter_spec.rb
+++ b/spec/elastic_apm/instrumenter_spec.rb
@@ -3,10 +3,11 @@
 module ElasticAPM
   RSpec.describe Instrumenter, :intercept do
     let(:config) { Config.new }
+    let(:stacktrace_builder) { StacktraceBuilder.new(config) }
     let(:callback) { ->(*_) {} }
     before { allow(callback).to receive(:call) }
 
-    subject { Instrumenter.new(config, &callback) }
+    subject { Instrumenter.new(config, stacktrace_builder, &callback) }
 
     context 'life cycle' do
       describe '#stop' do

--- a/spec/elastic_apm/instrumenter_spec.rb
+++ b/spec/elastic_apm/instrumenter_spec.rb
@@ -7,7 +7,13 @@ module ElasticAPM
     let(:callback) { ->(*_) {} }
     before { allow(callback).to receive(:call) }
 
-    subject { Instrumenter.new(config, stacktrace_builder, &callback) }
+    subject do
+      Instrumenter.new(
+        config,
+        stacktrace_builder: stacktrace_builder,
+        &callback
+      )
+    end
 
     context 'life cycle' do
       describe '#stop' do

--- a/spec/elastic_apm_spec.rb
+++ b/spec/elastic_apm_spec.rb
@@ -111,6 +111,15 @@ RSpec.describe ElasticAPM do
         expect(span2.name).to be 'All the way down'
       end
 
+      it 'includes stacktraces by default' do
+        allow(agent.config).to receive(:span_frames_min_duration_us).and_return(-1)
+
+        subject
+
+        expect(placeholder.spans.length).to be 2
+        expect(placeholder.spans.map(&:stacktrace)).to all(be_a(ElasticAPM::Stacktrace))
+      end
+
       it { should be 'original result' }
     end
 

--- a/spec/elastic_apm_spec.rb
+++ b/spec/elastic_apm_spec.rb
@@ -112,12 +112,13 @@ RSpec.describe ElasticAPM do
       end
 
       it 'includes stacktraces by default' do
-        allow(agent.config).to receive(:span_frames_min_duration_us).and_return(-1)
+        allow(agent.config).to receive(:span_frames_min_duration_us) { -1 }
 
         subject
 
         expect(placeholder.spans.length).to be 2
-        expect(placeholder.spans.map(&:stacktrace)).to all(be_a(ElasticAPM::Stacktrace))
+        expect(placeholder.spans.map(&:stacktrace))
+          .to all(be_a(ElasticAPM::Stacktrace))
       end
 
       it { should be 'original result' }


### PR DESCRIPTION
I wasn't seeing traces while testing APM in Swiftype's on-prem build.
This fixes the issue by passing `stacktrace_builder` when creating
spans.