### PR TITLE
Change an example in configuration doc

### DIFF
--- a/docs/configuration.asciidoc
+++ b/docs/configuration.asciidoc
@@ -62,7 +62,7 @@ Some options can be set with `ENV` variables and all of them may be set in
 your source code.
 
 When setting values for lists using `ENV` variables, strings are split by comma
-eg `ELASTIC_APM_ENABLED_ENVIRONMENTS=development,production`.
+eg `ELASTIC_APM_CUSTOM_KEY_FILTERS="a,b" # => [/a/, /b/]`.
 
 [float]
 [[config-config-file]]


### PR DESCRIPTION
Hi, thank you for  the great gem. :smiley: 

I found a deprecated variable `ELASTIC_APM_ENABLED_ENVIRONMENTS` as an example in configuration doc, so I change it to another living variable.