### PR TITLE
Support for erb style on config file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 
 - Support for [OpenTracing](https://opentracing.io) ([#273](https://github.com/elastic/apm-agent-ruby/pull/273))
 - Add capture_* options ([#279](https://github.com/elastic/apm-agent-ruby/pull/279))
+- Support ERB tags in config file ([#286](https://github.com/elastic/apm-agent-ruby/pull/286))
 
 ### Changed
 

--- a/docs/configuration.asciidoc
+++ b/docs/configuration.asciidoc
@@ -16,7 +16,7 @@ The recommended way to configure Elastic APM is to create a file
 ----
 ---
 server_url: 'http://localhost:8200'
-secret_token: 'very_very_secret'
+secret_token: <%= ENV["VERY_SECRET_TOKEN"] %>
 ----
 
 Options are applied in the following order (last one wins):

--- a/lib/elastic_apm/config.rb
+++ b/lib/elastic_apm/config.rb
@@ -319,7 +319,7 @@ module ElasticAPM
 
     def set_from_config_file
       return unless File.exist?(config_file)
-      assign(YAML.load_file(config_file) || {})
+      assign(YAML.load(ERB.new(File.read(config_file)).result) || {})
     rescue ConfigError => e
       alert_logger.warn format(
         'Failed to configure from config file: %s',

--- a/lib/elastic_apm/config.rb
+++ b/lib/elastic_apm/config.rb
@@ -2,6 +2,7 @@
 
 require 'logger'
 require 'yaml'
+require 'erb'
 
 require 'elastic_apm/util/prefixed_logger'
 require 'elastic_apm/config/duration'

--- a/lib/elastic_apm/config.rb
+++ b/lib/elastic_apm/config.rb
@@ -319,7 +319,7 @@ module ElasticAPM
 
     def set_from_config_file
       return unless File.exist?(config_file)
-      assign(YAML.load(ERB.new(File.read(config_file)).result) || {})
+      assign(YAML.safe_load(ERB.new(File.read(config_file)).result) || {})
     rescue ConfigError => e
       alert_logger.warn format(
         'Failed to configure from config file: %s',

--- a/spec/elastic_apm/config_spec.rb
+++ b/spec/elastic_apm/config_spec.rb
@@ -17,6 +17,11 @@ module ElasticAPM
       expect(config.server_url).to eq 'somewhere-config.com'
     end
 
+    it 'loads from erb-styled config file' do
+      config = Config.new(config_file: 'spec/fixtures/elastic_apm_erb.yml')
+      expect(config.server_url).to eq 'somewhere-config.com'
+    end
+
     it 'takes options from ENV' do
       ENV['ELASTIC_APM_SERVER_URL'] = 'by-env!'
       config = Config.new

--- a/spec/fixtures/elastic_apm_erb.yml
+++ b/spec/fixtures/elastic_apm_erb.yml
@@ -1,0 +1,2 @@
+---
+server_url: <%= 'somewhere-config.com' %>


### PR DESCRIPTION
This PR adds support to erb styled variables on config file

[Issue 212](https://github.com/elastic/apm-agent-ruby/issues/212)