### PR TITLE
Add debugging docs page

### DIFF
--- a/docs/debugging.asciidoc
+++ b/docs/debugging.asciidoc
@@ -26,5 +26,5 @@ Things to consider:
 
   - Is `server_url` misconfigured or APM Server down? If the agent fails to connect you will also see log messages containing `Connection error` or `Couldn't establish connection to APM Server`.
   - Experiencing high load? The agent can spawn multiple instances of its Workers that pick off the queue by changing the option `pool_size` (default is `1`).
-  - If you have high load you could also consider setting `transaction_sample_rate` to something smaller than `1.0`. This determines whether to include _spans_ for every _transaction_. If you have enough traffic, skipping some (probably) identical spans won't have a noticeable effect on your data.
+  - If you have high load you may also consider setting `transaction_sample_rate` to something smaller than `1.0`. This determines whether to include _spans_ for every _transaction_. If you have enough traffic, skipping some (probably) identical spans won't have a noticeable effect on your data.
 

--- a/docs/debugging.asciidoc
+++ b/docs/debugging.asciidoc
@@ -1,0 +1,23 @@
+[[debugging]]
+== Debugging the agent itself
+
+Hopefully the agent Just Works™ for you but depending on your situation the agent could need some tuning.
+
+Firstly, to know more about what's going on inside the agent, you can increase the amount of log messages it writes by setting the log level with the option `log_level = 0` -- `0` being the level of most messages, `DEBUG`.
+
+[float]
+[[debugging-errors]]
+=== Errors
+
+[float]
+[[debugging-errors-queue-full]]
+==== `Queue is full (256 items), skipping…`
+
+The agent has an internal queue that holds events after they are done, before they are safely serialized and sent to APM Server. To avoid using up all of your memory, the queue has a fixed size. Taking from the queue happens faster than adding to it but it can happen that the queue fills, hence the warning.
+
+Things to consider:
+
+  - Is `server_url` misconfigured or APM Server down?
+  - Experiencing high load? The agent can spawn multiple instances of its Workers that pick off the queue by changing the option `pool_size` (default is `1`).
+  - If you have high load you could also consider setting `transaction_sample_rate` to something smaller than `1.0`. This determines whether to include _spans_ for every _transaction_. If you have enough traffic, skipping some (probably) identical spans won't have a noticeable effect on your data.
+

--- a/docs/debugging.asciidoc
+++ b/docs/debugging.asciidoc
@@ -3,7 +3,7 @@
 
 Hopefully the agent Just Works™, but depending on your situation the agent might need some tuning.
 
-Firstly, to know more about what's going on inside the agent, you can increase the amount of log messages it writes by setting the log level with the option `log_level = 0` -- `0` being the level of most messages, `DEBUG`.
+First, to learn more about what's going on inside the agent, you can increase the amount of log messages it writes. To do this, set the log level with the option `log_level = 0` -- `0` being the level of most messages, `DEBUG`.
 
 In your `config/elastic_apm.yml`:
 

--- a/docs/debugging.asciidoc
+++ b/docs/debugging.asciidoc
@@ -20,7 +20,7 @@ log_level: <%= Logger::DEBUG %>
 [[debugging-errors-queue-full]]
 ==== `Queue is full (256 items), skipping…`
 
-The agent has an internal queue that holds events after they are done, before they are safely serialized and sent to APM Server. To avoid using up all of your memory, the queue has a fixed size. Depending on your load and server setup, events may be added to the queue faster than they are consumed, hence the warning.
+The agent has an internal queue that holds events after they are done, and before they are safely serialized and sent to APM Server. To avoid using up all of your memory, this queue has a fixed size. Depending on your load and server setup, events may be added to the queue faster than they are consumed, hence the warning.
 
 Things to consider:
 

--- a/docs/debugging.asciidoc
+++ b/docs/debugging.asciidoc
@@ -1,7 +1,7 @@
 [[debugging]]
 == Debugging the agent itself
 
-Hopefully the agent Just Works™ for you but depending on your situation the agent could need some tuning.
+Hopefully the agent Just Works™, but depending on your situation the agent might need some tuning.
 
 Firstly, to know more about what's going on inside the agent, you can increase the amount of log messages it writes by setting the log level with the option `log_level = 0` -- `0` being the level of most messages, `DEBUG`.
 

--- a/docs/debugging.asciidoc
+++ b/docs/debugging.asciidoc
@@ -5,6 +5,13 @@ Hopefully the agent Just Works™ for you but depending on your situation the ag
 
 Firstly, to know more about what's going on inside the agent, you can increase the amount of log messages it writes by setting the log level with the option `log_level = 0` -- `0` being the level of most messages, `DEBUG`.
 
+In your `config/elastic_apm.yml`:
+
+[source,yaml]
+----
+log_level: <%= Logger::DEBUG %>
+----
+
 [float]
 [[debugging-errors]]
 === Errors
@@ -13,11 +20,11 @@ Firstly, to know more about what's going on inside the agent, you can increase t
 [[debugging-errors-queue-full]]
 ==== `Queue is full (256 items), skipping…`
 
-The agent has an internal queue that holds events after they are done, before they are safely serialized and sent to APM Server. To avoid using up all of your memory, the queue has a fixed size. Taking from the queue happens faster than adding to it but it can happen that the queue fills, hence the warning.
+The agent has an internal queue that holds events after they are done, before they are safely serialized and sent to APM Server. To avoid using up all of your memory, the queue has a fixed size. Depending on your load and server setup, events may be added to the queue faster than they are consumed, hence the warning.
 
 Things to consider:
 
-  - Is `server_url` misconfigured or APM Server down?
+  - Is `server_url` misconfigured or APM Server down? If the agent fails to connect you will also see log messages containing `Connection error` or `Couldn't establish connection to APM Server`.
   - Experiencing high load? The agent can spawn multiple instances of its Workers that pick off the queue by changing the option `pool_size` (default is `1`).
   - If you have high load you could also consider setting `transaction_sample_rate` to something smaller than `1.0`. This determines whether to include _spans_ for every _transaction_. If you have enough traffic, skipping some (probably) identical spans won't have a noticeable effect on your data.
 

--- a/docs/debugging.asciidoc
+++ b/docs/debugging.asciidoc
@@ -13,8 +13,8 @@ log_level: <%= Logger::DEBUG %>
 ----
 
 [float]
-[[debugging-errors]]
-=== Errors
+[[debugging-log-messages]]
+=== Log messages
 
 [float]
 [[debugging-errors-queue-full]]

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -26,5 +26,7 @@ include::./supported-technologies.asciidoc[]
 
 include::./api.asciidoc[]
 
+include::./debugging.asciidoc[]
+
 include::./release-notes.asciidoc[]
 


### PR DESCRIPTION
The purpose of this page is to provide a few helpful hints at how to debug a non-working agent as well as have a canonical place to point people to, if they experience their event queues filling up.

As soon as the page is up I want to actually link to it in the warning message to point folks in the right direction instead of (unrelated perhaps) issues. We can use the new url shortener to make a nice, short link.

@bmorelli25 I'm assigning you as you probably have a few ideas on how to improve the copy. See this as a first draft and do whatever you want to it 😉 