### PR TITLE
Add `active` config option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 
 ## Unreleased
 
+### Added
+
+- Added the option `active` that will prevent the agent from starting if set to `false` ([#338](https://github.com/elastic/apm-agent-ruby/pull/338))
+
 ### Fixed
 
 - Fix error with `capture_body` and nested request bodies ([#339](https://github.com/elastic/apm-agent-ruby/pull/339))

--- a/docs/configuration.asciidoc
+++ b/docs/configuration.asciidoc
@@ -120,6 +120,17 @@ ruby -r securerandom -e 'print SecureRandom.uuid'
 WARNING: Secret tokens only provide any real security if your APM server use TLS.
 
 [float]
+[[config-active]]
+==== `active`
+|============
+| Environment          | `Config` key | Default
+| `ELASTIC_APM_ACTIVE` | `active`     | `true`
+|============
+
+Whether or not to start the agent.
+If `active` is `false`, `ElasticAPM.start` will do nothing and all calls to the root API will return `nil`.
+
+[float]
 [[config-api-buffer-size]]
 ==== `api_buffer_size`
 |============

--- a/lib/elastic_apm/agent.rb
+++ b/lib/elastic_apm/agent.rb
@@ -22,6 +22,7 @@ module ElasticAPM
       @instance
     end
 
+    # rubocop:disable Metrics/MethodLength
     def self.start(config)
       return @instance if @instance
 
@@ -41,6 +42,7 @@ module ElasticAPM
         @instance = new(config).start
       end
     end
+    # rubocop:enable Metrics/MethodLength
 
     def self.stop
       LOCK.synchronize do
@@ -73,7 +75,6 @@ module ElasticAPM
     attr_reader :config, :transport, :instrumenter,
       :stacktrace_builder, :context_builder, :error_builder, :metrics
 
-    # rubocop:disable Metrics/MethodLength, Metrics/AbcSize
     def start
       info '[%s] Starting agent, reporting to %s', VERSION, config.server_url
 
@@ -87,7 +88,6 @@ module ElasticAPM
 
       self
     end
-    # rubocop:enable Metrics/MethodLength, Metrics/AbcSize
 
     def stop
       debug 'Stopping agent'

--- a/lib/elastic_apm/agent.rb
+++ b/lib/elastic_apm/agent.rb
@@ -30,6 +30,14 @@ module ElasticAPM
       LOCK.synchronize do
         return @instance if @instance
 
+        unless config.active?
+          config.logger.debug format(
+            '%sAgent disabled with active: false',
+            Logging::PREFIX
+          )
+          return
+        end
+
         @instance = new(config).start
       end
     end
@@ -65,6 +73,7 @@ module ElasticAPM
     attr_reader :config, :transport, :instrumenter,
       :stacktrace_builder, :context_builder, :error_builder, :metrics
 
+    # rubocop:disable Metrics/MethodLength, Metrics/AbcSize
     def start
       info '[%s] Starting agent, reporting to %s', VERSION, config.server_url
 
@@ -78,6 +87,7 @@ module ElasticAPM
 
       self
     end
+    # rubocop:enable Metrics/MethodLength, Metrics/AbcSize
 
     def stop
       debug 'Stopping agent'

--- a/lib/elastic_apm/config.rb
+++ b/lib/elastic_apm/config.rb
@@ -19,6 +19,7 @@ module ElasticAPM
 
       server_url: 'http://localhost:8200',
 
+      active: true,
       api_buffer_size: 256,
       api_request_size: '750kb',
       api_request_time: '10s',
@@ -59,6 +60,7 @@ module ElasticAPM
       'ELASTIC_APM_SERVER_URL' => 'server_url',
       'ELASTIC_APM_SECRET_TOKEN' => 'secret_token',
 
+      'ELASTIC_APM_ACTIVE' => [:bool, 'active'],
       'ELASTIC_APM_API_BUFFER_SIZE' => [:int, 'api_buffer_size'],
       'ELASTIC_APM_API_REQUEST_SIZE' => [:int, 'api_request_size'],
       'ELASTIC_APM_API_REQUEST_TIME' => 'api_request_time',
@@ -131,6 +133,7 @@ module ElasticAPM
     attr_accessor :server_url
     attr_accessor :secret_token
 
+    attr_accessor :active
     attr_accessor :api_buffer_size
     attr_accessor :api_request_size
     attr_accessor :api_request_time
@@ -176,6 +179,7 @@ module ElasticAPM
     attr_accessor :view_paths
     attr_accessor :root_path
 
+    alias :active? :active
     alias :capture_body? :capture_body
     alias :capture_headers? :capture_headers
     alias :capture_env? :capture_env

--- a/spec/elastic_apm/agent_spec.rb
+++ b/spec/elastic_apm/agent_spec.rb
@@ -23,6 +23,15 @@ module ElasticAPM
 
           Agent.stop # clean up
         end
+
+        context 'when active: false' do
+          let(:config) { Config.new(active: false) }
+
+          it "doesn't start" do
+            Agent.start(config)
+            expect(Agent.instance).to be nil
+          end
+        end
       end
 
       describe '.stop' do


### PR DESCRIPTION
This adds a config option `active` that, when true, prohibits the agent from starting on boot.

---

See #333