### PR TITLE
Handle files that lie about their line counts

### DIFF
--- a/lib/elastic_apm/stacktrace/frame.rb
+++ b/lib/elastic_apm/stacktrace/frame.rb
@@ -41,7 +41,7 @@ module ElasticAPM
       private
 
       def read_lines(path, range)
-        File.readlines(path)[range]
+        File.readlines(path)[range] || []
       rescue Errno::ENOENT
         []
       end


### PR DESCRIPTION
This can happen with e.g. compiled slim templates.

Fixes this error:
```
(byebug) ex
#<NoMethodError: undefined method `[]' for nil:NilClass>
(byebug) bt
--> #0  ElasticAPM::Stacktrace::Frame.build_context(context_line_count#Integer) at /home/vagrant/.gem/ruby/2.6.3/gems/elastic-apm-2.8.1/lib/elastic_apm/stacktrace/frame.rb:40
    #1  ElasticAPM::StacktraceBuilder.build_frame(cache#Hash, keys#Array) at /home/vagrant/.gem/ruby/2.6.3/gems/elastic-apm-2.8.1/lib/elastic_apm/stacktrace_builder.rb:46
    #2  block in ElasticAPM::Util::LruCache.block in [](key#Array) at /home/vagrant/.gem/ruby/2.6.3/gems/elastic-apm-2.8.1/lib/elastic_apm/util/lru_cache.rb:15
    ͱ-- #3  Thread::Mutex.synchronize at /home/vagrant/.gem/ruby/2.6.3/gems/elastic-apm-2.8.1/lib/elastic_apm/util/lru_cache.rb:14
    #4  ElasticAPM::Util::LruCache.[](key#Array) at /home/vagrant/.gem/ruby/2.6.3/gems/elastic-apm-2.8.1/lib/elastic_apm/util/lru_cache.rb:14
    #5  block (2 levels) in ElasticAPM::StacktraceBuilder.block (2 levels) in build(backtrace#Array, type#Symbol) at /home/vagrant/.gem/ruby/2.6.3/gems/elastic-apm-2.8.1/lib/elastic_apm/stacktrace_builder.rb:25
    ͱ-- #6  Array.map at /home/vagrant/.gem/ruby/2.6.3/gems/elastic-apm-2.8.1/lib/elastic_apm/stacktrace_builder.rb:24
    #7  block in ElasticAPM::StacktraceBuilder.block in build(backtrace#Array, type#Symbol) at /home/vagrant/.gem/ruby/2.6.3/gems/elastic-apm-2.8.1/lib/elastic_apm/stacktrace_builder.rb:24
    ͱ-- #8  Kernel.tap at /home/vagrant/.gem/ruby/2.6.3/gems/elastic-apm-2.8.1/lib/elastic_apm/stacktrace_builder.rb:23
    #9  ElasticAPM::StacktraceBuilder.build(backtrace#Array, type#Symbol) at /home/vagrant/.gem/ruby/2.6.3/gems/elastic-apm-2.8.1/lib/elastic_apm/stacktrace_builder.rb:23
    #10 ElasticAPM::Span.build_stacktrace! at /home/vagrant/.gem/ruby/2.6.3/gems/elastic-apm-2.8.1/lib/elastic_apm/span.rb:84
    #11 ElasticAPM::Span.done(end_time#Integer) at /home/vagrant/.gem/ruby/2.6.3/gems/elastic-apm-2.8.1/lib/elastic_apm/span.rb:55
    #12 ElasticAPM::Instrumenter.end_span at /home/vagrant/.gem/ruby/2.6.3/gems/elastic-apm-2.8.1/lib/elastic_apm/instrumenter.rb:179
    #13 ElasticAPM::Agent.end_span at /home/vagrant/.gem/ruby/2.6.3/gems/elastic-apm-2.8.1/lib/elastic_apm/agent.rb:162
    #14 #<Class:ElasticAPM>.end_span at /home/vagrant/.gem/ruby/2.6.3/gems/elastic-apm-2.8.1/lib/elastic_apm.rb:241
    #15 #<Class:ElasticAPM>.with_span(name#String, type#String, context#NilClass, include_stacktrace#TrueClass, trace_context#NilClass) at /home/vagrant/.gem/ruby/2.6.3/gems/elastic-apm-2.8.1/lib/elastic_apm.rb:278
    #16 Redis::Client.call(command#Array, &block#NilClass) at /home/vagrant/.gem/ruby/2.6.3/gems/elastic-apm-2.8.1/lib/elastic_apm/spies/redis.rb:17
    #17 block in Redis.block in get(key#String) at /home/vagrant/.gem/ruby/2.6.3/gems/redis-4.1.1/lib/redis.rb:914
    #18 block in Redis.block in synchronize at /home/vagrant/.gem/ruby/2.6.3/gems/redis-4.1.1/lib/redis.rb:52
    #19 MonitorMixin.mon_synchronize at /home/vagrant/.rubies/ruby-2.6.3/lib/ruby/2.6.0/monitor.rb:230
    #20 Redis.synchronize at /home/vagrant/.gem/ruby/2.6.3/gems/redis-4.1.1/lib/redis.rb:52
    #21 Redis.get(key#String) at /home/vagrant/.gem/ruby/2.6.3/gems/redis-4.1.1/lib/redis.rb:913
    #22 Redis::Store::Interface.get(key#String, options#NilClass) at /home/vagrant/.gem/ruby/2.6.3/gems/redis-store-1.6.0/lib/redis/store/interface.rb:5
    #23 Redis::Store::Serialization.get(key#String, options#Hash) at /home/vagrant/.gem/ruby/2.6.3/gems/redis-store-1.6.0/lib/redis/store/serialization.rb:17
    #24 block in Redis::Store::Namespace.block in get(key#String, options#Hash) at /home/vagrant/.gem/ruby/2.6.3/gems/redis-store-1.6.0/lib/redis/store/namespace.rb:23
    #25 Redis::Store::Namespace.namespace(key#String) at /home/vagrant/.gem/ruby/2.6.3/gems/redis-store-1.6.0/lib/redis/store/namespace.rb:89
    #26 Redis::Store::Namespace.get(key#String, options#Hash) at /home/vagrant/.gem/ruby/2.6.3/gems/redis-store-1.6.0/lib/redis/store/namespace.rb:23
    #27 block in ActiveSupport::Cache::RedisStore.block in read_entry(key#String, options#Hash) at /home/vagrant/.gem/ruby/2.6.3/gems/redis-activesupport-5.0.7/lib/active_support/cache/redis_store.rb:266
    #28 ActiveSupport::Cache::RedisStore.with(&block#Proc) at /home/vagrant/.gem/ruby/2.6.3/gems/redis-activesupport-5.0.7/lib/active_support/cache/redis_store.rb:248
    #29 ActiveSupport::Cache::RedisStore.read_entry(key#String, options#Hash) at /home/vagrant/.gem/ruby/2.6.3/gems/redis-activesupport-5.0.7/lib/active_support/cache/redis_store.rb:266
    #30 block in ActiveSupport::Cache::Store.block in read(name#Array, options#Hash) at /home/vagrant/.gem/ruby/2.6.3/gems/activesupport-5.2.3/lib/active_support/cache.rb:346
    #31 block in ActiveSupport::Cache::Store.block in instrument(operation#Symbol, key#Array, options#Hash) at /home/vagrant/.gem/ruby/2.6.3/gems/activesupport-5.2.3/lib/active_support/cache.rb:663
    #32 #<Class:ActiveSupport::Notifications>.instrument(name#String, payload#Hash) at /home/vagrant/.gem/ruby/2.6.3/gems/activesupport-5.2.3/lib/active_support/notifications.rb:170
    #33 ActiveSupport::Cache::Store.instrument(operation#Symbol, key#Array, options#Hash) at /home/vagrant/.gem/ruby/2.6.3/gems/activesupport-5.2.3/lib/active_support/cache.rb:663
    #34 ActiveSupport::Cache::Store.read(name#Array, options#Hash) at /home/vagrant/.gem/ruby/2.6.3/gems/activesupport-5.2.3/lib/active_support/cache.rb:345
    #35 block in AbstractController::Caching::Fragments.block in read_fragment(key#Array, options#Hash) at /home/vagrant/.gem/ruby/2.6.3/gems/actionpack-5.2.3/lib/abstract_controller/caching/fragments.rb:114
    #36 block in AbstractController::Caching::Fragments.block in instrument_fragment_cache(name#Symbol, key#Array) at /home/vagrant/.gem/ruby/2.6.3/gems/actionpack-5.2.3/lib/abstract_controller/caching/fragments.rb:162
    #37 block in #<Class:ActiveSupport::Notifications>.block in instrument(name#String, payload#Hash) at /home/vagrant/.gem/ruby/2.6.3/gems/activesupport-5.2.3/lib/active_support/notifications.rb:168
    #38 ActiveSupport::Notifications::Instrumenter.instrument(name#String, payload#Hash) at /home/vagrant/.gem/ruby/2.6.3/gems/activesupport-5.2.3/lib/active_support/notifications/instrumenter.rb:23
    #39 #<Class:ActiveSupport::Notifications>.instrument(name#String, payload#Hash) at /home/vagrant/.gem/ruby/2.6.3/gems/activesupport-5.2.3/lib/active_support/notifications.rb:168
    #40 AbstractController::Caching::Fragments.instrument_fragment_cache(name#Symbol, key#Array) at /home/vagrant/.gem/ruby/2.6.3/gems/actionpack-5.2.3/lib/abstract_controller/caching/fragments.rb:162
    #41 AbstractController::Caching::Fragments.read_fragment(key#Array, options#Hash) at /home/vagrant/.gem/ruby/2.6.3/gems/actionpack-5.2.3/lib/abstract_controller/caching/fragments.rb:113
    #42 ActionView::Helpers::CacheHelper.read_fragment_for(name#Array, options#Hash) at /home/vagrant/.gem/ruby/2.6.3/gems/actionview-5.2.3/lib/action_view/helpers/cache_helper.rb:248
    #43 ActionView::Helpers::CacheHelper.fragment_for(name#Array, options#Hash, &block#Proc) at /home/vagrant/.gem/ruby/2.6.3/gems/actionview-5.2.3/lib/action_view/helpers/cache_helper.rb:238
    #44 ActionView::Helpers::CacheHelper.cache(name#String, options#Hash, &block#Proc) at /home/vagrant/.gem/ruby/2.6.3/gems/actionview-5.2.3/lib/action_view/helpers/cache_helper.rb:169
    #45 ActionView::CompiledTemplates._app_views_layouts_application_html_slim__4547642653075776876_47225505729020(local_assigns#Hash, output_buffer#NilClass) at /vagrant/app/views/layouts/application.html.slim:335
    #46 block in ActionView::Template.block in render(view##<Class:0x000055e716faa160>, locals#Hash, buffer#NilClass, &block#Proc) at /home/vagrant/.gem/ruby/2.6.3/gems/actionview-5.2.3/lib/action_view/template.rb:159
    #47 block in #<Class:ActiveSupport::Notifications>.block in instrument(name#String, payload#Hash) at /home/vagrant/.gem/ruby/2.6.3/gems/activesupport-5.2.3/lib/active_support/notifications.rb:168
    #48 ActiveSupport::Notifications::Instrumenter.instrument(name#String, payload#Hash) at /home/vagrant/.gem/ruby/2.6.3/gems/activesupport-5.2.3/lib/active_support/notifications/instrumenter.rb:23
    #49 #<Class:ActiveSupport::Notifications>.instrument(name#String, payload#Hash) at /home/vagrant/.gem/ruby/2.6.3/gems/activesupport-5.2.3/lib/active_support/notifications.rb:168
    #50 ActionView::Template.instrument_render_template(&block#Proc) at /home/vagrant/.gem/ruby/2.6.3/gems/actionview-5.2.3/lib/action_view/template.rb:354
    #51 ActionView::Template.render(view##<Class:0x000055e716faa160>, locals#Hash, buffer#NilClass, &block#Proc) at /home/vagrant/.gem/ruby/2.6.3/gems/actionview-5.2.3/lib/action_view/template.rb:157
    #52 ActionView::TemplateRenderer.render_with_layout(path#Proc, locals#Hash) at /home/vagrant/.gem/ruby/2.6.3/gems/actionview-5.2.3/lib/action_view/renderer/template_renderer.rb:66
    #53 ActionView::TemplateRenderer.render_template(template#ActionView::Template, layout_name#Proc, locals#Hash) at /home/vagrant/.gem/ruby/2.6.3/gems/actionview-5.2.3/lib/action_view/renderer/template_renderer.rb:52
    #54 ActionView::TemplateRenderer.render(context##<Class:0x000055e716faa160>, options#Hash) at /home/vagrant/.gem/ruby/2.6.3/gems/actionview-5.2.3/lib/action_view/renderer/template_renderer.rb:16
    #55 ActionView::Renderer.render_template(context##<Class:0x000055e716faa160>, options#Hash) at /home/vagrant/.gem/ruby/2.6.3/gems/actionview-5.2.3/lib/action_view/renderer/renderer.rb:44
    #56 ActionView::Renderer.render(context##<Class:0x000055e716faa160>, options#Hash) at /home/vagrant/.gem/ruby/2.6.3/gems/actionview-5.2.3/lib/action_view/renderer/renderer.rb:25
    #57 ActionView::Rendering._render_template(options#Hash) at /home/vagrant/.gem/ruby/2.6.3/gems/actionview-5.2.3/lib/action_view/rendering.rb:103
    #58 ActionController::Streaming._render_template(options#Hash) at /home/vagrant/.gem/ruby/2.6.3/gems/actionpack-5.2.3/lib/action_controller/metal/streaming.rb:219
    #59 ActionView::Rendering.render_to_body(options#Hash) at /home/vagrant/.gem/ruby/2.6.3/gems/actionview-5.2.3/lib/action_view/rendering.rb:84
    #60 ActionController::Rendering.render_to_body(options#Hash) at /home/vagrant/.gem/ruby/2.6.3/gems/actionpack-5.2.3/lib/action_controller/metal/rendering.rb:52
    #61 ActionController::Renderers.render_to_body(options#Hash) at /home/vagrant/.gem/ruby/2.6.3/gems/actionpack-5.2.3/lib/action_controller/metal/renderers.rb:142
    #62 AbstractController::Rendering.render(*args#Array, &block#NilClass) at /home/vagrant/.gem/ruby/2.6.3/gems/actionpack-5.2.3/lib/abstract_controller/rendering.rb:25
    #63 ActionController::Rendering.render(*args#Array) at /home/vagrant/.gem/ruby/2.6.3/gems/actionpack-5.2.3/lib/action_controller/metal/rendering.rb:36
    #64 block (2 levels) in ActionController::Instrumentation.block (2 levels) in render(*args#Array) at /home/vagrant/.gem/ruby/2.6.3/gems/actionpack-5.2.3/lib/action_controller/metal/instrumentation.rb:46
    #65 block in #<Class:Benchmark>.block in ms at /home/vagrant/.gem/ruby/2.6.3/gems/activesupport-5.2.3/lib/active_support/core_ext/benchmark.rb:14
    #66 #<Class:Benchmark>.realtime at /home/vagrant/.rubies/ruby-2.6.3/lib/ruby/2.6.0/benchmark.rb:308
    #67 #<Class:Benchmark>.ms at /home/vagrant/.gem/ruby/2.6.3/gems/activesupport-5.2.3/lib/active_support/core_ext/benchmark.rb:14
    #68 block in ActionController::Instrumentation.block in render(*args#Array) at /home/vagrant/.gem/ruby/2.6.3/gems/actionpack-5.2.3/lib/action_controller/metal/instrumentation.rb:46
    #69 ActionController::Instrumentation.cleanup_view_runtime at /home/vagrant/.gem/ruby/2.6.3/gems/actionpack-5.2.3/lib/action_controller/metal/instrumentation.rb:87
    #70 ActiveRecord::Railties::ControllerRuntime.cleanup_view_runtime at /home/vagrant/.gem/ruby/2.6.3/gems/activerecord-5.2.3/lib/active_record/railties/controller_runtime.rb:36
    #71 ActionController::Instrumentation.render(*args#Array) at /home/vagrant/.gem/ruby/2.6.3/gems/actionpack-5.2.3/lib/action_controller/metal/instrumentation.rb:45
    #72 ActionController::ImplicitRender.default_render(*args#Array) at /home/vagrant/.gem/ruby/2.6.3/gems/actionpack-5.2.3/lib/action_controller/metal/implicit_render.rb:35
    #73 block in ActionController::BasicImplicitRender.block in send_action(method#String, *args#Array) at /home/vagrant/.gem/ruby/2.6.3/gems/actionpack-5.2.3/lib/action_controller/metal/basic_implicit_render.rb:6
    ͱ-- #74 Kernel.tap at /home/vagrant/.gem/ruby/2.6.3/gems/actionpack-5.2.3/lib/action_controller/metal/basic_implicit_render.rb:6
    #75 ActionController::BasicImplicitRender.send_action(method#String, *args#Array) at /home/vagrant/.gem/ruby/2.6.3/gems/actionpack-5.2.3/lib/action_controller/metal/basic_implicit_render.rb:6
    #76 AbstractController::Base.process_action(method_name#String, *args#Array) at /home/vagrant/.gem/ruby/2.6.3/gems/actionpack-5.2.3/lib/abstract_controller/base.rb:194
    #77 ActionController::Rendering.process_action(*args) at /home/vagrant/.gem/ruby/2.6.3/gems/actionpack-5.2.3/lib/action_controller/metal/rendering.rb:30
    #78 block in AbstractController::Callbacks.block in process_action(*args#Array) at /home/vagrant/.gem/ruby/2.6.3/gems/actionpack-5.2.3/lib/abstract_controller/callbacks.rb:42
    #79 ActiveSupport::Callbacks.run_callbacks(kind#Symbol) at /home/vagrant/.gem/ruby/2.6.3/gems/activesupport-5.2.3/lib/active_support/callbacks.rb:132
    #80 AbstractController::Callbacks.process_action(*args#Array) at /home/vagrant/.gem/ruby/2.6.3/gems/actionpack-5.2.3/lib/abstract_controller/callbacks.rb:41
    #81 ActionController::Rescue.process_action(*args#Array) at /home/vagrant/.gem/ruby/2.6.3/gems/actionpack-5.2.3/lib/action_controller/metal/rescue.rb:22
    #82 block in ActionController::Instrumentation.block in process_action(*args#Array) at /home/vagrant/.gem/ruby/2.6.3/gems/actionpack-5.2.3/lib/action_controller/metal/instrumentation.rb:34
    #83 block in #<Class:ActiveSupport::Notifications>.block in instrument(name#String, payload#Hash) at /home/vagrant/.gem/ruby/2.6.3/gems/activesupport-5.2.3/lib/active_support/notifications.rb:168
    #84 ActiveSupport::Notifications::Instrumenter.instrument(name#String, payload#Hash) at /home/vagrant/.gem/ruby/2.6.3/gems/activesupport-5.2.3/lib/active_support/notifications/instrumenter.rb:23
    #85 #<Class:ActiveSupport::Notifications>.instrument(name#String, payload#Hash) at /home/vagrant/.gem/ruby/2.6.3/gems/activesupport-5.2.3/lib/active_support/notifications.rb:168
    #86 ActionController::Instrumentation.process_action(*args#Array) at /home/vagrant/.gem/ruby/2.6.3/gems/actionpack-5.2.3/lib/action_controller/metal/instrumentation.rb:32
    #87 ActionController::ParamsWrapper.process_action(*args#Array) at /home/vagrant/.gem/ruby/2.6.3/gems/actionpack-5.2.3/lib/action_controller/metal/params_wrapper.rb:256
    #88 ActiveRecord::Railties::ControllerRuntime.process_action(action#String, *args#Array) at /home/vagrant/.gem/ruby/2.6.3/gems/activerecord-5.2.3/lib/active_record/railties/controller_runtime.rb:24
    #89 AbstractController::Base.process(action#String, *args#Array) at /home/vagrant/.gem/ruby/2.6.3/gems/actionpack-5.2.3/lib/abstract_controller/base.rb:134
    #90 ActionView::Rendering.process(*args) at /home/vagrant/.gem/ruby/2.6.3/gems/actionview-5.2.3/lib/action_view/rendering.rb:32
    #91 ActionController::Metal.dispatch(name#String, request#ActionDispatch::Request, response#ActionDispatch::Response) at /home/vagrant/.gem/ruby/2.6.3/gems/actionpack-5.2.3/lib/action_controller/metal.rb:191
    #92 #<Class:ActionController::Metal>.dispatch(name#String, req#ActionDispatch::Request, res#ActionDispatch::Response) at /home/vagrant/.gem/ruby/2.6.3/gems/actionpack-5.2.3/lib/action_controller/metal.rb:252
    #93 ActionDispatch::Routing::RouteSet::Dispatcher.dispatch(controller#Class, action#String, req#ActionDispatch::Request, res#ActionDispatch::Response) at /home/vagrant/.gem/ruby/2.6.3/gems/actionpack-5.2.3/lib/action_dispatch/routing/route_set.rb:52
    #94 ActionDispatch::Routing::RouteSet::Dispatcher.serve(req#ActionDispatch::Request) at /home/vagrant/.gem/ruby/2.6.3/gems/actionpack-5.2.3/lib/action_dispatch/routing/route_set.rb:34
    #95 block in block in <class:Constraints> at /home/vagrant/.gem/ruby/2.6.3/gems/actionpack-5.2.3/lib/action_dispatch/routing/mapper.rb:18
    #96 ActionDispatch::Routing::Mapper::Constraints.serve(req#ActionDispatch::Request) at /home/vagrant/.gem/ruby/2.6.3/gems/actionpack-5.2.3/lib/action_dispatch/routing/mapper.rb:48
    #97 block in ActionDispatch::Journey::Router.block in serve(req#ActionDispatch::Request) at /home/vagrant/.gem/ruby/2.6.3/gems/actionpack-5.2.3/lib/action_dispatch/journey/router.rb:52
    ͱ-- #98 Array.each at /home/vagrant/.gem/ruby/2.6.3/gems/actionpack-5.2.3/lib/action_dispatch/journey/router.rb:35
    #99 ActionDispatch::Journey::Router.serve(req#ActionDispatch::Request) at /home/vagrant/.gem/ruby/2.6.3/gems/actionpack-5.2.3/lib/action_dispatch/journey/router.rb:35
    #100 ActionDispatch::Routing::RouteSet.call(env#Hash) at /home/vagrant/.gem/ruby/2.6.3/gems/actionpack-5.2.3/lib/action_dispatch/routing/route_set.rb:840
    #101 block in Warden::Manager.block in call(env#Hash) at /home/vagrant/.gem/ruby/2.6.3/gems/warden-1.2.8/lib/warden/manager.rb:36
    ͱ-- #102 Kernel.catch(*args) at /home/vagrant/.gem/ruby/2.6.3/gems/warden-1.2.8/lib/warden/manager.rb:34
    #103 Warden::Manager.call(env#Hash) at /home/vagrant/.gem/ruby/2.6.3/gems/warden-1.2.8/lib/warden/manager.rb:34
    #104 Rack::TempfileReaper.call(env#Hash) at /home/vagrant/.gem/ruby/2.6.3/gems/rack-2.0.7/lib/rack/tempfile_reaper.rb:15
    #105 Rack::ETag.call(env#Hash) at /home/vagrant/.gem/ruby/2.6.3/gems/rack-2.0.7/lib/rack/etag.rb:25
    #106 Rack::ConditionalGet.call(env#Hash) at /home/vagrant/.gem/ruby/2.6.3/gems/rack-2.0.7/lib/rack/conditional_get.rb:25
    #107 Rack::Head.call(env#Hash) at /home/vagrant/.gem/ruby/2.6.3/gems/rack-2.0.7/lib/rack/head.rb:12
    #108 ActionDispatch::ContentSecurityPolicy::Middleware.call(env#Hash) at /home/vagrant/.gem/ruby/2.6.3/gems/actionpack-5.2.3/lib/action_dispatch/http/content_security_policy.rb:18
    #109 Rack::Session::Abstract::Persisted.context(env#Hash, app#ActionDispatch::ContentSecurityPolicy::Middleware) at /home/vagrant/.gem/ruby/2.6.3/gems/rack-2.0.7/lib/rack/session/abstract/id.rb:232
    #110 Rack::Session::Abstract::Persisted.call(env#Hash) at /home/vagrant/.gem/ruby/2.6.3/gems/rack-2.0.7/lib/rack/session/abstract/id.rb:226
    #111 ActionDispatch::Cookies.call(env#Hash) at /home/vagrant/.gem/ruby/2.6.3/gems/actionpack-5.2.3/lib/action_dispatch/middleware/cookies.rb:670
    #112 block in ActionDispatch::Callbacks.block in call(env#Hash) at /home/vagrant/.gem/ruby/2.6.3/gems/actionpack-5.2.3/lib/action_dispatch/middleware/callbacks.rb:28
    #113 ActiveSupport::Callbacks.run_callbacks(kind#Symbol) at /home/vagrant/.gem/ruby/2.6.3/gems/activesupport-5.2.3/lib/active_support/callbacks.rb:98
    #114 ActionDispatch::Callbacks.call(env#Hash) at /home/vagrant/.gem/ruby/2.6.3/gems/actionpack-5.2.3/lib/action_dispatch/middleware/callbacks.rb:26
    #115 ActionDispatch::DebugExceptions.call(env#Hash) at /home/vagrant/.gem/ruby/2.6.3/gems/actionpack-5.2.3/lib/action_dispatch/middleware/debug_exceptions.rb:61
    #116 ActionDispatch::ShowExceptions.call(env#Hash) at /home/vagrant/.gem/ruby/2.6.3/gems/actionpack-5.2.3/lib/action_dispatch/middleware/show_exceptions.rb:33
    #117 Rails::Rack::Logger.call_app(request#ActionDispatch::Request, env#Hash) at /home/vagrant/.gem/ruby/2.6.3/gems/railties-5.2.3/lib/rails/rack/logger.rb:38
    #118 block in Rails::Rack::Logger.block in call(env#Hash) at /home/vagrant/.gem/ruby/2.6.3/gems/railties-5.2.3/lib/rails/rack/logger.rb:26
    #119 block in ActiveSupport::TaggedLogging.block in tagged(*tags#Array) at /home/vagrant/.gem/ruby/2.6.3/gems/activesupport-5.2.3/lib/active_support/tagged_logging.rb:71
    #120 ActiveSupport::TaggedLogging::Formatter.tagged(*tags#Array) at /home/vagrant/.gem/ruby/2.6.3/gems/activesupport-5.2.3/lib/active_support/tagged_logging.rb:28
    #121 ActiveSupport::TaggedLogging.tagged(*tags#Array) at /home/vagrant/.gem/ruby/2.6.3/gems/activesupport-5.2.3/lib/active_support/tagged_logging.rb:71
    #122 Rails::Rack::Logger.call(env#Hash) at /home/vagrant/.gem/ruby/2.6.3/gems/railties-5.2.3/lib/rails/rack/logger.rb:26
    #123 ActionDispatch::RemoteIp.call(env#Hash) at /home/vagrant/.gem/ruby/2.6.3/gems/actionpack-5.2.3/lib/action_dispatch/middleware/remote_ip.rb:81
    #124 RequestStore::Middleware.call(env#Hash) at /home/vagrant/.gem/ruby/2.6.3/gems/request_store-1.4.1/lib/request_store/middleware.rb:19
    #125 ActionDispatch::RequestId.call(env#Hash) at /home/vagrant/.gem/ruby/2.6.3/gems/actionpack-5.2.3/lib/action_dispatch/middleware/request_id.rb:27
    #126 Rack::MethodOverride.call(env#Hash) at /home/vagrant/.gem/ruby/2.6.3/gems/rack-2.0.7/lib/rack/method_override.rb:22
    #127 Rack::Runtime.call(env#Hash) at /home/vagrant/.gem/ruby/2.6.3/gems/rack-2.0.7/lib/rack/runtime.rb:22
    #128 ActionDispatch::Executor.call(env#Hash) at /home/vagrant/.gem/ruby/2.6.3/gems/actionpack-5.2.3/lib/action_dispatch/middleware/executor.rb:14
    #129 Rack::Sendfile.call(env#Hash) at /home/vagrant/.gem/ruby/2.6.3/gems/rack-2.0.7/lib/rack/sendfile.rb:111
    #130 ElasticAPM::Middleware.call(env#Hash) at /home/vagrant/.gem/ruby/2.6.3/gems/elastic-apm-2.8.1/lib/elastic_apm/middleware.rb:20
    #131 SecureHeaders::Middleware.call(env#Hash) at /home/vagrant/.gem/ruby/2.6.3/gems/secure_headers-6.1.0/lib/secure_headers/middleware.rb:11
    #132 Rails::Engine.call(env#Hash) at /home/vagrant/.gem/ruby/2.6.3/gems/railties-5.2.3/lib/rails/engine.rb:524
    #133 Puma::Configuration::ConfigMiddleware.call(env#Hash) at /home/vagrant/.gem/ruby/2.6.3/gems/puma-3.12.1/lib/puma/configuration.rb:227
    #134 Puma::Server.handle_request(req#Puma::Client, lines#Puma::IOBuffer) at /home/vagrant/.gem/ruby/2.6.3/gems/puma-3.12.1/lib/puma/server.rb:660
    #135 Puma::Server.process_client(client#Puma::Client, buffer#Puma::IOBuffer) at /home/vagrant/.gem/ruby/2.6.3/gems/puma-3.12.1/lib/puma/server.rb:474
    #136 block in Puma::Server.block in run(background#TrueClass) at /home/vagrant/.gem/ruby/2.6.3/gems/puma-3.12.1/lib/puma/server.rb:334
    #137 block in Puma::ThreadPool.block in spawn_thread at /home/vagrant/.gem/ruby/2.6.3/gems/puma-3.12.1/lib/puma/thread_pool.rb:135
```