### PR TITLE
Truncate error.culprit length

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Fixed
+
+- `error.culprit` is properly truncated to 1024 characters ([#418](https://github.com/elastic/apm-agent-ruby/pull/418))
+
 ## 2.7.0 (2019-05-07)
 
 ### Added

--- a/lib/elastic_apm/transport/serializers/error_serializer.rb
+++ b/lib/elastic_apm/transport/serializers/error_serializer.rb
@@ -18,7 +18,7 @@ module ElasticAPM
             trace_id: error.trace_id,
             parent_id: error.parent_id,
 
-            culprit: error.culprit,
+            culprit: keyword_field(error.culprit),
             timestamp: error.timestamp
           }
 


### PR DESCRIPTION
Per https://github.com/elastic/apm/issues/43