### PR TITLE
Align http User-Agent with other agents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 
 ## Unreleased
 
+### Changed
+
+- Use standardized User-Agent ([#419](https://github.com/elastic/apm-agent-ruby/pull/419))
+
 ### Fixed
 
 - `error.culprit` is properly truncated to 1024 characters ([#418](https://github.com/elastic/apm-agent-ruby/pull/418))

--- a/spec/elastic_apm/transport/connection_spec.rb
+++ b/spec/elastic_apm/transport/connection_spec.rb
@@ -52,9 +52,9 @@ module ElasticAPM
         stub = build_stub(
           headers: {
             'User-Agent' => %r{
-              \Aelastic-apm-ruby/(\d\.)+\d\s
-              http.rb/(\d\.)+\d\s
-              j?ruby/(\d\.)+\d\z
+              \Aelastic-apm-ruby/(\d\.)+\d+\s
+              http.rb/(\d\.)+\d+\s
+              j?ruby/(\d+\.)+\d+\z
             }x
           }
         )

--- a/spec/elastic_apm/transport/connection_spec.rb
+++ b/spec/elastic_apm/transport/connection_spec.rb
@@ -48,6 +48,21 @@ module ElasticAPM
         end
       end
 
+      it 'has a fitting user agent' do
+        stub = build_stub(
+          headers: {
+            'User-Agent' => %r{
+              \Aelastic-apm-ruby/(\d\.)+\d\s
+              http.rb/(\d\.)+\d\s
+              ruby/(\d\.)+\d\z
+            }x
+          }
+        )
+        subject.write('{}')
+        subject.flush
+        expect(stub).to have_been_requested
+      end
+
       describe 'secret token' do
         let(:config) { Config.new(secret_token: 'asd') }
 

--- a/spec/elastic_apm/transport/connection_spec.rb
+++ b/spec/elastic_apm/transport/connection_spec.rb
@@ -54,7 +54,7 @@ module ElasticAPM
             'User-Agent' => %r{
               \Aelastic-apm-ruby/(\d\.)+\d\s
               http.rb/(\d\.)+\d\s
-              ruby/(\d\.)+\d\z
+              j?ruby/(\d\.)+\d\z
             }x
           }
         )

--- a/spec/elastic_apm/transport/connection_spec.rb
+++ b/spec/elastic_apm/transport/connection_spec.rb
@@ -52,8 +52,8 @@ module ElasticAPM
         stub = build_stub(
           headers: {
             'User-Agent' => %r{
-              \Aelastic-apm-ruby/(\d\.)+\d+\s
-              http.rb/(\d\.)+\d+\s
+              \Aelastic-apm-ruby/(\d+\.)+\d+\s
+              http.rb/(\d+\.)+\d+\s
               j?ruby/(\d+\.)+\d+\z
             }x
           }


### PR DESCRIPTION
Example `elastic-apm-ruby/2.7.0 http.rb/4.1.1 ruby/2.6.3`

https://github.com/elastic/apm/issues/88

Closes #416 