### PR TITLE
Support chained exceptions

### DIFF
--- a/lib/elastic_apm/error/exception.rb
+++ b/lib/elastic_apm/error/exception.rb
@@ -11,6 +11,7 @@ module ElasticAPM
           "#{exception.class}: #{exception.message}"
         @type = exception.class.to_s
         @module = format_module exception
+        @cause = self.class.new exception.cause if exception.cause
 
         attrs.each do |key, val|
           send(:"#{key}=", val)
@@ -24,7 +25,8 @@ module ElasticAPM
         :message,
         :module,
         :stacktrace,
-        :type
+        :type,
+        :cause
       )
 
       private

--- a/lib/elastic_apm/transport/serializers/error_serializer.rb
+++ b/lib/elastic_apm/transport/serializers/error_serializer.rb
@@ -48,7 +48,8 @@ module ElasticAPM
             code: keyword_field(exception.code),
             attributes: exception.attributes,
             stacktrace: exception.stacktrace.to_a,
-            handled: exception.handled
+            handled: exception.handled,
+            cause: (build_exception(exception.cause) if exception.cause)
           }
         end
 

--- a/spec/elastic_apm/error/exception_spec.rb
+++ b/spec/elastic_apm/error/exception_spec.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+module ElasticAPM
+  RSpec.describe Error::Exception do
+    describe '#initialize' do
+      it 'takes an exception and optional attributes' do
+        exc = Error::Exception.new ZeroDivisionError.new, message: 'Things'
+        expect(exc.message).to eq 'Things'
+        expect(exc.type).to eq 'ZeroDivisionError'
+      end
+
+      context 'with an exception chain' do
+        it 'chains the causes' do
+          exc = Error::Exception.new actual_chained_exception,
+            message: 'Things'
+          expect(exc.message).to eq 'Things'
+          expect(exc.type).to eq 'NoMethodError'
+
+          cause1 = exc.cause
+          expect(cause1).to be_a Error::Exception
+          expect(cause1.message).to eq 'Errno::ENOENT: No such file or ' \
+                                           'directory @ rb_sysopen - gotcha'
+          expect(cause1.type).to eq 'Errno::ENOENT'
+
+          cause2 = cause1.cause
+          expect(cause2).to be_a Error::Exception
+          expect(cause2.message).to eq 'ZeroDivisionError: divided by 0'
+          expect(cause2.type).to eq 'ZeroDivisionError'
+        end
+      end
+    end
+  end
+end

--- a/spec/elastic_apm/transport/serializers/error_serializer_spec.rb
+++ b/spec/elastic_apm/transport/serializers/error_serializer_spec.rb
@@ -74,7 +74,7 @@ module ElasticAPM
                 module: 'Errno',
                 code: nil,
                 attributes: nil,
-                stacktrace: be_an(Array),
+                stacktrace: eq([]),
                 handled: nil,
                 cause: be_a(Hash)
               )
@@ -86,7 +86,7 @@ module ElasticAPM
                 module: '',
                 code: nil,
                 attributes: nil,
-                stacktrace: be_an(Array),
+                stacktrace: eq([]),
                 handled: nil,
                 cause: nil
               )

--- a/spec/support/exception_helpers.rb
+++ b/spec/support/exception_helpers.rb
@@ -6,4 +6,20 @@ module ExceptionHelpers
   rescue => e # rubocop:disable Style/RescueStandardError
     e
   end
+
+  # rubocop:disable Metrics/MethodLength
+  def actual_chained_exception
+    1 / 0
+  rescue ZeroDivisionError
+    begin
+      File.open('gotcha')
+    rescue Errno::ENOENT
+      begin
+        [].merge
+      rescue NoMethodError => e
+        e
+      end
+    end
+  end
+  # rubocop:enable Metrics/MethodLength
 end


### PR DESCRIPTION
### Replaced by #488

Add support for chained exceptions in the `exception` sub-document of the serialized `error` document.

Changes:

1. Added an attribute `cause` on an `Error::Exception`. The cause is set to another `Error::Exception` that wraps the `#cause` value of the Ruby Exception. That `Error::Exception` may also have a `cause` attribute...thus making a chain.

2. Added a field `cause` to the `exception` sub-document in the serialized `error` object. The `cause` value is an object: the serialized chained exception.

3. Added tests for chained exceptions in the `ErrorSerializer` specs and created a new spec for testing the `Exception::Error` class.

Questions:
- Should `attrs` be passed to the new method for the chained exception? Attributes like `handled` should be passed (I think) but the `message` attribute shouldn’t be. See [here](https://github.com/elastic/apm-agent-ruby/compare/master...estolfo:exception-chain?expand=1#diff-3ce13d89f08b5686f82492b8fcee97b9R14).
- In the `exception` sub-document of the `error` document, should `cause` be nil if there is no cause or should it be excluded from the document?

Closes elastic/apm-agent-ruby#469