### PR TITLE
Fix disabling verifying server certificate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 ### Fixed
 
 - Fix support for older versions of Http.rb ([#438](https://github.com/elastic/apm-agent-ruby/pull/434))
+- Fix disabling SSL verification ([#449](https://github.com/elastic/apm-agent-ruby/pull/449))
 
 ## 2.8.1 (2019-05-29)
 

--- a/lib/elastic_apm/transport/connection.rb
+++ b/lib/elastic_apm/transport/connection.rb
@@ -130,11 +130,20 @@ module ElasticAPM
         ].join(' ')
       end
 
-      def build_ssl_context
-        return unless @config.use_ssl? && @config.server_ca_cert
+      def build_ssl_context # rubocop:disable Metrics/MethodLength
+        return unless @config.use_ssl?
 
         OpenSSL::SSL::SSLContext.new.tap do |context|
-          context.ca_file = @config.server_ca_cert
+          if @config.server_ca_cert
+            context.ca_file = @config.server_ca_cert
+          end
+
+          context.verify_mode =
+            if @config.verify_server_cert
+              OpenSSL::SSL::VERIFY_PEER
+            else
+              OpenSSL::SSL::VERIFY_NONE
+            end
         end
       end
     end

--- a/spec/elastic_apm/transport/connection_spec.rb
+++ b/spec/elastic_apm/transport/connection_spec.rb
@@ -176,6 +176,43 @@ module ElasticAPM
         end
       end
 
+      describe 'verify_server_cert' do
+        let(:config) do
+          Config.new(server_url: 'https://self-signed.badssl.com')
+        end
+
+        it 'is enabled by default' do
+          expect(config.logger)
+            .to receive(:error)
+            .with(/OpenSSL::SSL::SSLError/)
+
+          WebMock.disable!
+          subject.write('')
+          subject.flush
+          WebMock.enable!
+        end
+
+        context 'when disabled' do
+          let(:config) do
+            Config.new(
+              server_url: 'https://self-signed.badssl.com',
+              verify_server_cert: false
+            )
+          end
+
+          it "doesn't complain" do
+            expect(config.logger)
+              .to_not receive(:error)
+              .with(/OpenSSL::SSL::SSLError/)
+
+            WebMock.disable!
+            subject.write('')
+            subject.flush
+            WebMock.enable!
+          end
+        end
+      end
+
       # rubocop:disable Metrics/MethodLength
       def build_stub(body: nil, headers: {}, to_return: {}, status: 202, &block)
         opts = {


### PR DESCRIPTION
Fixes elastic/apm-agent-ruby#443 