### PR TITLE
Let Faraday spy run with NetHTTPSpy disabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 ### Fixed
 
 - Re-added `default_tags` ([#395](https://github.com/elastic/apm-agent-ruby/pull/395))
+- A bug in the Faraday spy when disabling the Net::HTTP spy ([#396](https://github.com/elastic/apm-agent-ruby/pull/396))
 
 ## 2.6.1
 

--- a/lib/elastic_apm/spies/faraday.rb
+++ b/lib/elastic_apm/spies/faraday.rb
@@ -5,6 +5,14 @@ module ElasticAPM
   module Spies
     # @api private
     class FaradaySpy
+      def self.without_net_http
+        return yield unless defined?(NetHTTPSpy)
+
+        ElasticAPM::Spies::NetHTTPSpy.disable_in do
+          yield
+        end
+      end
+
       # rubocop:disable Metrics/MethodLength, Metrics/AbcSize
       # rubocop:disable Metrics/BlockLength, Metrics/PerceivedComplexity
       # rubocop:disable Metrics/CyclomaticComplexity
@@ -32,7 +40,7 @@ module ElasticAPM
             type = "ext.faraday.#{method}"
 
             ElasticAPM.with_span name, type do |span|
-              ElasticAPM::Spies::NetHTTPSpy.disable_in do
+              ElasticAPM::Spies::FaradaySpy.without_net_http do
                 trace_context = span&.trace_context || transaction.trace_context
 
                 run_request_without_apm(method, url, body, headers) do |req|


### PR DESCRIPTION
Fixes elastic/apm-agent-ruby#381 