### PR TITLE
JRuby performance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 ### Fixed
 
 - An issue where Spans would not get Stacktraces attached ([#282](https://github.com/elastic/apm-agent-ruby/pull/282))
+- Skip `caller` unless needed ([#287](https://github.com/elastic/apm-agent-ruby/pull/283))
 
 ## 2.1.2 (2018-12-07)
 

--- a/lib/elastic_apm.rb
+++ b/lib/elastic_apm.rb
@@ -230,7 +230,7 @@ module ElasticAPM # rubocop:disable Metrics/ModuleLength
         break unless span && include_stacktrace
         break unless agent.config.span_frames_min_duration?
 
-        span.original_backtrace = caller
+        span.original_backtrace ||= caller
       end
     end
 

--- a/lib/elastic_apm.rb
+++ b/lib/elastic_apm.rb
@@ -225,9 +225,13 @@ module ElasticAPM # rubocop:disable Metrics/ModuleLength
         name,
         type,
         context: context,
-        backtrace: include_stacktrace ? caller : nil,
         trace_context: trace_context
-      )
+      ).tap do |span|
+        break unless span && include_stacktrace
+        break unless agent.config.span_frames_min_duration?
+
+        span.original_backtrace = caller
+      end
     end
 
     # Ends the current span

--- a/lib/elastic_apm/config.rb
+++ b/lib/elastic_apm/config.rb
@@ -241,6 +241,10 @@ module ElasticAPM
       @span_frames_min_duration_us = duration * 1_000_000
     end
 
+    def span_frames_min_duration?
+      span_frames_min_duration != 0
+    end
+
     DEPRECATED_OPTIONS = %i[
       compression_level=
       compression_minimum_size=

--- a/lib/elastic_apm/instrumenter.rb
+++ b/lib/elastic_apm/instrumenter.rb
@@ -160,7 +160,7 @@ module ElasticAPM
         trace_context: trace_context || parent.trace_context.child
       )
 
-      if backtrace
+      if backtrace && config.span_frames_min_duration?
         span.original_backtrace = backtrace
       end
 

--- a/lib/elastic_apm/instrumenter.rb
+++ b/lib/elastic_apm/instrumenter.rb
@@ -160,7 +160,7 @@ module ElasticAPM
         trace_context: trace_context || parent.trace_context.child
       )
 
-      if backtrace && span_frames_min_duration?
+      if backtrace
         span.original_backtrace = backtrace
       end
 
@@ -210,10 +210,6 @@ module ElasticAPM
 
     def random_sample?
       rand <= config.transaction_sample_rate
-    end
-
-    def span_frames_min_duration?
-      config.span_frames_min_duration != 0
     end
   end
   # rubocop:enable Metrics/ClassLength

--- a/lib/elastic_apm/span.rb
+++ b/lib/elastic_apm/span.rb
@@ -58,6 +58,8 @@ module ElasticAPM
     def done(end_time: Util.micros)
       stop end_time
 
+      build_stacktrace! if should_build_stacktrace?
+
       self
     end
 
@@ -73,15 +75,6 @@ module ElasticAPM
       started? && !stopped?
     end
 
-    def stacktrace
-      return @stacktrace if defined? @stacktrace
-      @stacktrace = if should_build_stacktrace?
-        @stacktrace_builder.build(original_backtrace, type: :span).tap do
-          self.original_backtrace = nil # release it
-        end
-      end
-    end
-
     # relations
 
     def inspect
@@ -92,6 +85,11 @@ module ElasticAPM
     end
 
     private
+
+    def build_stacktrace!
+      @stacktrace = @stacktrace_builder.build(original_backtrace, type: :span)
+      self.original_backtrace = nil # release original
+    end
 
     def should_build_stacktrace?
       @stacktrace_builder && original_backtrace && long_enough_for_stacktrace?

--- a/spec/elastic_apm/instrumenter_spec.rb
+++ b/spec/elastic_apm/instrumenter_spec.rb
@@ -130,6 +130,14 @@ module ElasticAPM
           expect(subject.current_span).to eq span
         end
 
+        context 'with a backtrace' do
+          it 'saves original backtrace for later' do
+            backtrace = caller
+            span = subject.start_span 'Span', backtrace: backtrace
+            expect(span.original_backtrace).to eq backtrace
+          end
+        end
+
         context 'inside another span' do
           it 'sets current span as parent' do
             parent = subject.start_span 'Level 1'

--- a/spec/elastic_apm/instrumenter_spec.rb
+++ b/spec/elastic_apm/instrumenter_spec.rb
@@ -139,14 +139,6 @@ module ElasticAPM
           end
         end
 
-        context 'with a backtrace' do
-          it 'saves original backtrace for later' do
-            backtrace = caller
-            span = subject.start_span 'Span', backtrace: backtrace
-            expect(span.original_backtrace).to eq backtrace
-          end
-        end
-
         context 'when max spans reached' do
           let(:config) { Config.new(transaction_max_spans: 1) }
           before do


### PR DESCRIPTION
The agent added more overhead than I expected to our JRuby app. I believe
the main issue is `caller` is just slow on JRuby 😞 I couldn't find any better
fix than skipping the call if the span isn't sampled. It would be nice to have a
separate setting for stacktrace sample rate, but I didn't want to go down that
path before bringing up the issue.

The second commit moves stacktrace building to the worker thread. Not as
important but I thought it made sense.