### PR TITLE
Revert "net-http spy: use Module.prepend instead of alias"

### DIFF
--- a/lib/elastic_apm/spies/net_http.rb
+++ b/lib/elastic_apm/spies/net_http.rb
@@ -28,33 +28,32 @@ module ElasticAPM
         end
       end
 
-      module Overrides
-        # @api private
-        def request(req, body = nil)
-          return super if ElasticAPM::Spies::NetHTTPSpy.disabled?
-
-          transaction = ElasticAPM.current_transaction
-          return super unless transaction
-
-          host, = req['host'] && req['host'].split(':')
-          method = req.method
-
-          host ||= address
-
-          name = "#{method} #{host}"
-          type = "ext.net_http.#{method}"
-
-          ElasticAPM.with_span name, type do |span|
-            trace_context = span&.trace_context || transaction.trace_context
-            req['Elastic-Apm-Traceparent'] = trace_context.to_header
-            super
-          end
-        end
-      end
-
       def install
         Net::HTTP.class_eval do
-          prepend Overrides
+          alias request_without_apm request
+
+          def request(req, body = nil, &block)
+            unless (transaction = ElasticAPM.current_transaction)
+              return request_without_apm(req, body, &block)
+            end
+            if ElasticAPM::Spies::NetHTTPSpy.disabled?
+              return request_without_apm(req, body, &block)
+            end
+
+            host, = req['host'] && req['host'].split(':')
+            method = req.method
+
+            host ||= address
+
+            name = "#{method} #{host}"
+            type = "ext.net_http.#{method}"
+
+            ElasticAPM.with_span name, type do |span|
+              trace_context = span&.trace_context || transaction.trace_context
+              req['Elastic-Apm-Traceparent'] = trace_context.to_header
+              request_without_apm(req, body, &block)
+            end
+          end
         end
       end
       # rubocop:enable Metrics/MethodLength, Metrics/AbcSize


### PR DESCRIPTION
Reverts elastic/apm-agent-ruby#382

Turns out when other code tries to `class_eval` on top of `Module#prepend`ed code it turns into an infinitely recursive loop, ultimately raising a `stack level too deep` error.

See for example https://docs.newrelic.com/docs/agents/ruby-agent/troubleshooting/systemstackerror-stack-level-too-deep

While `Module#prepend` is the more sensible and perhaps modern solution, I'm reverting this for now.