### PR TITLE
Reintroduce skipping events by returning nil in filter

### DIFF
--- a/lib/elastic_apm/transport/filters.rb
+++ b/lib/elastic_apm/transport/filters.rb
@@ -6,6 +6,8 @@ module ElasticAPM
   module Transport
     # @api private
     module Filters
+      SKIP = :skip
+
       def self.new(config)
         Container.new(config)
       end
@@ -27,7 +29,7 @@ module ElasticAPM
         def apply!(payload)
           @filters.reduce(payload) do |result, (_key, filter)|
             result = filter.call(result)
-            break if result.nil?
+            break SKIP if result.nil?
             result
           end
         end

--- a/lib/elastic_apm/transport/worker.rb
+++ b/lib/elastic_apm/transport/worker.rb
@@ -58,7 +58,10 @@ module ElasticAPM
 
       def serialize_and_filter(resource)
         serialized = serializers.serialize(resource)
-        @filters.apply!(serialized)
+
+        # if a filter returns nil, it means skip the event
+        return nil if @filters.apply!(serialized) == Filters::SKIP
+
         JSON.fast_generate(serialized)
       rescue Exception
         error format('Failed converting event to JSON: %s', resource.inspect)

--- a/spec/elastic_apm/transport/filters_spec.rb
+++ b/spec/elastic_apm/transport/filters_spec.rb
@@ -40,7 +40,7 @@ module ElasticAPM
 
           result = subject.apply!(things: 1)
 
-          expect(result).to be_nil
+          expect(result).to be Filters::SKIP
           expect(untouched).to_not have_received(:call)
         end
       end

--- a/spec/elastic_apm/transport/worker_spec.rb
+++ b/spec/elastic_apm/transport/worker_spec.rb
@@ -66,6 +66,20 @@ module ElasticAPM
 
           thread.join 1
         end
+
+        context 'when a filter wants to skip the event' do
+          before do
+            filters.add(:always_nil, ->(_payload) { nil })
+          end
+
+          it 'applies filters, writes resources to the connection' do
+            queue.push Transaction.new
+
+            Thread.new { subject.work_forever }.join 0.1
+
+            expect(subject.connection.calls.length).to be 0
+          end
+        end
       end
 
       describe '#process' do


### PR DESCRIPTION
This was somehow removed.

It gets a little bit weird as the filters are destructive and alter the original payload (to save copying every payload ever) but are still expected to have a return value. Seems not so ruby-like in a way.

An alternative implementation could use exceptions to make skipping a bit more obvious. Like, require a filter to `raise Filters::Skip, 'status ping'` to skip. But that would mean changing the api and be a breaking change (unless we do both but not sure it's worth it – wdyt @simitt ?