### PR TITLE
Fix request bodies with nested data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Fixed
+
+- Fix error with `capture_body` and nested request bodies ([#339](https://github.com/elastic/apm-agent-ruby/pull/339))
+
 ## 2.4.0 (2019-02-27)
 
 ### Added

--- a/lib/elastic_apm/transport/filters/secrets_filter.rb
+++ b/lib/elastic_apm/transport/filters/secrets_filter.rb
@@ -37,15 +37,26 @@ module ElasticAPM
           payload
         end
 
+        # rubocop:disable Metrics/MethodLength, Metrics/CyclomaticComplexity
         def strip_from!(obj)
           return unless obj && obj.is_a?(Hash)
 
           obj.each do |k, v|
-            if filter_key?(k) || filter_value?(v)
-              obj[k] = FILTERED
+            if filter_key?(k)
+              next obj[k] = FILTERED
+            end
+
+            case v
+            when Hash
+              strip_from!(v)
+            when String
+              if filter_value?(v)
+                obj[k] = FILTERED
+              end
             end
           end
         end
+        # rubocop:enable Metrics/MethodLength, Metrics/CyclomaticComplexity
 
         def filter_key?(key)
           @key_filters.any? { |regex| key.match regex }

--- a/spec/elastic_apm/transport/filters/secrets_filter_spec.rb
+++ b/spec/elastic_apm/transport/filters/secrets_filter_spec.rb
@@ -29,7 +29,11 @@ module ElasticAPM
           payload = { transaction: { context: { response: { headers: {
             ApiKey: 'very zecret!',
             Untouched: 'very much',
-            TotallyNotACreditCard: '4111 1111 1111 1111'
+            TotallyNotACreditCard: '4111 1111 1111 1111',
+            nested: {
+              even_works_token: 'abc'
+            },
+            secret_array_for_good_measure: [1, 2, 3]
           } } } } }
 
           subject.call(payload)
@@ -39,7 +43,9 @@ module ElasticAPM
           expect(headers).to match(
             ApiKey: '[FILTERED]',
             Untouched: 'very much',
-            TotallyNotACreditCard: '[FILTERED]'
+            TotallyNotACreditCard: '[FILTERED]',
+            nested: { even_works_token: '[FILTERED]' },
+            secret_array_for_good_measure: '[FILTERED]'
           )
         end
 


### PR DESCRIPTION
Nested request bodies captured with `capture_body` will raise `#<NoMethodError: undefined method 'match' for {"nested"=>"value"}:Hash>` during the secrets filter because we expected all values to be strings.

Happening since latest release. Will release patch version.