### PR TITLE
[APM-CI] use current as pipeline shared library version

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,5 +1,5 @@
 #!/usr/bin/env groovy
-@Library('apm@v1.0.9') _
+@Library('apm@current') _
 
 import co.elastic.matrix.*
 import groovy.transform.Field
@@ -25,6 +25,8 @@ pipeline {
     ansiColor('xterm')
     disableResume()
     durabilityHint('PERFORMANCE_OPTIMIZED')
+    rateLimitBuilds(throttle: [count: 60, durationName: 'hour', userBoost: true])
+    quietPeriod(10)
   }
   triggers {
     issueCommentTrigger('.*(?:jenkins\\W+)?run\\W+(?:the\\W+)?tests(?:\\W+please)?.*')
@@ -39,7 +41,7 @@ pipeline {
     Checkout the code and stash it, to use it on other stages.
     */
     stage('Checkout') {
-      agent { label 'flyweight' }
+      agent { label 'master || immutable' }
       options { skipDefaultCheckout() }
       steps {
         deleteDir()
@@ -51,7 +53,7 @@ pipeline {
     Execute unit tests.
     */
     stage('Test') {
-      agent { label 'flyweight' }
+      agent { label 'linux && immutable' }
       options { skipDefaultCheckout() }
       steps {
         deleteDir()


### PR DESCRIPTION
* avoid having to change the Jenkinsfile every time we set a pipeline shared library as a stable version to use.
* limit max PR builds per hour to 60
* set quiet period to 10 seconds
* remove flyweight Jenkins nodes
