### PR TITLE
Add Compatibility for Optional CA Cert

### DIFF
--- a/docs/configuration.asciidoc
+++ b/docs/configuration.asciidoc
@@ -129,7 +129,7 @@ WARNING: Secret tokens only provide any real security if your APM server use TLS
 
 Maximum amount of objects kept in queue, before sending to APM Server.
 
-If you hit this limit you either have to increase the agent's 
+If you hit this limit you either have to increase the agent's
 <<config-pool-size,worker pool size>> or it could mean the agent has trouble
 connecting to APM Server. The <<config-log-path,logs>> should tell you what
 went wrong.
@@ -511,6 +511,20 @@ Set it to `-1` to collect stack traces for all spans.
 Set it to `0` to disable stack trace collection for all spans.
 
 It has to be provided in *<<config-format-duration, duration format>>*.
+
+[float]
+[[config-ssl-ca-cert]]
+==== `ssl_ca_cert`
+
+[options="header"]
+|============
+| Environment                | `Config` key    | Default | Example
+| `ELASTIC_APM_SSL_CA_CERT`  | `ssl_ca_cert`   | `nil`   | /path/to/ca.pem
+|============
+
+This parameter should contain the path to a .pem formatted CA certificate. This
+allows verification of self-signed certificates instead of disabling server
+certificate verification.
 
 [float]
 [[config-transaction-max-spans]]

--- a/lib/elastic_apm/config.rb
+++ b/lib/elastic_apm/config.rb
@@ -47,6 +47,7 @@ module ElasticAPM
       source_lines_span_app_frames: 5,
       source_lines_span_library_frames: 0,
       span_frames_min_duration: '5ms',
+      ssl_ca_cert: nil,
       transaction_max_spans: 500,
       transaction_sample_rate: 1.0,
       verify_server_cert: true,
@@ -92,6 +93,7 @@ module ElasticAPM
       'ELASTIC_APM_SOURCE_LINES_SPAN_LIBRARY_FRAMES' =>
         [:int, 'source_lines_span_library_frames'],
       'ELASTIC_APM_SPAN_FRAMES_MIN_DURATION' => 'span_frames_min_duration',
+      'ELASTIC_APM_SSL_CA_CERT' => 'ssl_ca_cert',
       'ELASTIC_APM_TRANSACTION_MAX_SPANS' => [:int, 'transaction_max_spans'],
       'ELASTIC_APM_TRANSACTION_SAMPLE_RATE' =>
         [:float, 'transaction_sample_rate'],
@@ -162,6 +164,7 @@ module ElasticAPM
     attr_accessor :source_lines_error_library_frames
     attr_accessor :source_lines_span_app_frames
     attr_accessor :source_lines_span_library_frames
+    attr_accessor :ssl_ca_cert
     attr_accessor :transaction_max_spans
     attr_accessor :transaction_sample_rate
     attr_accessor :verify_server_cert

--- a/lib/elastic_apm/transport/connection.rb
+++ b/lib/elastic_apm/transport/connection.rb
@@ -41,6 +41,16 @@ module ElasticAPM
           headers['Authorization'] = "Bearer #{token}"
         end
 
+        # Set SSL CA Cert
+        if config.use_ssl? && config.ssl_ca_cert
+          ssl_ctx = OpenSSL::SSL::SSLContext.new
+          ssl_ctx.ca_file = config.ssl_ca_cert
+
+          # include SSL context in default options
+          client_options = HTTP.default_options.merge(ssl_context: ssl_ctx)
+          HTTP.default_options = client_options
+        end
+
         @client = HTTP.headers(headers).persistent(@url)
 
         @mutex = Mutex.new


### PR DESCRIPTION
# Overview

Providing a CA cert allows the use of a
self-signed server certificate without disabling
certificate verification.

This adds an optional `ssl_ca_cert` parameter and
conditionally adds it to the default_options
hash of HTTP.rb. That includes it automatically
in the connection and subsequent requests.

## Changes

- Adds a new optional config parameter, `ssl_ca_cert`
- Adds a new environment variable config parameter, `ELASTIC_APM_SSL_CA_CERT`
- Adds the `ssl_ca_cert` path value to the HTTP.rb default options in an OpenSSL::SSL::SSLContext variable to allow OpenSSL to verify the APM Server certificate against the provided CA cert

## Usage

The path to the CA file can be specified using the parameter name explicitly, through the file, or by environment variable. 

### Config Variable

```ruby
ElasticAPM::Config.new(ssl_ca_cert: "/path/to/ca.pem")
```

### Config File

```yaml
---
service_name: "MyApp"
pool_size: 2 
ssl_ca_cert: "/path/to/ca.pem"
```

### Environment Variable

```shell
# .env
ELASTIC_APM_SSL_CA_CERT=/path/to/ca.pem
```

## Related Issues

Closes #301.