### PR TITLE
[APM-CI][Integration test][Ruby] Support JRuby with different JDK versions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ Gemfile.lock
 spec/elastic_apm.log
 spec/ruby-agent-junit.xml
 .gem
+*.bulk

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -74,10 +74,10 @@ should "Squash and merge".
 
 To do a full test run, use either `bundle exec rspec` or `rake spec`. Individual specs should also run as expected. The Mongo test needs a Mongo instance running, but will start one itself if Docker is installed.
 
-To test other platform, use the Docker setup and scripts like `spec.sh RUBY FRAMEWORK`.
+To test other platform, use the Docker setup and scripts like `spec.sh RUBY_DOCKER_IMAGE FRAMEWORK`.
 
 ```sh
-$ spec/scripts/spec.sh ruby-2.6 rails-5.2
+$ spec/scripts/spec.sh ruby:2.6 rails-5.2
 ```
 
 ### Releasing

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -262,7 +262,11 @@ def runBenchmark(version){
           } catch(e){
             throw e
           } finally {
-            sendBenchmarks(file: "benchmark-${version}.bulk",
+            // Transform the versions like:
+            //  - docker.elastic.co/observability-ci/jruby:9.2-12-jdk to jruby-9.2-12-jdk
+            //  - jruby:9.1 to jruby-9.1
+            def transformedVersion = version.replaceAll('.*/', '').replaceAll(':', '-')
+            sendBenchmarks(file: "benchmark-${transformedVersion}.bulk",
               index: "benchmark-ruby", archive: true)
           }
         }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -253,7 +253,7 @@ def runBenchmark(version){
       //  - jruby:9.1 to jruby-9.1
       def transformedVersion = version.replaceAll('.*/', '').replaceAll(':', '-')
       env.HOME = "${env.WORKSPACE}/${transformedVersion}"
-      dir("${version}"){
+      dir("${transformedVersion}"){
         deleteDir()
         unstash 'source'
         dir("${BASE_DIR}"){

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -185,11 +185,11 @@ pipeline {
 Parallel task generator for the integration tests.
 */
 class RubyParallelTaskGenerator extends DefaultParallelTaskGenerator {
-  
+
   public RubyParallelTaskGenerator(Map params){
     super(params)
   }
-  
+
   /**
   build a clousure that launch and agent and execute the corresponding test script,
   then store the results.
@@ -229,6 +229,7 @@ def runScript(Map params = [:]){
   env.PATH = "${env.PATH}:${env.WORKSPACE}/bin"
   deleteDir()
   unstash 'source'
+  dockerLoginToInternalRegistry()
   dir("${BASE_DIR}"){
     retry(2){
       sleep randomNumber(min:10, max: 30)
@@ -247,6 +248,7 @@ def runBenchmark(version){
       dir("${version}"){
         deleteDir()
         unstash 'source'
+        dockerLoginToInternalRegistry()
         dir("${BASE_DIR}"){
           try{
             sh "./spec/scripts/benchmarks.sh ${version}"
@@ -260,4 +262,12 @@ def runBenchmark(version){
       }
     }
   }
+}
+
+/**
+  Login to the internal docker registry
+*/
+def dockerLoginToInternalRegistry(){
+  dockerLogin(secret: 'secret/apm-team/ci/elastic-observability-docker-elastic-co',
+              registry: 'docker.elastic.co')
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -199,7 +199,8 @@ class RubyParallelTaskGenerator extends DefaultParallelTaskGenerator {
       steps.sleep steps.randomNumber(min:10, max: 30)
       steps.node('linux && immutable'){
         // Label is transformed to avoid using the internal docker registry in the x coordinate
-        def label = "${tag}:${x?.drop(x?.lastIndexOf('/')+1)}#${y}"
+        // TODO: def label = "${tag}:${x?.drop(x?.lastIndexOf('/')+1)}#${y}"
+        def label = "${tag}:${x}#${y}"
         try {
           steps.runScript(label: label, ruby: x, framework: y)
           saveResult(x, y, 1)

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -234,9 +234,9 @@ def runScript(Map params = [:]){
   deleteDir()
   unstash 'source'
   dir("${BASE_DIR}"){
-    dockerLogin(secret: "${DOCKER_SECRET}", registry: "${DOCKER_REGISTRY}")
     retry(2){
       sleep randomNumber(min:10, max: 30)
+      dockerLogin(secret: "${DOCKER_SECRET}", registry: "${DOCKER_REGISTRY}")
       sh("./spec/scripts/spec.sh ${ruby} ${framework}")
     }
   }
@@ -253,7 +253,10 @@ def runBenchmark(version){
         deleteDir()
         unstash 'source'
         dir("${BASE_DIR}"){
-          dockerLogin(secret: "${DOCKER_SECRET}", registry: "${DOCKER_REGISTRY}")
+          retry(2){
+            sleep randomNumber(min:10, max: 30)
+            dockerLogin(secret: "${DOCKER_SECRET}", registry: "${DOCKER_REGISTRY}")
+          }
           try{
             sh "./spec/scripts/benchmarks.sh ${version}"
           } catch(e){

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -19,7 +19,7 @@ pipeline {
     JOB_GCS_BUCKET = credentials('gcs-bucket')
     CODECOV_SECRET = 'secret/apm-team/ci/apm-agent-ruby-codecov'
     DOCKER_REGISTRY = 'docker.elastic.co'
-    DOCKER_SECRET = 'secret/apm-team/ci/elastic-observability-docker-elastic-co'
+    DOCKER_SECRET = 'secret/apm-team/ci/docker-registry/prod'
   }
   options {
     timeout(time: 2, unit: 'HOURS')

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -248,7 +248,11 @@ def runScript(Map params = [:]){
 def runBenchmark(version){
   return {
     node('metal'){
-      env.HOME = "${env.WORKSPACE}/${version}"
+      // Transform the versions like:
+      //  - docker.elastic.co/observability-ci/jruby:9.2-12-jdk to jruby-9.2-12-jdk
+      //  - jruby:9.1 to jruby-9.1
+      def transformedVersion = version.replaceAll('.*/', '').replaceAll(':', '-')
+      env.HOME = "${env.WORKSPACE}/${transformedVersion}"
       dir("${version}"){
         deleteDir()
         unstash 'source'
@@ -262,10 +266,6 @@ def runBenchmark(version){
           } catch(e){
             throw e
           } finally {
-            // Transform the versions like:
-            //  - docker.elastic.co/observability-ci/jruby:9.2-12-jdk to jruby-9.2-12-jdk
-            //  - jruby:9.1 to jruby-9.1
-            def transformedVersion = version.replaceAll('.*/', '').replaceAll(':', '-')
             sendBenchmarks(file: "benchmark-${transformedVersion}.bulk",
               index: "benchmark-ruby", archive: true)
           }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -208,7 +208,7 @@ class RubyParallelTaskGenerator extends DefaultParallelTaskGenerator {
           saveResult(x, y, 1)
         } catch(e){
           saveResult(x, y, 0)
-          error("${label} tests failed : ${e.toString()}\n")
+          steps.error("${label} tests failed : ${e.toString()}\n")
         } finally {
           steps.junit(allowEmptyResults: false,
             keepLongStdio: true,

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -198,7 +198,8 @@ class RubyParallelTaskGenerator extends DefaultParallelTaskGenerator {
     return {
       steps.sleep steps.randomNumber(min:10, max: 30)
       steps.node('linux && immutable'){
-        def label = "${tag}:${x}#${y}"
+        // Label is transformed to avoid using the internal docker registry in the x coordinate
+        def label = "${tag}:${x?.drop(x?.lastIndexOf('/')+1)}#${y}"
         try {
           steps.runScript(label: label, ruby: x, framework: y)
           saveResult(x, y, 1)

--- a/spec/.jenkins_exclude.yml
+++ b/spec/.jenkins_exclude.yml
@@ -1,73 +1,73 @@
 exclude:
   # Tests fail, but we don't care
-  - RUBY_VERSION: jruby-9.2
+  - RUBY_VERSION: docker.elastic.co/observability-ci/jruby:9.2
     FRAMEWORK: rails-4.2
-  - RUBY_VERSION: jruby-9.1
+  - RUBY_VERSION: docker.elastic.co/observability-ci/jruby:9.1
     FRAMEWORK: rails-4.2
-  - RUBY_VERSION: jruby-9.2-12-jdk
+  - RUBY_VERSION: docker.elastic.co/observability-ci/jruby:9.2-12-jdk
     FRAMEWORK: rails-4.2
-  - RUBY_VERSION: jruby-9.2-11-jdk
+  - RUBY_VERSION: docker.elastic.co/observability-ci/jruby:9.2-11-jdk
     FRAMEWORK: rails-4.2
-  - RUBY_VERSION: jruby-9.2-8-jdk
+  - RUBY_VERSION: docker.elastic.co/observability-ci/jruby:9.2-8-jdk
     FRAMEWORK: rails-4.2
-  - RUBY_VERSION: jruby-9.1-7-jdk
+  - RUBY_VERSION: docker.elastic.co/observability-ci/jruby:9.1-7-jdk
     FRAMEWORK: rails-4.2
 
   # Only test master on newest ruby
-  - RUBY_VERSION: ruby-2.5
+  - RUBY_VERSION: ruby:2.5
     FRAMEWORK: rails-master
-  - RUBY_VERSION: ruby-2.4
+  - RUBY_VERSION: ruby:2.4
     FRAMEWORK: rails-master
-  - RUBY_VERSION: ruby-2.3
+  - RUBY_VERSION: ruby:2.3
     FRAMEWORK: rails-master
-  - RUBY_VERSION: jruby-9.2
+  - RUBY_VERSION: docker.elastic.co/observability-ci/jruby:9.2
     FRAMEWORK: rails-master
-  - RUBY_VERSION: jruby-9.1
+  - RUBY_VERSION: docker.elastic.co/observability-ci/jruby:9.1
     FRAMEWORK: rails-master
-  - RUBY_VERSION: jruby-9.2-12-jdk
+  - RUBY_VERSION: docker.elastic.co/observability-ci/jruby:9.2-12-jdk
     FRAMEWORK: rails-master
-  - RUBY_VERSION: jruby-9.2-11-jdk
+  - RUBY_VERSION: docker.elastic.co/observability-ci/jruby:9.2-11-jdk
     FRAMEWORK: rails-master
-  - RUBY_VERSION: jruby-9.2-8-jdk
+  - RUBY_VERSION: docker.elastic.co/observability-ci/jruby:9.2-8-jdk
     FRAMEWORK: rails-master
-  - RUBY_VERSION: jruby-9.1-7-jdk
+  - RUBY_VERSION: docker.elastic.co/observability-ci/jruby:9.1-7-jdk
     FRAMEWORK: rails-master
 
-  - RUBY_VERSION: ruby-2.5
+  - RUBY_VERSION: ruby:2.5
     FRAMEWORK: sinatra-master
-  - RUBY_VERSION: ruby-2.4
+  - RUBY_VERSION: ruby:2.4
     FRAMEWORK: sinatra-master
-  - RUBY_VERSION: ruby-2.3
+  - RUBY_VERSION: ruby:2.3
     FRAMEWORK: sinatra-master
-  - RUBY_VERSION: jruby-9.2
+  - RUBY_VERSION: docker.elastic.co/observability-ci/jruby:9.2
     FRAMEWORK: sinatra-master
-  - RUBY_VERSION: jruby-9.1
+  - RUBY_VERSION: docker.elastic.co/observability-ci/jruby:9.1
     FRAMEWORK: sinatra-master
-  - RUBY_VERSION: jruby-9.2-12-jdk
+  - RUBY_VERSION: docker.elastic.co/observability-ci/jruby:9.2-12-jdk
     FRAMEWORK: sinatra-master
-  - RUBY_VERSION: jruby-9.2-11-jdk
+  - RUBY_VERSION: docker.elastic.co/observability-ci/jruby:9.2-11-jdk
     FRAMEWORK: sinatra-master
-  - RUBY_VERSION: jruby-9.2-8-jdk
+  - RUBY_VERSION: docker.elastic.co/observability-ci/jruby:9.2-8-jdk
     FRAMEWORK: sinatra-master
-  - RUBY_VERSION: jruby-9.1-7-jdk
+  - RUBY_VERSION: docker.elastic.co/observability-ci/jruby:9.1-7-jdk
     FRAMEWORK: sinatra-master
 
   # Rails 6 beta
-  - RUBY_VERSION: ruby-2.5
+  - RUBY_VERSION: ruby:2.5
     FRAMEWORK: rails-6.0-beta.2
-  - RUBY_VERSION: ruby-2.4
+  - RUBY_VERSION: ruby:2.4
     FRAMEWORK: rails-6.0-beta.2
-  - RUBY_VERSION: ruby-2.3
+  - RUBY_VERSION: ruby:2.3
     FRAMEWORK: rails-6.0-beta.2
-  - RUBY_VERSION: jruby-9.2
+  - RUBY_VERSION: docker.elastic.co/observability-ci/jruby:9.2
     FRAMEWORK: rails-6.0-beta.2
-  - RUBY_VERSION: jruby-9.1
+  - RUBY_VERSION: docker.elastic.co/observability-ci/jruby:9.1
     FRAMEWORK: rails-6.0-beta.2
-  - RUBY_VERSION: jruby-9.2-12-jdk
+  - RUBY_VERSION: docker.elastic.co/observability-ci/jruby:9.2-12-jdk
     FRAMEWORK: rails-6.0-beta.2
-  - RUBY_VERSION: jruby-9.2-11-jdk
+  - RUBY_VERSION: docker.elastic.co/observability-ci/jruby:9.2-11-jdk
     FRAMEWORK: rails-6.0-beta.2
-  - RUBY_VERSION: jruby-9.2-8-jdk
+  - RUBY_VERSION: docker.elastic.co/observability-ci/jruby:9.2-8-jdk
     FRAMEWORK: rails-6.0-beta.2
-  - RUBY_VERSION: jruby-9.1-7-jdk
+  - RUBY_VERSION: docker.elastic.co/observability-ci/jruby:9.1-7-jdk
     FRAMEWORK: rails-6.0-beta.2

--- a/spec/.jenkins_exclude.yml
+++ b/spec/.jenkins_exclude.yml
@@ -1,8 +1,8 @@
 exclude:
   # Tests fail, but we don't care
-  - RUBY_VERSION: docker.elastic.co/observability-ci/jruby:9.2
+  - RUBY_VERSION: jruby:9.2
     FRAMEWORK: rails-4.2
-  - RUBY_VERSION: docker.elastic.co/observability-ci/jruby:9.1
+  - RUBY_VERSION: jruby:9.1
     FRAMEWORK: rails-4.2
   - RUBY_VERSION: docker.elastic.co/observability-ci/jruby:9.2-12-jdk
     FRAMEWORK: rails-4.2
@@ -20,9 +20,9 @@ exclude:
     FRAMEWORK: rails-master
   - RUBY_VERSION: ruby:2.3
     FRAMEWORK: rails-master
-  - RUBY_VERSION: docker.elastic.co/observability-ci/jruby:9.2
+  - RUBY_VERSION: jruby:9.2
     FRAMEWORK: rails-master
-  - RUBY_VERSION: docker.elastic.co/observability-ci/jruby:9.1
+  - RUBY_VERSION: jruby:9.1
     FRAMEWORK: rails-master
   - RUBY_VERSION: docker.elastic.co/observability-ci/jruby:9.2-12-jdk
     FRAMEWORK: rails-master
@@ -39,9 +39,9 @@ exclude:
     FRAMEWORK: sinatra-master
   - RUBY_VERSION: ruby:2.3
     FRAMEWORK: sinatra-master
-  - RUBY_VERSION: docker.elastic.co/observability-ci/jruby:9.2
+  - RUBY_VERSION: jruby:9.2
     FRAMEWORK: sinatra-master
-  - RUBY_VERSION: docker.elastic.co/observability-ci/jruby:9.1
+  - RUBY_VERSION: jruby:9.1
     FRAMEWORK: sinatra-master
   - RUBY_VERSION: docker.elastic.co/observability-ci/jruby:9.2-12-jdk
     FRAMEWORK: sinatra-master
@@ -59,9 +59,9 @@ exclude:
     FRAMEWORK: rails-6.0-beta.2
   - RUBY_VERSION: ruby:2.3
     FRAMEWORK: rails-6.0-beta.2
-  - RUBY_VERSION: docker.elastic.co/observability-ci/jruby:9.2
+  - RUBY_VERSION: jruby:9.2
     FRAMEWORK: rails-6.0-beta.2
-  - RUBY_VERSION: docker.elastic.co/observability-ci/jruby:9.1
+  - RUBY_VERSION: jruby:9.1
     FRAMEWORK: rails-6.0-beta.2
   - RUBY_VERSION: docker.elastic.co/observability-ci/jruby:9.2-12-jdk
     FRAMEWORK: rails-6.0-beta.2

--- a/spec/.jenkins_exclude.yml
+++ b/spec/.jenkins_exclude.yml
@@ -4,6 +4,14 @@ exclude:
     FRAMEWORK: rails-4.2
   - RUBY_VERSION: jruby-9.1
     FRAMEWORK: rails-4.2
+  - RUBY_VERSION: jruby-9.2-12-jdk
+    FRAMEWORK: rails-4.2
+  - RUBY_VERSION: jruby-9.2-11-jdk
+    FRAMEWORK: rails-4.2
+  - RUBY_VERSION: jruby-9.2-8-jdk
+    FRAMEWORK: rails-4.2
+  - RUBY_VERSION: jruby-9.1-7-jdk
+    FRAMEWORK: rails-4.2
 
   # Only test master on newest ruby
   - RUBY_VERSION: ruby-2.5
@@ -16,6 +24,14 @@ exclude:
     FRAMEWORK: rails-master
   - RUBY_VERSION: jruby-9.1
     FRAMEWORK: rails-master
+  - RUBY_VERSION: jruby-9.2-12-jdk
+    FRAMEWORK: rails-master
+  - RUBY_VERSION: jruby-9.2-11-jdk
+    FRAMEWORK: rails-master
+  - RUBY_VERSION: jruby-9.2-8-jdk
+    FRAMEWORK: rails-master
+  - RUBY_VERSION: jruby-9.1-7-jdk
+    FRAMEWORK: rails-master
 
   - RUBY_VERSION: ruby-2.5
     FRAMEWORK: sinatra-master
@@ -26,6 +42,14 @@ exclude:
   - RUBY_VERSION: jruby-9.2
     FRAMEWORK: sinatra-master
   - RUBY_VERSION: jruby-9.1
+    FRAMEWORK: sinatra-master
+  - RUBY_VERSION: jruby-9.2-12-jdk
+    FRAMEWORK: sinatra-master
+  - RUBY_VERSION: jruby-9.2-11-jdk
+    FRAMEWORK: sinatra-master
+  - RUBY_VERSION: jruby-9.2-8-jdk
+    FRAMEWORK: sinatra-master
+  - RUBY_VERSION: jruby-9.1-7-jdk
     FRAMEWORK: sinatra-master
 
   # Rails 6 beta
@@ -38,4 +62,12 @@ exclude:
   - RUBY_VERSION: jruby-9.2
     FRAMEWORK: rails-6.0-beta.2
   - RUBY_VERSION: jruby-9.1
+    FRAMEWORK: rails-6.0-beta.2
+  - RUBY_VERSION: jruby-9.2-12-jdk
+    FRAMEWORK: rails-6.0-beta.2
+  - RUBY_VERSION: jruby-9.2-11-jdk
+    FRAMEWORK: rails-6.0-beta.2
+  - RUBY_VERSION: jruby-9.2-8-jdk
+    FRAMEWORK: rails-6.0-beta.2
+  - RUBY_VERSION: jruby-9.1-7-jdk
     FRAMEWORK: rails-6.0-beta.2

--- a/spec/.jenkins_ruby.yml
+++ b/spec/.jenkins_ruby.yml
@@ -5,3 +5,7 @@ RUBY_VERSION:
   - ruby-2.3
   - jruby-9.2
   - jruby-9.1
+  - jruby-9.2-12-jdk
+  - jruby-9.2-11-jdk
+  - jruby-9.2-8-jdk
+  - jruby-9.1-7-jdk

--- a/spec/.jenkins_ruby.yml
+++ b/spec/.jenkins_ruby.yml
@@ -1,11 +1,11 @@
 RUBY_VERSION:
-  - ruby-2.6
-  - ruby-2.5
-  - ruby-2.4
-  - ruby-2.3
-  - jruby-9.2
-  - jruby-9.1
-  - jruby-9.2-12-jdk
-  - jruby-9.2-11-jdk
-  - jruby-9.2-8-jdk
-  - jruby-9.1-7-jdk
+  - ruby:2.6
+  - ruby:2.5
+  - ruby:2.4
+  - ruby:2.3
+  - jruby:9.2
+  - jruby:9.1
+  - docker.elastic.co/observability-ci/jruby:9.2-12-jdk
+  - docker.elastic.co/observability-ci/jruby:9.2-11-jdk
+  - docker.elastic.co/observability-ci/jruby:9.2-8-jdk
+  - docker.elastic.co/observability-ci/jruby:9.1-7-jdk

--- a/spec/Dockerfile
+++ b/spec/Dockerfile
@@ -11,7 +11,7 @@ RUN [ apt-get ] \
 
 RUN [ yum ] \
     && ( yum update -y -q \
-        && yum install -y build-essential libpq-dev git ) \
+        && yum install -y git ) \
     || true
 
 WORKDIR /app

--- a/spec/Dockerfile
+++ b/spec/Dockerfile
@@ -4,5 +4,14 @@ FROM ${RUBY_IMAGE}
 ENV CI "1"
 ENV INCLUDE_COVERAGE "1"
 
-RUN apt-get update -qq && apt-get install -y build-essential libpq-dev git
+RUN [ apt-get ] \
+    && ( apt-get update -qq \
+        && apt-get install -y build-essential libpq-dev git ) \
+    || true
+
+RUN [ yum ] \
+    && ( yum update -y -q \
+        && yum install -y build-essential libpq-dev git ) \
+    || true
+
 WORKDIR /app

--- a/spec/scripts/benchmarks.sh
+++ b/spec/scripts/benchmarks.sh
@@ -7,27 +7,28 @@ if [ $# -lt 1 ]; then
 fi
 
 RUBY_IMAGE=${1}
-VERSION=$(echo $RUBY_IMAGE | cut -d":" -f2)
+VERSION=$(echo "${RUBY_IMAGE}" | cut -d":" -f2)
 
 ## Transform the versions like:
 ##  - docker.elastic.co/observability-ci/jruby:9.2-12-jdk to jruby-9.2-12-jdk
 ##  - jruby:9.1 to jruby-9.1
-TRANSFORMED_VERSION=$(basename $RUBY_IMAGE | sed "s#:#-#g")
+TRANSFORMED_VERSION=$(basename "${RUBY_IMAGE}" | sed "s#:#-#g")
 
 local_vendor_path="$HOME/.cache/ruby-vendor"
 container_vendor_path="/tmp/vendor/${TRANSFORMED_VERSION/ruby-/}"
+CURRENT_PATH=$(dirname "$(pwd)")
 
-mkdir -p $local_vendor_path
+mkdir -p "${local_vendor_path}"
 
 cd spec
 
-docker build --pull --force-rm --build-arg RUBY_IMAGE=$RUBY_IMAGE -t apm-agent-ruby:${VERSION} .
+docker build --pull --force-rm --build-arg "RUBY_IMAGE=${RUBY_IMAGE}" -t "apm-agent-ruby:${VERSION}" .
 RUBY_VERSION=${VERSION} docker-compose run \
   --user $UID \
   -e HOME=/app \
   -w /app \
   -e LOCAL_USER_ID=$UID \
   -v "$local_vendor_path:$container_vendor_path" \
-  -v "$(dirname $(pwd))":/app \
+  -v "${CURRENT_PATH}:/app" \
   --rm ruby_rspec \
   /bin/bash -c "bundle install --path $container_vendor_path && bench/benchmark.rb 2> /dev/null | bench/report.rb > benchmark-${TRANSFORMED_VERSION}.bulk"

--- a/spec/scripts/benchmarks.sh
+++ b/spec/scripts/benchmarks.sh
@@ -6,13 +6,6 @@ if [ $# -lt 1 ]; then
   exit 2
 fi
 
-local_vendor_path="$HOME/.cache/ruby-vendor"
-container_vendor_path="/tmp/vendor/${1/ruby-/}"
-
-mkdir -p $local_vendor_path
-
-cd spec
-
 RUBY_IMAGE=${1}
 VERSION=$(echo $RUBY_IMAGE | cut -d":" -f2)
 
@@ -20,6 +13,14 @@ VERSION=$(echo $RUBY_IMAGE | cut -d":" -f2)
 ##  - docker.elastic.co/observability-ci/jruby:9.2-12-jdk to jruby-9.2-12-jdk
 ##  - jruby:9.1 to jruby-9.1
 TRANSFORMED_VERSION=$(basename $RUBY_IMAGE | sed "s#:#-#g")
+
+local_vendor_path="$HOME/.cache/ruby-vendor"
+container_vendor_path="/tmp/vendor/${TRANSFORMED_VERSION/ruby-/}"
+
+mkdir -p $local_vendor_path
+
+cd spec
+
 
 docker build --pull --force-rm --build-arg RUBY_IMAGE=$RUBY_IMAGE -t apm-agent-ruby:${VERSION} .
 RUBY_VERSION=${VERSION} docker-compose run \

--- a/spec/scripts/benchmarks.sh
+++ b/spec/scripts/benchmarks.sh
@@ -1,4 +1,10 @@
 #!/usr/bin/env bash
+#
+# Perform benchmarks for the given docker ruby image.
+# NOTE:  It's required to be launched inside the root of the project.
+#
+# Usage: ./spec/scripts/benchmarks.sh jruby:9.1
+#
 set -exuo pipefail
 
 if [ $# -lt 1 ]; then

--- a/spec/scripts/benchmarks.sh
+++ b/spec/scripts/benchmarks.sh
@@ -16,7 +16,6 @@ TRANSFORMED_VERSION=$(basename "${RUBY_IMAGE}" | sed "s#:#-#g")
 
 local_vendor_path="$HOME/.cache/ruby-vendor"
 container_vendor_path="/tmp/vendor/${TRANSFORMED_VERSION/ruby-/}"
-CURRENT_PATH=$(dirname "$(pwd)")
 
 mkdir -p "${local_vendor_path}"
 
@@ -29,6 +28,6 @@ RUBY_VERSION=${VERSION} docker-compose run \
   -w /app \
   -e LOCAL_USER_ID=$UID \
   -v "$local_vendor_path:$container_vendor_path" \
-  -v "${CURRENT_PATH}:/app" \
+  -v "$(dirname "$(pwd)"):/app" \
   --rm ruby_rspec \
   /bin/bash -c "bundle install --path $container_vendor_path && bench/benchmark.rb 2> /dev/null | bench/report.rb > benchmark-${TRANSFORMED_VERSION}.bulk"

--- a/spec/scripts/benchmarks.sh
+++ b/spec/scripts/benchmarks.sh
@@ -21,7 +21,6 @@ mkdir -p $local_vendor_path
 
 cd spec
 
-
 docker build --pull --force-rm --build-arg RUBY_IMAGE=$RUBY_IMAGE -t apm-agent-ruby:${VERSION} .
 RUBY_VERSION=${VERSION} docker-compose run \
   --user $UID \

--- a/spec/scripts/spec.sh
+++ b/spec/scripts/spec.sh
@@ -8,12 +8,13 @@ fi
 
 cd spec
 
-RUBY_IMAGE=${1/-/:}
+RUBY_IMAGE=${1}
+VERSION=$(echo $1 | cut -d":" -f2)
 
 docker-compose up -d mongodb
 
-docker build --build-arg RUBY_IMAGE=$RUBY_IMAGE -t apm-agent-ruby:$1 .
-RUBY_VERSION=$1 docker-compose run \
+docker build --pull --build-arg RUBY_IMAGE=$RUBY_IMAGE -t apm-agent-ruby:${VERSION} .
+RUBY_VERSION=${VERSION} docker-compose run \
   -e FRAMEWORK=$2 \
   -e INCLUDE_SCHEMA_SPECS=1 \
   -v "$(dirname $(pwd))":/app \

--- a/spec/scripts/spec.sh
+++ b/spec/scripts/spec.sh
@@ -12,7 +12,7 @@ RUBY_IMAGE=${1/-/:}
 
 docker-compose up -d mongodb
 
-docker build --pull --build-arg RUBY_IMAGE=$RUBY_IMAGE -t apm-agent-ruby:$1 .
+docker build --build-arg RUBY_IMAGE=$RUBY_IMAGE -t apm-agent-ruby:$1 .
 RUBY_VERSION=$1 docker-compose run \
   -e FRAMEWORK=$2 \
   -e INCLUDE_SCHEMA_SPECS=1 \

--- a/spec/scripts/spec.sh
+++ b/spec/scripts/spec.sh
@@ -6,19 +6,21 @@ if [ $# -lt 2 ]; then
   exit 2
 fi
 
-cd spec
-
 RUBY_IMAGE=${1}
-VERSION=$(echo $1 | cut -d":" -f2)
+FRAMEWORK=${2}
+TEST=${3:-spec}
+VERSION=$(echo "${RUBY_IMAGE}" | cut -d":" -f2)
+
+cd spec
 
 docker-compose up -d mongodb
 
-docker build --pull --build-arg RUBY_IMAGE=$RUBY_IMAGE -t apm-agent-ruby:${VERSION} .
+docker build --pull --build-arg "RUBY_IMAGE=${RUBY_IMAGE}" -t "apm-agent-ruby:${VERSION}" .
 RUBY_VERSION=${VERSION} docker-compose run \
-  -e FRAMEWORK=$2 \
+  -e FRAMEWORK="${FRAMEWORK}" \
   -e INCLUDE_SCHEMA_SPECS=1 \
-  -v "$(dirname $(pwd))":/app \
+  -v "$(dirname "$(pwd)"):/app" \
   --rm ruby_rspec \
   /bin/bash -c "\
     bundle install && \
-    timeout -s9 5m bundle exec rspec -f progress -f JUnit -o spec/ruby-agent-junit.xml ${3:-spec}"
+    timeout -s9 5m bundle exec rspec -f progress -f JUnit -o spec/ruby-agent-junit.xml ${TEST}"

--- a/spec/scripts/spec.sh
+++ b/spec/scripts/spec.sh
@@ -1,4 +1,12 @@
 #!/usr/bin/env bash
+#
+# Test the given docker ruby image and framework. Optionally to filter what test
+# to be triggered otherwise all of them.
+#
+# NOTE: It's required to be launched inside the root of the project.
+#
+# Usage: ./spec/scripts/spec.sh jruby:9.1 sinatra-2.0
+#
 set -ex
 
 if [ $# -lt 2 ]; then


### PR DESCRIPTION
Caused by https://github.com/elastic/apm-agent-ruby/issues/287

## Highlights
- Support jruby with different jdk versions
- Enable docker login with a retry + sleep in case any infra issues.
- Ruby versions moved from `-` split to `:` as it is the way we can support our internal docker registry.
- Fix pipeline to bypass a weird script approval misleading message.

## Tasks
- [x] Test locally for the current list of versions in `spec/.jenkins_ruby.yml`
- [x] Validate whether the Jenkinsfile works as expected. [here](https://apm-ci.elastic.co/job/apm-agent-ruby/job/apm-agent-ruby-mbp/job/PR-403/14/)
- [x] --Script approval is required-- False! It's solved with https://github.com/elastic/apm-agent-ruby/pull/403/commits/db5ab60768dd3cf15f2e3321fd280af7bd6dedfe
- [x] Benchmark is also required. Unfortunately, the PRs are not validating it and I've just found it

## Todo
- I'd rather prefer to handle the stage naming in the UI Pipeline view in another PR as it does require to change the shared library too. What do I mean? See the below screenshot:
 
![image](https://user-images.githubusercontent.com/2871786/57475437-40395d80-728c-11e9-9ce7-2e752420cae2.png)

The name of the stage is based on the name of the docker images plus the framework, as the name of the new docker images are hosted in our internal docker registry, their names are quite long. 

What do you think?