### PR TITLE
Add additional benchmark calculating overhead/txn

### DIFF
--- a/bench/benchmark.rb
+++ b/bench/benchmark.rb
@@ -1,6 +1,8 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
 
+ENV['RAILS_ENV'] = 'production'
+
 require 'benchmark'
 include Benchmark
 require 'rack/test'

--- a/bench/report.rb
+++ b/bench/report.rb
@@ -47,4 +47,7 @@ overhead =
   1000 /  # milliseconds
   10_000     # transactions
 
-puts meta.merge(overhead: overhead).to_json
+puts meta.merge(
+  title: 'overhead',
+  overhead: overhead
+).to_json

--- a/bench/report.rb
+++ b/bench/report.rb
@@ -12,29 +12,39 @@ git_sha, git_msg = `git log -n 1 --pretty="format:%H|||%s"`.split('|||')
 git_date = `git log -n 1 --pretty="format:%ai"`
 platform = Gem::Platform.local
 
+meta = {
+  executed_at: Time.new.iso8601,
+  'git.commit' => git_sha,
+  'git.date' => String(git_date).strip != '' && Time.parse(git_date).iso8601,
+  'git.subject' => git_msg,
+  hostname: `hostname`.chomp,
+  engine: RUBY_ENGINE,
+  arch: platform.cpu,
+  os: platform.os,
+  ruby_version: "#{RUBY_ENGINE == 'jruby' ? 'j' : ''}#{RUBY_VERSION}"
+}
+
 results =
   input
   .grep(/^with/)
   .map do |line|
     title = line.match(/^(.*):/) { |m| m[1] }
     user, system, total, real = line.scan(/[0-9\.]+/).map(&:to_f)
-    {
+    meta.merge(
       title: title,
       user: user,
       system: system,
       total: total,
       real: real,
-      executed_at: Time.new.iso8601,
-      'git.commit' => git_sha,
-      'git.date' => String(git_date).strip != '' && Time.parse(git_date).iso8601,
-      'git.subject' => git_msg,
-      hostname: `hostname`.chomp,
-      engine: RUBY_ENGINE,
-      arch: platform.cpu,
-      os: platform.os,
-      ruby_version: "#{RUBY_ENGINE == 'jruby' ? 'j' : ''}#{RUBY_VERSION}"
-    }
+    )
   end
 
 puts '{ "index" : { "_index" : "benchmark-ruby", "_type" : "_doc" } }'
 results.each { |result| puts result.to_json }
+
+overhead =
+  (results[0][:total] - results[1][:total]) *
+  1000 /  # milliseconds
+  10_000     # transactions
+
+puts meta.merge(overhead: overhead).to_json


### PR DESCRIPTION
```
{ "index" : { "_index" : "benchmark-ruby", "_type" : "_doc" } }
{"executed_at":"2019-05-23T15:50:41+02:00","git.commit":"9b143700995395270e8a3a0d01cc88652944e9bc","git.d
ate":"2019-05-23T15:48:11+02:00","git.subject":"Add additional benchmark calculating overhead/txn","hostn
ame":"mikker","engine":"ruby","arch":"x86_64","os":"darwin","ruby_version":"2.6.3","title":"with agent","
user":21.584418,"system":3.68097,"total":25.265388,"real":25.581958}
{"executed_at":"2019-05-23T15:50:41+02:00","git.commit":"9b143700995395270e8a3a0d01cc88652944e9bc","git.d
ate":"2019-05-23T15:48:11+02:00","git.subject":"Add additional benchmark calculating overhead/txn","hostn
ame":"mikker","engine":"ruby","arch":"x86_64","os":"darwin","ruby_version":"2.6.3","title":"without agent
","user":14.355698,"system":2.013474,"total":16.369172,"real":17.30159}
{"executed_at":"2019-05-23T15:50:41+02:00","git.commit":"9b143700995395270e8a3a0d01cc88652944e9bc","git.d
ate":"2019-05-23T15:48:11+02:00","git.subject":"Add additional benchmark calculating overhead/txn","hostn
ame":"mikker","engine":"ruby","arch":"x86_64","os":"darwin","ruby_version":"2.6.3","overhead":0.889621600
0000002}
```