### PR TITLE
ci(jenkins): trigger async ITs and update github check for the pull request

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -175,7 +175,8 @@ pipeline {
         steps {
           log(level: 'INFO', text: 'Launching Async ITs')
           build(job: env.ITS_PIPELINE, propagate: false, wait: false,
-                parameters: [string(name: 'BUILD_OPTS', value: "--ruby-agent-version ${env.GIT_BASE_COMMIT}"),
+                parameters: [booleanParam(name: 'Run_As_Master_Branch', value: true),
+                             string(name: 'BUILD_OPTS', value: "--ruby-agent-version ${env.GIT_BASE_COMMIT}"),
                              string(name: 'GITHUB_CHECK_NAME', value: env.GITHUB_CHECK_ITS_NAME),
                              string(name: 'GITHUB_CHECK_REPO', value: env.REPO),
                              string(name: 'GITHUB_CHECK_SHA1', value: env.GIT_BASE_COMMIT)])

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -22,7 +22,7 @@ pipeline {
     DOCKER_REGISTRY = 'docker.elastic.co'
     DOCKER_SECRET = 'secret/apm-team/ci/docker-registry/prod'
     GITHUB_CHECK_ITS_NAME = 'Integration Tests'
-    ITS_PIPELINE = 'apm-integration-tests-mbp/master'
+    ITS_PIPELINE = 'apm-integration-tests-selector-mbp/master'
   }
   options {
     timeout(time: 2, unit: 'HOURS')
@@ -175,7 +175,7 @@ pipeline {
         steps {
           log(level: 'INFO', text: 'Launching Async ITs')
           build(job: env.ITS_PIPELINE, propagate: false, wait: false,
-                parameters: [booleanParam(name: 'Run_As_Master_Branch', value: true),
+                parameters: [string(name: 'AGENT_INTEGRATION_TEST', value: 'Ruby'),
                              string(name: 'BUILD_OPTS', value: "--ruby-agent-version ${env.GIT_BASE_COMMIT}"),
                              string(name: 'GITHUB_CHECK_NAME', value: env.GITHUB_CHECK_ITS_NAME),
                              string(name: 'GITHUB_CHECK_REPO', value: env.REPO),

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -176,7 +176,7 @@ pipeline {
           log(level: 'INFO', text: 'Launching Async ITs')
           build(job: env.ITS_PIPELINE, propagate: false, wait: false,
                 parameters: [string(name: 'AGENT_INTEGRATION_TEST', value: 'Ruby'),
-                             string(name: 'BUILD_OPTS', value: "--ruby-agent-version ${env.GIT_BASE_COMMIT} --ruby-agent-version-state ${env.GIT_BUILD_CAUSE}"),
+                             string(name: 'BUILD_OPTS', value: "--ruby-agent-version ${env.GIT_BASE_COMMIT} --ruby-agent-version-state ${env.GIT_BUILD_CAUSE} --ruby-agent-repo ${env.CHANGE_FORK}/${env.REPO}"),
                              string(name: 'GITHUB_CHECK_NAME', value: env.GITHUB_CHECK_ITS_NAME),
                              string(name: 'GITHUB_CHECK_REPO', value: env.REPO),
                              string(name: 'GITHUB_CHECK_SHA1', value: env.GIT_BASE_COMMIT)])

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -235,7 +235,7 @@ class RubyParallelTaskGenerator extends DefaultParallelTaskGenerator {
           steps.junit(allowEmptyResults: false,
             keepLongStdio: true,
             testResults: "**/spec/ruby-agent-junit.xml")
-          steps.codecov(repo: env.REPO, basedir: "${steps.env.BASE_DIR}",
+          steps.codecov(repo: "${steps.env.REPO}", basedir: "${steps.env.BASE_DIR}",
             secret: "${steps.env.CODECOV_SECRET}")
         }
       }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -176,7 +176,7 @@ pipeline {
           log(level: 'INFO', text: 'Launching Async ITs')
           build(job: env.ITS_PIPELINE, propagate: false, wait: false,
                 parameters: [string(name: 'AGENT_INTEGRATION_TEST', value: 'Ruby'),
-                             string(name: 'BUILD_OPTS', value: "--ruby-agent-version ${env.GIT_BASE_COMMIT}"),
+                             string(name: 'BUILD_OPTS', value: "--ruby-agent-version ${env.GIT_BASE_COMMIT} --ruby-agent-version-state ${env.GIT_BUILD_CAUSE}"),
                              string(name: 'GITHUB_CHECK_NAME', value: env.GITHUB_CHECK_ITS_NAME),
                              string(name: 'GITHUB_CHECK_REPO', value: env.REPO),
                              string(name: 'GITHUB_CHECK_SHA1', value: env.GIT_BASE_COMMIT)])


### PR DESCRIPTION
fixes https://github.com/elastic/apm-integration-testing/issues/41

## Highlights
- It's triggered for each PR by default and disabled to any upstream branches.
- Trigger the Integration Tests, aka ITs, pipelines from https://github.com/elastic/apm-integration-testing based on PRs or on demand, aka manually.
- It does trigger only the `ruby` stage in the ITs.
- ITs should be async.
- This new stage notifies the GitHub check with the status of the execution.
- Depends on https://github.com/elastic/apm-integration-testing/pull/470

## Tasks
- [x] Agree with the stakeholders
- [x] It does require to support ITs from commits rather than branches.