### PR TITLE
Handle source lines from files that misreport line counts

### DIFF
--- a/lib/elastic_apm/stacktrace/frame.rb
+++ b/lib/elastic_apm/stacktrace/frame.rb
@@ -32,6 +32,8 @@ module ElasticAPM
         to = lineno + padding - 1
         file_lines = read_lines(abs_path, from..to)
 
+        return unless file_lines
+
         self.context_line = file_lines[padding]
         self.pre_context  = file_lines.first(padding)
         self.post_context = file_lines.last(padding)
@@ -43,7 +45,7 @@ module ElasticAPM
       def read_lines(path, range)
         File.readlines(path)[range]
       rescue Errno::ENOENT
-        []
+        nil
       end
     end
   end


### PR DESCRIPTION
E.g. compiled slim templates as reported by @liamwhite.

https://github.com/elastic/apm-agent-ruby/pull/444

Closes #444