### PR TITLE
Remove duplicate context section

### DIFF
--- a/docs/api.asciidoc
+++ b/docs/api.asciidoc
@@ -111,7 +111,7 @@ ElasticAPM.with_transaction 'Do things' do |transaction|
 end
 ----
 
-Arguments: 
+Arguments:
 
   * `name`: A name for your transaction. Transactions are grouped by name. **Required**.
   * `type`: A `type` for your transaction eg. `db.postgresql.sql`.
@@ -395,7 +395,3 @@ See the {apm-rum-ref}[JavaScript RUM agent documentation] for more information.
 
 - `name`: String
 - `type`: String
-
-[float]
-[[api-context]]
-=== Context

--- a/docs/api.asciidoc
+++ b/docs/api.asciidoc
@@ -234,6 +234,7 @@ Arguments:
 Returns `[ElasticAPM::Error]`.
 
 [float]
+[[api-context]]
 === Context
 
 [float]


### PR DESCRIPTION
Creating PR for removal of duplicate context section in `api.asciidoc`. 

For what I have understood, this last Context section should be removed, since it is described earlier in the document. 

Please have a look and if there is any issue let me know :) No failing test or rubocop styling violations, but I have run them, just to be sure.  

Also if you have more challenging issue/bug, I will gladly help with it.
   
Fixes elastic/apm-agent-ruby#388 