### PR TITLE
Store parent_id and id in trace_context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 ### Fixed
 
 - Reading CPU stats from /proc/stat on RHEL ([#312](https://github.com/elastic/apm-agent-ruby/pull/312))
+- Changing TraceContext to differentiate between `id` and `parent_id` ([#326](https://github.com/elastic/apm-agent-ruby/pull/326))
 
 ## 2.3.1 (2019-01-31)
 

--- a/lib/elastic_apm/instrumenter.rb
+++ b/lib/elastic_apm/instrumenter.rb
@@ -152,13 +152,12 @@ module ElasticAPM
       parent = current_span || transaction
 
       span = Span.new(
-        name,
-        type,
+        name: name,
         transaction_id: transaction.id,
-        parent_id: parent.id,
+        trace_context: trace_context || parent.trace_context.child,
+        type: type,
         context: context,
-        stacktrace_builder: stacktrace_builder,
-        trace_context: trace_context || parent.trace_context.child
+        stacktrace_builder: stacktrace_builder
       )
 
       if backtrace && config.span_frames_min_duration?

--- a/lib/elastic_apm/opentracing.rb
+++ b/lib/elastic_apm/opentracing.rb
@@ -93,28 +93,20 @@ module ElasticAPM
 
     # @api private
     class SpanContext
-      def initialize(id:, trace_id:, baggage: nil)
+      def initialize(trace_context:, baggage: nil)
         if baggage
           ElasticAPM.agent.config.logger.warn(
             'Baggage is not supported by ElasticAPM'
           )
         end
 
-        @id = id
-        @trace_id = trace_id
-        @trace_context =
-          ElasticAPM::TraceContext.new(trace_id: trace_id, span_id: id)
+        @trace_context = trace_context
       end
 
-      attr_accessor :id, :trace_id, :trace_context
+      attr_accessor :trace_context
 
       def self.from_trace_context(trace_context)
-        new(
-          trace_id: trace_context.trace_id,
-          id: trace_context.span_id
-        ).tap do |span_context|
-          span_context.trace_context = trace_context
-        end
+        new(trace_context: trace_context)
       end
     end
 

--- a/lib/elastic_apm/span.rb
+++ b/lib/elastic_apm/span.rb
@@ -1,47 +1,41 @@
 # frozen_string_literal: true
 
 require 'securerandom'
+require 'forwardable'
 
 require 'elastic_apm/span/context'
 
 module ElasticAPM
   # @api private
   class Span
+    extend Forwardable
+
+    def_delegators :@trace_context, :trace_id, :parent_id, :id
+
     DEFAULT_TYPE = 'custom'
 
     # rubocop:disable Metrics/ParameterLists
     def initialize(
-      name,
-      type = nil,
-      transaction_id: nil,
-      parent_id: nil,
+      name:,
+      transaction_id:,
+      trace_context:,
+      type: nil,
       context: nil,
-      stacktrace_builder: nil,
-      trace_context: nil
+      stacktrace_builder: nil
     )
       @name = name
       @type = type || DEFAULT_TYPE
 
       @transaction_id = transaction_id
-
-      @parent_id = parent_id
-      @trace_context = trace_context || TraceContext.for_span
+      @trace_context = trace_context
 
       @context = context || Span::Context.new
       @stacktrace_builder = stacktrace_builder
     end
     # rubocop:enable Metrics/ParameterLists
 
-    attr_accessor :name, :type, :original_backtrace, :parent_id, :trace_context
+    attr_accessor :name, :type, :original_backtrace, :trace_context
     attr_reader :context, :stacktrace, :duration, :timestamp, :transaction_id
-
-    def id
-      trace_context&.span_id
-    end
-
-    def trace_id
-      trace_context&.trace_id
-    end
 
     # life cycle
 

--- a/lib/elastic_apm/transaction.rb
+++ b/lib/elastic_apm/transaction.rb
@@ -9,7 +9,8 @@ module ElasticAPM
     extend Deprecations
     extend Forwardable
 
-    def_delegators :@trace_context, :trace_id, :parent_id, :id
+    def_delegators :@trace_context,
+      :trace_id, :parent_id, :id, :ensure_parent_id
 
     DEFAULT_TYPE = 'custom'
 
@@ -30,8 +31,7 @@ module ElasticAPM
       @context = context || Context.new # TODO: Lazy generate this?
       Util.reverse_merge!(@context.tags, tags) if tags
 
-      @trace_context = trace_context ||
-                       TraceContext.for_transaction(sampled: sampled)
+      @trace_context = trace_context || TraceContext.new(recorded: sampled)
 
       @started_spans = 0
       @dropped_spans = 0
@@ -58,10 +58,6 @@ module ElasticAPM
     end
 
     deprecate :done?, :stopped?
-
-    def ensure_parent_id
-      trace_context.ensure_parent_id
-    end
 
     # life cycle
 

--- a/spec/elastic_apm/middleware_spec.rb
+++ b/spec/elastic_apm/middleware_spec.rb
@@ -86,7 +86,7 @@ module ElasticAPM
           expect(trace_context.version).to eq '00'
           expect(trace_context.trace_id)
             .to eq '0af7651916cd43dd8448eb211c80319c'
-          expect(trace_context.span_id).to eq 'b7ad6b7169203331'
+          expect(trace_context.parent_id).to eq 'b7ad6b7169203331'
           expect(trace_context).to_not be_recorded
         end
       end
@@ -104,7 +104,7 @@ module ElasticAPM
           trace_context = @intercepted.transactions.first.trace_context
           expect(trace_context.trace_id)
             .to_not eq '0af7651916cd43dd8448eb211c80319c'
-          expect(trace_context.span_id).to_not match(/INVALID/)
+          expect(trace_context.parent_id).to_not match(/INVALID/)
         end
       end
 

--- a/spec/elastic_apm/trace_context_spec.rb
+++ b/spec/elastic_apm/trace_context_spec.rb
@@ -11,7 +11,8 @@ module ElasticAPM
 
       its(:version) { should be '00' }
       its(:trace_id) { should match(/.{16}/) }
-      its(:span_id) { should match(/.{8}/) }
+      its(:id) { should match(/.{8}/) }
+      its(:parent_id) { should be_nil }
       it { should be_recorded }
     end
 
@@ -24,7 +25,9 @@ module ElasticAPM
         it { expect { subject }.to_not raise_error }
         its(:version) { should eq '00' }
         its(:trace_id) { should eq '0af7651916cd43dd8448eb211c80319c' }
-        its(:span_id) { should eq 'b7ad6b7169203331' }
+        its(:parent_id) { should eq 'b7ad6b7169203331' }
+        its(:id) { should_not be_nil }
+        its(:id) { should_not eq 'b7ad6b7169203331' }
         its(:flags) { should eq '00000000' }
       end
 
@@ -74,11 +77,45 @@ module ElasticAPM
       end
     end
 
+    describe '#ensure_parent_id' do
+      let(:parent_id) { nil }
+      subject(:tc) { described_class.new span_id: parent_id }
+
+      context 'parent_id set' do
+        let(:parent_id) { 'b7ad6b7169203331' }
+        it "doesn't change parent_id" do
+          expect(tc.ensure_parent_id).to eq parent_id
+          expect(tc.parent_id).to eq parent_id
+        end
+      end
+
+      it 'sets and returns parent_id' do
+        pid = tc.ensure_parent_id
+        expect(tc.parent_id).to eq pid
+      end
+    end
+
+    describe '#child' do
+      let(:header) { '00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-00' }
+      subject(:tc) { described_class.parse header }
+      subject(:tc) do
+        described_class.new span_id: 'b7ad6b7169203331', id: 'c8ad6b7169203331'
+      end
+
+      it 'sets id and parent_id' do
+        child = tc.child
+        expect(tc.parent_id).to eq 'b7ad6b7169203331'
+        expect(tc.id).to eq 'c8ad6b7169203331'
+        expect(child.parent_id).to eq 'c8ad6b7169203331'
+        expect(child.id).not_to eq tc.parent_id
+      end
+    end
+
     describe '#to_header' do
       subject do
         described_class.new.tap do |tp|
           tp.trace_id = '1' * 32
-          tp.span_id = '2' * 16
+          tp.id = '2' * 16
           tp.flags = '00000011'
         end
       end

--- a/spec/elastic_apm/trace_context_spec.rb
+++ b/spec/elastic_apm/trace_context_spec.rb
@@ -4,10 +4,10 @@ require 'spec_helper'
 
 module ElasticAPM
   RSpec.describe TraceContext do
-    describe '.for_transaction' do
+    describe '.new' do
       let(:transaction) { Transaction.new }
 
-      subject { described_class.for_transaction }
+      subject { described_class.new }
 
       its(:version) { should be '00' }
       its(:trace_id) { should match(/.{16}/) }

--- a/spec/elastic_apm/transaction_spec.rb
+++ b/spec/elastic_apm/transaction_spec.rb
@@ -59,9 +59,9 @@ module ElasticAPM
         expect(subject.parent_id).to be parent_id
       end
 
-      it 'keeps and returns current if set' do
+      it 'keeps and returns current parent id if set' do
         trace_context = TraceContext.new
-        trace_context.span_id = 'things'
+        trace_context.parent_id = 'things'
         subject = Transaction.new trace_context: trace_context
 
         parent_id = subject.ensure_parent_id

--- a/spec/elastic_apm/transport/serializers/span_serializer_spec.rb
+++ b/spec/elastic_apm/transport/serializers/span_serializer_spec.rb
@@ -10,8 +10,12 @@ module ElasticAPM
 
         describe '#build', :mock_time do
           let(:transaction) { Transaction.new.start }
+          let(:tc) { TraceContext.parse("00-#{'1' * 32}-#{'2' * 16}-01") }
           let :span do
-            Span.new('Span', transaction_id: transaction.id).tap do |span|
+            Span.new(name: 'Span',
+                     transaction_id: transaction.id,
+                     trace_context: tc)
+                .tap do |span|
               span.start
               travel 100
               span.stop
@@ -39,13 +43,13 @@ module ElasticAPM
 
           context 'with a context' do
             let(:span) do
-              Span.new(
-                'Span',
-                context: Span::Context.new(
-                  db: { statement: 'asd' },
-                  http: { url: 'dsa' }
-                )
-              )
+              Span.new(name: 'Span',
+                       transaction_id: transaction.id,
+                       trace_context: tc,
+                       context: Span::Context.new(
+                         db: { statement: 'asd' },
+                         http: { url: 'dsa' }
+                       ))
             end
 
             it 'adds context object' do

--- a/spec/elastic_apm/transport/serializers_spec.rb
+++ b/spec/elastic_apm/transport/serializers_spec.rb
@@ -17,7 +17,10 @@ module ElasticAPM
       describe '#serialize' do
         it 'serializes known objects' do
           expect(subject.serialize(Transaction.new)).to be_a Hash
-          expect(subject.serialize(Span.new('Name'))).to be_a Hash
+          expect(subject.serialize(Span.new(name: 'Name',
+                                            transaction_id: '',
+                                            trace_context: TraceContext.new)))
+            .to be_a Hash
           expect(subject.serialize(Error.new)).to be_a Hash
         end
 

--- a/spec/integration/opentracing_spec.rb
+++ b/spec/integration/opentracing_spec.rb
@@ -245,7 +245,11 @@ RSpec.describe 'OpenTracing bridge', :intercept do
       end
 
       context 'when span' do
-        let(:elastic_span) { ElasticAPM::Span.new 'Not test' }
+        let(:elastic_span) do
+          ElasticAPM::Span.new(name: 'Span',
+                               transaction_id: 'transaction_id',
+                               trace_context: trace_context)
+        end
         let(:trace_context) { nil }
 
         it_behaves_like :opengraph_span


### PR DESCRIPTION
The `TraceContext` did only define a `span_id` which was used as `id` and as `parent_id` at the same time in a transaction. This PR intends to clearly separate `id` used in `transaction` and `span` events from the `parent_id` parsed from the request headers. 

fixes #322