### PR TITLE
Save request cookies on context, filter cookies in headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,10 +9,12 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 ### Added
 
 - Add `transaction.type` to errors ([#434](https://github.com/elastic/apm-agent-ruby/pull/434))
+- Add cookies to `request.cookies` ([#448](https://github.com/elastic/apm-agent-ruby/pull/448))
 
 ### Fixed
 
 - Fix support for older versions of Http.rb ([#438](https://github.com/elastic/apm-agent-ruby/pull/434))
+- Strip `Cookie` and `Set-Cookie` from headers ([#448](https://github.com/elastic/apm-agent-ruby/pull/448))
 
 ## 2.8.1 (2019-05-29)
 
@@ -69,7 +71,7 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 
 Both APIs are backwards compatible with fallbacks and deprecation warnings, scheduled for removal in next major release.
 
-### Added 
+### Added
 
 - Configuration options to use an HTTP proxy ([#352](https://github.com/elastic/apm-agent-ruby/pull/352))
 
@@ -130,7 +132,7 @@ Both APIs are backwards compatible with fallbacks and deprecation warnings, sche
 ### Added
 
 - Support for [OpenTracing](https://opentracing.io) ([#273](https://github.com/elastic/apm-agent-ruby/pull/273))
-- Add capture_* options ([#279](https://github.com/elastic/apm-agent-ruby/pull/279))
+- Add capture\_\* options ([#279](https://github.com/elastic/apm-agent-ruby/pull/279))
 - Evaluate the config file as ERB ([#288](https://github.com/elastic/apm-agent-ruby/pull/288))
 
 ### Changed

--- a/lib/elastic_apm/context_builder.rb
+++ b/lib/elastic_apm/context_builder.rb
@@ -38,6 +38,8 @@ module ElasticAPM
       request.headers = headers if config.capture_headers?
       request.env = env if config.capture_env?
 
+      request.cookies = req.cookies
+
       context
     end
     # rubocop:enable Metrics/MethodLength, Metrics/AbcSize

--- a/lib/elastic_apm/transport/filters/secrets_filter.rb
+++ b/lib/elastic_apm/transport/filters/secrets_filter.rb
@@ -14,7 +14,8 @@ module ElasticAPM
           /secret/i,
           /token/i,
           /api[-._]?key/i,
-          /session[-._]?id/i
+          /session[-._]?id/i,
+          /(set[-_])?cookie/i
         ].freeze
 
         VALUE_FILTERS = [
@@ -30,6 +31,7 @@ module ElasticAPM
         def call(payload)
           strip_from! payload.dig(:transaction, :context, :request, :headers)
           strip_from! payload.dig(:transaction, :context, :request, :env)
+          strip_from! payload.dig(:transaction, :context, :request, :cookies)
           strip_from! payload.dig(:transaction, :context, :response, :headers)
           strip_from! payload.dig(:error, :context, :request, :headers)
           strip_from! payload.dig(:error, :context, :response, :headers)

--- a/spec/elastic_apm/context_builder_spec.rb
+++ b/spec/elastic_apm/context_builder_spec.rb
@@ -9,7 +9,8 @@ module ElasticAPM
       it 'enriches request' do
         env = Rack::MockRequest.env_for(
           '/somewhere/in/there?q=yes',
-          method: 'POST'
+          method: 'POST',
+          'HTTP_COOKIE' => 'things=1'
         )
         env['HTTP_CONTENT_TYPE'] = 'application/json'
 
@@ -28,8 +29,11 @@ module ElasticAPM
         expect(request.url.hash).to eq nil
         expect(request.url.full).to eq 'http://example.org/somewhere/in/there?q=yes'
 
+        expect(request.cookies).to eq('things' => '1')
+
         expect(request.headers).to eq(
-          'Content-Type' => 'application/json'
+          'Content-Type' => 'application/json',
+          'Cookie' => 'things=1'
         )
       end
 

--- a/spec/elastic_apm/transport/filters/secrets_filter_spec.rb
+++ b/spec/elastic_apm/transport/filters/secrets_filter_spec.rb
@@ -11,7 +11,8 @@ module ElasticAPM
           payload = { transaction: { context: { request: { headers: {
             ApiKey: 'very zecret!',
             Untouched: 'very much',
-            TotallyNotACreditCard: '4111 1111 1111 1111'
+            TotallyNotACreditCard: '4111 1111 1111 1111',
+            'HTTP_COOKIE': 'things=1'
           } } } } }
 
           subject.call(payload)
@@ -21,7 +22,8 @@ module ElasticAPM
           expect(headers).to match(
             ApiKey: '[FILTERED]',
             Untouched: 'very much',
-            TotallyNotACreditCard: '[FILTERED]'
+            TotallyNotACreditCard: '[FILTERED]',
+            HTTP_COOKIE: '[FILTERED]'
           )
         end
 


### PR DESCRIPTION
Fixes elastic/apm-agent-ruby#447 