### PR TITLE
Add server proxy support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 
 Both APIs are backwards compatible with fallbacks and deprecation warnings, scheduled for removal in next major release.
 
+### Added 
+
+- Configuration options to use an HTTP proxy ([#352](https://github.com/elastic/apm-agent-ruby/pull/352))
+
 ### Changed
 
 - Errors get their own contexts, perhaps leading to slightly different (but more correct) results. ([#335](https://github.com/elastic/apm-agent-ruby/pull/335))

--- a/docs/configuration.asciidoc
+++ b/docs/configuration.asciidoc
@@ -453,6 +453,28 @@ If you have high load and get warnings about the buffer being full, increasing
 the worker pool size might help.
 
 [float]
+[[config-proxy-address]]
+==== `proxy_address`
+
+[options="header"]
+|============
+| Environment | `Config` key    | Default | Example
+| N/A         | `proxy_address` | `nil`   | `"example.com"`
+|============
+
+An address to use as a proxy for the HTTP client.
+
+Options available are:
+
+- `proxy_address`
+- `proxy_headers`
+- `proxy_password`
+- `proxy_port`
+- `proxy_username`
+
+See https://github.com/httprb/http/wiki/Proxy-Support[Http.rb's docs].
+
+[float]
 [[config-service-name]]
 ==== `service_name`
 

--- a/lib/elastic_apm/config.rb
+++ b/lib/elastic_apm/config.rb
@@ -133,6 +133,12 @@ module ElasticAPM
     attr_accessor :server_url
     attr_accessor :secret_token
 
+    attr_accessor :proxy_address
+    attr_accessor :proxy_port
+    attr_accessor :proxy_username
+    attr_accessor :proxy_password
+    attr_accessor :proxy_headers
+
     attr_accessor :active
     attr_accessor :api_buffer_size
     attr_accessor :api_request_size

--- a/lib/elastic_apm/config.rb
+++ b/lib/elastic_apm/config.rb
@@ -133,18 +133,12 @@ module ElasticAPM
     attr_accessor :server_url
     attr_accessor :secret_token
 
-    attr_accessor :proxy_address
-    attr_accessor :proxy_port
-    attr_accessor :proxy_username
-    attr_accessor :proxy_password
-    attr_accessor :proxy_headers
-
     attr_accessor :active
     attr_accessor :api_buffer_size
     attr_accessor :api_request_size
     attr_accessor :api_request_time
-    attr_accessor :capture_headers
     attr_accessor :capture_env
+    attr_accessor :capture_headers
     attr_accessor :current_user_email_method
     attr_accessor :current_user_id_method
     attr_accessor :current_user_method
@@ -165,6 +159,11 @@ module ElasticAPM
     attr_accessor :logger
     attr_accessor :metrics_interval
     attr_accessor :pool_size
+    attr_accessor :proxy_address
+    attr_accessor :proxy_headers
+    attr_accessor :proxy_password
+    attr_accessor :proxy_port
+    attr_accessor :proxy_username
     attr_accessor :server_ca_cert
     attr_accessor :service_name
     attr_accessor :service_version

--- a/lib/elastic_apm/transport/connection.rb
+++ b/lib/elastic_apm/transport/connection.rb
@@ -52,7 +52,7 @@ module ElasticAPM
       # rubocop:enable Metrics/MethodLength
 
       def configure_proxy
-        unless @config.proxy_address.present? && @config.proxy_port.present?
+        unless @config.proxy_address && @config.proxy_port
           return
         end
 

--- a/lib/elastic_apm/transport/connection.rb
+++ b/lib/elastic_apm/transport/connection.rb
@@ -49,6 +49,16 @@ module ElasticAPM
 
         @client = HTTP.headers(headers).persistent(@url)
 
+        if config.proxy_address.present? && config.proxy_port.present?
+          @client = @client.via(
+            config.proxy_address,
+            config.proxy_port,
+            config.proxy_username,
+            config.proxy_password,
+            config.proxy_headers
+          )
+        end
+
         @mutex = Mutex.new
       end
       # rubocop:enable Metrics/MethodLength, Metrics/AbcSize

--- a/lib/elastic_apm/transport/connection.rb
+++ b/lib/elastic_apm/transport/connection.rb
@@ -28,7 +28,7 @@ module ElasticAPM
       }.freeze
       GZIP_HEADERS = HEADERS.merge('Content-Encoding' => 'gzip').freeze
 
-      # rubocop:disable Metrics/MethodLength, Metrics/AbcSize
+      # rubocop:disable Metrics/MethodLength
       def initialize(config, metadata)
         @config = config
         @metadata = metadata.to_json
@@ -42,26 +42,36 @@ module ElasticAPM
           headers['Authorization'] = "Bearer #{token}"
         end
 
-        if config.use_ssl? && config.server_ca_cert
-          @ssl_context = OpenSSL::SSL::SSLContext.new
-          @ssl_context.ca_file = config.server_ca_cert
-        end
-
         @client = HTTP.headers(headers).persistent(@url)
 
-        if config.proxy_address.present? && config.proxy_port.present?
-          @client = @client.via(
-            config.proxy_address,
-            config.proxy_port,
-            config.proxy_username,
-            config.proxy_password,
-            config.proxy_headers
-          )
-        end
+        configure_proxy
+        configure_ssl
 
         @mutex = Mutex.new
       end
-      # rubocop:enable Metrics/MethodLength, Metrics/AbcSize
+      # rubocop:enable Metrics/MethodLength
+
+      def configure_proxy
+        unless @config.proxy_address.present? && @config.proxy_port.present?
+          return
+        end
+
+        @client = @client.via(
+          @config.proxy_address,
+          @config.proxy_port,
+          @config.proxy_username,
+          @config.proxy_password,
+          @config.proxy_headers
+        )
+      end
+
+      def configure_ssl
+        return unless @config.use_ssl? && @config.server_ca_cert
+
+        @ssl_context = OpenSSL::SSL::SSLContext.new.tap do |context|
+          context.ca_file = @config.server_ca_cert
+        end
+      end
 
       def write(str)
         return if @config.disable_send

--- a/spec/elastic_apm/transport/connection_spec.rb
+++ b/spec/elastic_apm/transport/connection_spec.rb
@@ -40,6 +40,31 @@ module ElasticAPM
             expect(stub).to_not have_been_requested
           end
         end
+
+        context 'with a proxy' do
+          let(:config) do
+            Config.new(
+              proxy_address: 'example.com',
+              proxy_port: 80,
+              http_compression: false
+            )
+          end
+
+          it 'uses proxy' do
+            expect_any_instance_of(HTTP::Client)
+              .to receive(:via).and_call_original
+
+            stub = build_stub(body: /{"msg": "hey!"}/)
+
+            subject.write('{"msg": "hey!"}')
+            expect(subject).to be_connected
+
+            subject.flush
+            expect(subject).to_not be_connected
+
+            expect(stub).to have_been_requested
+          end
+        end
       end
 
       describe 'secret token' do


### PR DESCRIPTION
The test is perhaps a bit silly as it only tests the call to any `HTTP::Client` but at least we make sure to hit the relevant code path.

Closes elastic/apm-agent-ruby#347 