### PR TITLE
[docs] Add release notes

### DIFF
--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -26,3 +26,5 @@ include::./supported-technologies.asciidoc[]
 
 include::./api.asciidoc[]
 
+include::./release-notes.asciidoc[]
+

--- a/docs/release-notes.asciidoc
+++ b/docs/release-notes.asciidoc
@@ -1,0 +1,4 @@
+[[release-notes]]
+== Release notes
+
+Release notes are published in the https://github.com/elastic/apm-agent-ruby/blob/master/CHANGELOG.md[changelog].


### PR DESCRIPTION
See elastic/apm#68.

Adds a link to release notes.