### PR TITLE
Throttle 'queue full' warnings to only once per 5 secs

### DIFF
--- a/lib/elastic_apm/util/throttle.rb
+++ b/lib/elastic_apm/util/throttle.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+module ElasticAPM
+  module Util
+    # @api private
+
+    # Usage example:
+    #   Throttle.new(5) { thing to only do once per 5 secs }
+    class Throttle
+      def initialize(buffer_secs, &block)
+        @buffer_secs = buffer_secs
+        @block = block
+      end
+
+      def call
+        if @last_call && seconds_since_last_call < @buffer_secs
+          return @last_result
+        end
+
+        @last_call = now
+        @last_result = @block.call
+      end
+
+      private
+
+      def now
+        Process.clock_gettime(Process::CLOCK_MONOTONIC)
+      end
+
+      def seconds_since_last_call
+        now - @last_call
+      end
+    end
+  end
+end

--- a/spec/elastic_apm/util/throttle_spec.rb
+++ b/spec/elastic_apm/util/throttle_spec.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require 'elastic_apm/util/throttle'
+
+module ElasticAPM
+  module Util
+    RSpec.describe Throttle do
+      let(:thing) { double call: 'ok' }
+
+      subject { described_class.new(0.1) { thing.call } } # 100 milisecs
+
+      it 'calls only once per 100 milisecs' do
+        expect(thing).to receive(:call).once
+        5.times { subject.call }
+
+        sleep 0.1
+
+        expect(thing).to receive(:call).once
+        5.times { subject.call }
+      end
+
+      it 'returns result of last call' do
+        subject = described_class.new(1) { 'here it is' }
+        expect(subject.call).to eq('here it is')
+        expect(subject.call).to eq('here it is')
+      end
+    end
+  end
+end


### PR DESCRIPTION
Fixes elastic/apm-agent-ruby#406 

@axw Picked 5 secs as cooldown time. Have no idea what would be a sensible amount of time.