### PR TITLE
Force encode captured bodies to utf-8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 
 - Reading CPU stats from /proc/stat on RHEL ([#312](https://github.com/elastic/apm-agent-ruby/pull/312))
 - Changing TraceContext to differentiate between `id` and `parent_id` ([#326](https://github.com/elastic/apm-agent-ruby/pull/326))
+- `capture_body` will now force encode text bodies to utf-8 when possible ([#332](https://github.com/elastic/apm-agent-ruby/pull/332))
 
 ## 2.3.1 (2019-01-31)
 

--- a/lib/elastic_apm/context_builder.rb
+++ b/lib/elastic_apm/context_builder.rb
@@ -51,7 +51,7 @@ module ElasticAPM
       else
         body = req.body.read
         req.body.rewind
-        body.byteslice(0, MAX_BODY_LENGTH)
+        body.byteslice(0, MAX_BODY_LENGTH).force_encoding('utf-8')
       end
     end
 

--- a/spec/elastic_apm/context_builder_spec.rb
+++ b/spec/elastic_apm/context_builder_spec.rb
@@ -76,7 +76,7 @@ module ElasticAPM
       context 'with JSON body' do
         let(:config) { Config.new capture_body: true }
 
-        it 'includes body' do
+        it 'includes body in utf-8' do
           env = Rack::MockRequest.env_for(
             '/',
             'CONTENT_TYPE' => 'application/json',
@@ -86,6 +86,7 @@ module ElasticAPM
           result = subject.build(env)
 
           expect(result.request.body).to eq '{"something":"everything"}'
+          expect(result.request.body.encoding).to eq Encoding::UTF_8
         end
       end
     end


### PR DESCRIPTION
Closes elastic/apm-agent-ruby#318 