### PR TITLE
Adding proxy support

### DIFF
--- a/lib/elastic_apm/config.rb
+++ b/lib/elastic_apm/config.rb
@@ -133,6 +133,12 @@ module ElasticAPM
     attr_accessor :server_url
     attr_accessor :secret_token
 
+    attr_accessor :proxy_address
+    attr_accessor :proxy_port
+    attr_accessor :proxy_username
+    attr_accessor :proxy_password
+    attr_accessor :proxy_headers
+
     attr_accessor :active
     attr_accessor :api_buffer_size
     attr_accessor :api_request_size

--- a/lib/elastic_apm/transport/connection.rb
+++ b/lib/elastic_apm/transport/connection.rb
@@ -49,6 +49,16 @@ module ElasticAPM
 
         @client = HTTP.headers(headers).persistent(@url)
 
+        if config.proxy_address.present? && config.proxy_port.present?
+          @client = @client.via(
+            config.proxy_address,
+            config.proxy_port,
+            config.proxy_username,
+            config.proxy_password,
+            config.proxy_headers
+          )
+        end
+
         @mutex = Mutex.new
       end
       # rubocop:enable Metrics/MethodLength, Metrics/AbcSize


### PR DESCRIPTION
Looked into adding a test via WebMock but it doesn't support asserting that a proxy was used (https://github.com/bblimke/webmock/issues/753). That said I am open to any suggestions/changes you would like to see.

Thanks.