### PR TITLE
Keep request.body as object when form data

### DIFF
--- a/lib/elastic_apm/context_builder.rb
+++ b/lib/elastic_apm/context_builder.rb
@@ -43,9 +43,16 @@ module ElasticAPM
     # rubocop:enable Metrics/MethodLength, Metrics/AbcSize
 
     def get_body(req)
-      body = req.body.read
-      req.body.rewind
-      body.byteslice(0, MAX_BODY_LENGTH)
+      case req.media_type
+      when 'application/x-www-form-urlencoded'
+        req.POST
+      when 'multipart/form-data'
+        req.POST
+      else
+        body = req.body.read
+        req.body.rewind
+        body.byteslice(0, MAX_BODY_LENGTH)
+      end
     end
 
     def rails_req?(env)

--- a/lib/elastic_apm/transport/filters/secrets_filter.rb
+++ b/lib/elastic_apm/transport/filters/secrets_filter.rb
@@ -28,30 +28,24 @@ module ElasticAPM
         end
 
         def call(payload)
-          strip_from payload.dig(:transaction, :context, :request, :headers)
-          strip_from payload.dig(:transaction, :context, :response, :headers)
-          strip_from payload.dig(:error, :context, :request, :headers)
-          strip_from payload.dig(:error, :context, :response, :headers)
-          strip_from payload.dig(:transaction, :context, :request, :body)
+          strip_from! payload.dig(:transaction, :context, :request, :headers)
+          strip_from! payload.dig(:transaction, :context, :response, :headers)
+          strip_from! payload.dig(:error, :context, :request, :headers)
+          strip_from! payload.dig(:error, :context, :response, :headers)
+          strip_from! payload.dig(:transaction, :context, :request, :body)
 
           payload
         end
 
-        # rubocop:disable Metrics/MethodLength
-        def strip_from(obj)
-          case obj
-          when Hash
-            obj.each do |k, v|
-              if filter_key?(k) || filter_value?(v)
-                obj[k] = FILTERED
-              end
+        def strip_from!(obj)
+          return unless obj && obj.is_a?(Hash)
+
+          obj.each do |k, v|
+            if filter_key?(k) || filter_value?(v)
+              obj[k] = FILTERED
             end
-          when String
-            return unless obj.include?('=')
-            obj.gsub!(/=([^&=]+)/, "=#{FILTERED}")
           end
         end
-        # rubocop:enable Metrics/MethodLength
 
         def filter_key?(key)
           @key_filters.any? { |regex| key.match regex }

--- a/spec/elastic_apm/context_builder_spec.rb
+++ b/spec/elastic_apm/context_builder_spec.rb
@@ -39,13 +39,13 @@ module ElasticAPM
         it 'includes body' do
           env = Rack::MockRequest.env_for(
             '/',
-            'CONTENT_TYPE' => 'application/x-www-form-urlencoded',
-            input: 'asd=123'
+            method: 'POST',
+            params: { thing: 123 }
           )
 
           result = subject.build(env)
 
-          expect(result.request.body).to eq 'asd=123'
+          expect(result.request.body).to eq('thing' => '123')
         end
       end
 
@@ -67,8 +67,8 @@ module ElasticAPM
 
             result = subject.build(env)
 
-            expect(result.request.body).to match(/Content-Disposition/)
-            expect(result.request.body.bytesize).to be 2048
+            expect(result.request.body).to match('file' => Hash)
+            expect(result.request.body['file'][:type]).to eq 'binary'
           end
         end
       end

--- a/spec/elastic_apm/transport/filters/secrets_filter_spec.rb
+++ b/spec/elastic_apm/transport/filters/secrets_filter_spec.rb
@@ -45,13 +45,13 @@ module ElasticAPM
 
         it 'removes secrets from form bodies' do
           payload = { transaction: { context: { request: {
-            body: +'api_key=secret&credit_card=4111111111111111'
+            body: { 'api_key' => 'super-secret', 'other' => 'not me' }
           } } } }
 
           subject.call(payload)
 
           body = payload.dig(:transaction, :context, :request, :body)
-          expect(body).to eq('api_key=[FILTERED]&credit_card=[FILTERED]')
+          expect(body).to match('api_key' => '[FILTERED]', 'other' => 'not me')
         end
 
         context 'with custom_key_filters' do


### PR DESCRIPTION
This changes request.body back to the object we get from Rack, making it way easier to sanitize. If not form data we leave the body untouched.