### PR TITLE
ci: docs stage is handled within the elasticsearch-ci/docs

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -136,31 +136,6 @@ pipeline {
           }
         }
       }
-      /**
-      Build the documentation.
-      */
-      stage('Documentation') {
-        agent { label 'linux && immutable' }
-        options { skipDefaultCheckout() }
-        when {
-          beforeAgent true
-          allOf {
-            anyOf {
-              branch 'master'
-              branch "\\d+\\.\\d+"
-              branch "v\\d?"
-              tag "v\\d+\\.\\d+\\.\\d+*"
-              expression { return params.Run_As_Master_Branch }
-            }
-            expression { return params.doc_ci }
-          }
-        }
-        steps {
-          deleteDir()
-          unstash 'source'
-          buildDocs(docsDir: "${BASE_DIR}/docs", archive: true)
-        }
-      }
       stage('Integration Tests') {
         agent none
         when {

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -39,7 +39,6 @@ pipeline {
   }
   parameters {
     booleanParam(name: 'Run_As_Master_Branch', defaultValue: false, description: 'Allow to run any steps on a PR, some steps normally only run on master branch.')
-    booleanParam(name: 'doc_ci', defaultValue: true, description: 'Enable build docs.')
     booleanParam(name: 'bench_ci', defaultValue: true, description: 'Enable run benchmarks.')
   }
   stages {


### PR DESCRIPTION
This is now managed within the elasticsearch-ci itself, so not required to run twice

