### PR TITLE
MongoSpy: Change span name format and add command to the context's db.statement field

### DIFF
--- a/lib/elastic_apm/spies/mongo.rb
+++ b/lib/elastic_apm/spies/mongo.rb
@@ -55,10 +55,13 @@ module ElasticAPM
         end
 
         def build_context(event)
+          # Some MongoDB commands are not on collections but rather db admin commands.
+          # For these commands, the value at the `command_name` key is the integer 1.
+          collection = event.command[event.command_name] unless event.command[event.command_name] == 1
           Span::Context.new(
             db: {
               instance: event.database_name,
-              statement: nil,
+              statement: ("#{collection}.#{event.command_name}" if collection),
               type: 'mongodb',
               user: nil
             }

--- a/lib/elastic_apm/spies/mongo.rb
+++ b/lib/elastic_apm/spies/mongo.rb
@@ -63,7 +63,7 @@ module ElasticAPM
           Span::Context.new(
             db: {
               instance: event.database_name,
-              statement: event.command.inspect,
+              statement: event.command.to_s,
               type: 'mongodb',
               user: nil
             }

--- a/lib/elastic_apm/spies/mongo.rb
+++ b/lib/elastic_apm/spies/mongo.rb
@@ -36,6 +36,8 @@ module ElasticAPM
 
         def push_event(event)
           return unless ElasticAPM.current_transaction
+          # Some MongoDB commands are not on collections but rather db admin commands.
+          # For these commands, the value at the `command_name` key is the integer 1.
           collection = event.command[event.command_name] unless event.command[event.command_name] == 1
           name = [event.database_name, collection, event.command_name].compact.join('.')
 
@@ -57,9 +59,6 @@ module ElasticAPM
         end
 
         def build_context(event)
-          # Some MongoDB commands are not on collections but rather db admin commands.
-          # For these commands, the value at the `command_name` key is the integer 1.
-          collection = event.command[event.command_name] unless event.command[event.command_name] == 1
           Span::Context.new(
             db: {
               instance: event.database_name,

--- a/lib/elastic_apm/spies/mongo.rb
+++ b/lib/elastic_apm/spies/mongo.rb
@@ -36,10 +36,12 @@ module ElasticAPM
 
         def push_event(event)
           return unless ElasticAPM.current_transaction
+          collection = event.command[event.command_name] != 1 && event.command[event.command_name]
+          name = [event.database_name, collection, event.command_name].compact.join('.')
 
           span =
             ElasticAPM.start_span(
-              event.command_name.to_s,
+              name,
               TYPE,
               context: build_context(event)
             )
@@ -61,7 +63,7 @@ module ElasticAPM
           Span::Context.new(
             db: {
               instance: event.database_name,
-              statement: (collection && "#{collection}.#{event.command_name}"),
+              statement: event.command.inspect,
               type: 'mongodb',
               user: nil
             }

--- a/lib/elastic_apm/spies/mongo.rb
+++ b/lib/elastic_apm/spies/mongo.rb
@@ -36,7 +36,7 @@ module ElasticAPM
 
         def push_event(event)
           return unless ElasticAPM.current_transaction
-          collection = event.command[event.command_name] != 1 && event.command[event.command_name]
+          collection = event.command[event.command_name] unless event.command[event.command_name] == 1
           name = [event.database_name, collection, event.command_name].compact.join('.')
 
           span =

--- a/lib/elastic_apm/spies/mongo.rb
+++ b/lib/elastic_apm/spies/mongo.rb
@@ -34,12 +34,18 @@ module ElasticAPM
 
         private
 
+        # rubocop:disable Metrics/MethodLength
         def push_event(event)
           return unless ElasticAPM.current_transaction
-          # Some MongoDB commands are not on collections but rather db admin commands.
-          # For these commands, the value at the `command_name` key is the integer 1.
-          collection = event.command[event.command_name] unless event.command[event.command_name] == 1
-          name = [event.database_name, collection, event.command_name].compact.join('.')
+          # Some MongoDB commands are not on collections but rather are db
+          # admin commands. For these commands, the value at the `command_name`
+          # key is the integer 1.
+          unless event.command[event.command_name] == 1
+            collection = event.command[event.command_name]
+          end
+          name = [event.database_name,
+                  collection,
+                  event.command_name].compact.join('.')
 
           span =
             ElasticAPM.start_span(
@@ -50,6 +56,7 @@ module ElasticAPM
 
           @events[event.operation_id] = span
         end
+        # rubocop:enable Metrics/MethodLength
 
         def pop_event(event)
           return unless (curr = ElasticAPM.current_span)

--- a/lib/elastic_apm/spies/mongo.rb
+++ b/lib/elastic_apm/spies/mongo.rb
@@ -61,7 +61,7 @@ module ElasticAPM
           Span::Context.new(
             db: {
               instance: event.database_name,
-              statement: ("#{collection}.#{event.command_name}" if collection),
+              statement: (collection && "#{collection}.#{event.command_name}"),
               type: 'mongodb',
               user: nil
             }

--- a/spec/elastic_apm/spies/mongo_spec.rb
+++ b/spec/elastic_apm/spies/mongo_spec.rb
@@ -48,7 +48,8 @@ module ElasticAPM
       db = span.context.db
       expect(db.instance).to eq 'elastic-apm-test'
       expect(db.type).to eq 'mongodb'
-      expect(db.statement).to include '{"listCollections"=>1, "cursor"=>{}, "nameOnly"=>true,'
+      expect(db.statement).to include '{"listCollections"=>1, "cursor"=>{}, ' \
+        '"nameOnly"=>true'
       expect(db.user).to be nil
 
       client.close
@@ -81,8 +82,10 @@ module ElasticAPM
       db = span.context.db
       expect(db.instance).to eq 'elastic-apm-test'
       expect(db.type).to eq 'mongodb'
-      # ParallelCollectionScan doesn't send 'lsid' in the command so we can validate the entire command document.
-      expect(db.statement).to eq '{"parallelCollectionScan"=>"testing", "numCursors"=>1}'
+      # ParallelCollectionScan doesn't send 'lsid' in the command so we can
+      # validate the entire command document.
+      expect(db.statement).to eq '{"parallelCollectionScan"=>"testing", ' \
+        '"numCursors"=>1}'
       expect(db.user).to be nil
 
       client.close
@@ -90,15 +93,15 @@ module ElasticAPM
       ElasticAPM.stop
     end
 
-    it 'instruments commands containing special BSON types on collections', :intercept do
+    it 'instruments commands with special BSON types', :intercept do
       ElasticAPM.start
       client =
-          Mongo::Client.new(
-              [url],
-              database: 'elastic-apm-test',
-              logger: Logger.new(nil),
-              server_selection_timeout: 5
-          )
+        Mongo::Client.new(
+          [url],
+          database: 'elastic-apm-test',
+          logger: Logger.new(nil),
+          server_selection_timeout: 5
+        )
 
       ElasticAPM.with_transaction 'Mongo test' do
         client['testing'].find(a: BSON::Decimal128.new('1')).to_a

--- a/spec/elastic_apm/spies/mongo_spec.rb
+++ b/spec/elastic_apm/spies/mongo_spec.rb
@@ -48,7 +48,7 @@ module ElasticAPM
       db = span.context.db
       expect(db.instance).to eq 'elastic-apm-test'
       expect(db.type).to eq 'mongodb'
-      expect(db.statement).to include('{"listCollections"=>1, "cursor"=>{}, "nameOnly"=>true,')
+      expect(db.statement).to include '{"listCollections"=>1, "cursor"=>{}, "nameOnly"=>true,'
       expect(db.user).to be nil
 
       client.close
@@ -82,7 +82,7 @@ module ElasticAPM
       expect(db.instance).to eq 'elastic-apm-test'
       expect(db.type).to eq 'mongodb'
       # ParallelCollectionScan doesn't send 'lsid' in the command so we can validate the entire command document.
-      expect(db.statement).to eq "#{BSON::Document.new('parallelCollectionScan' => 'testing', 'numCursors' => 1)}"
+      expect(db.statement).to eq '{"parallelCollectionScan"=>"testing", "numCursors"=>1}'
       expect(db.user).to be nil
 
       client.close
@@ -113,7 +113,7 @@ module ElasticAPM
       db = span.context.db
       expect(db.instance).to eq 'elastic-apm-test'
       expect(db.type).to eq 'mongodb'
-      expect(db.statement).to include("#{BSON::Document.new('a' => BSON::Decimal128.new('1'))}")
+      expect(db.statement).to include '{"a"=>BSON::Decimal128(\'1\')}'
       expect(db.user).to be nil
 
       client.close

--- a/spec/elastic_apm/spies/mongo_spec.rb
+++ b/spec/elastic_apm/spies/mongo_spec.rb
@@ -4,13 +4,11 @@ require 'mongo'
 
 module ElasticAPM
   RSpec.describe 'Spy: MongoDB' do
-    before(:all) do
+    before(:context) do
       start_mongodb
-      ElasticAPM.start
     end
 
-    after(:all) do
-      ElasticAPM.stop
+    after(:context) do
       stop_mongodb
     end
 
@@ -28,7 +26,7 @@ module ElasticAPM
     end
 
     it 'instruments db admin commands', :intercept do
-
+      ElasticAPM.start
       client =
         Mongo::Client.new(
           [url],
@@ -54,10 +52,12 @@ module ElasticAPM
       expect(db.user).to be nil
 
       client.close
+
+      ElasticAPM.stop
     end
 
     it 'instruments commands on collections', :intercept do
-
+      ElasticAPM.start
       client =
         Mongo::Client.new(
           [url],
@@ -83,6 +83,8 @@ module ElasticAPM
       expect(db.user).to be nil
 
       client.close
+
+      ElasticAPM.stop
     end
   end
 end


### PR DESCRIPTION
### Change 1

 I've added the collection and command names to the `Span::Context::DB` in the `MongoSpy`.
The only tricky thing is, there are some MongoDB commands (mostly db admin commands) that aren't executed in the context of a collection. In this case, the format of the command is:

`{ command_name: 1 }`

with the integer 1 being in place of a collection name. For this case, I left the `db.statement` value as `nil`, as it was before.

For a command executed in the context of a collection, the mongodb command is in the format:

`{ command_name: collection_name }`

For this case, I made the `db.statement` value `collection_name.command_name`.

Let me know if that's ok or if you'd like to fill in the `db.statement` value somehow for the db admin commands (the first case).

### Change 2

I changed the `mongo_spec` to start/stop the `ElasticAPM` agent and mongodb server in `before(:all)`/`after(:all)` hooks, as starting mongodb in particular takes a few seconds. This way, the two specs can run without having to each start mongodb. 
Nevertheless, looked at the other spec files and I noticed that often the agent is started directly in the spec and not in a `before(:all)` hook. Is there a reason for that?

## Update

### Change 1

I've changed the span name to be in the format `db.collection.operation`.
When the command is at the db level, the collection name is the integer 1. For this case, the span name is in the format `db.operation`

### Change 2

I've added the entire command to the `db.statement` value. This is consistent with other spies, most notably the `SequelSpy`.

### Change 3

I changed the `mongo_spec` to start/stop the mongodb server in `before(:context)`/`after(:context)` hooks, as starting mongodb in particular takes a few seconds. This way, the two specs can run without having to each start mongodb. 