### PR TITLE
ci(jenkins): codecov should happen once, for ruby:2.6

### DIFF
--- a/.ci/.jenkins_codecov.yml
+++ b/.ci/.jenkins_codecov.yml
@@ -1,0 +1,7 @@
+---
+
+RUBY:
+  - ruby:2.6
+
+FRAMEWORK:
+  - rails-5.2

--- a/.ci/.jenkins_codecov.yml
+++ b/.ci/.jenkins_codecov.yml
@@ -2,4 +2,4 @@
 # Tuple of ruby version and frameworks which are in charge to send data to codecov.
 # # is the separator between the ruby version and the framework.
 ENABLED:
-  - ruby:2.6#rails-5.2
+  - ruby:2.6#rails-6.0.0

--- a/.ci/.jenkins_codecov.yml
+++ b/.ci/.jenkins_codecov.yml
@@ -1,7 +1,5 @@
 ---
-
-RUBY:
-  - ruby:2.6
-
-FRAMEWORK:
-  - rails-5.2
+# Tuple of ruby version and frameworks which are in charge to send data to codecov.
+# # is the separator between the ruby version and the framework.
+ENABLED:
+  - ruby:2.6#rails-5.2

--- a/.ci/.jenkins_codecov.yml
+++ b/.ci/.jenkins_codecov.yml
@@ -2,4 +2,4 @@
 # Tuple of ruby version and frameworks which are in charge to send data to codecov.
 # # is the separator between the ruby version and the framework.
 ENABLED:
-  - ruby:2.6#rails-6.0.0
+  - ruby:2.6#rails-6.0

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -205,7 +205,7 @@ def runJob(rubyVersion, boolean isCoverage=false){
     branch = env.CHANGE_TARGET
   }
 
-  build( job: "apm-agent-ruby/apm-agent-ruby-downstream/${branch}",
+  build( job: "apm-agent-ruby/apm-agent-ruby-downstream/PR-485",
     parameters: [
       string(name: 'RUBY_VERSION', value: "${rubyVersion}"),
       string(name: 'BRANCH_SPECIFIER', value: "${env.GIT_BASE_COMMIT}"),

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -217,7 +217,7 @@ def runBenchmark(version){
 }
 
 def runJob(rubyVersion){
-  build( job: "apm-agent-ruby/apm-agent-ruby-downstream/PR-485",
+  build( job: "apm-agent-ruby/apm-agent-ruby-downstream/${env.BRANCH_NAME}",
     parameters: [
       string(name: 'RUBY_VERSION', value: "${rubyVersion}"),
       string(name: 'BRANCH_SPECIFIER', value: "${env.GIT_BASE_COMMIT}")

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -69,7 +69,7 @@ pipeline {
               def ruby = readYaml(file: '.ci/.jenkins_ruby.yml')
               def testTasks = [:]
               ruby['RUBY_VERSION'].each{ rubyVersion ->
-                isCoverage = rubyVersion.equals('ruby:2.6')
+                isCoverage = rubyVersion.contains('ruby:2.6')
                 testTasks[rubyVersion] = { runJob(rubyVersion, isCoverage) }
               }
               parallel(testTasks)

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -88,8 +88,7 @@ pipeline {
               def ruby = readYaml(file: '.ci/.jenkins_ruby.yml')
               def testTasks = [:]
               ruby['RUBY_VERSION'].each{ rubyVersion ->
-                isCoverage = rubyVersion.contains('ruby:2.6')
-                testTasks[rubyVersion] = { runJob(rubyVersion, isCoverage) }
+                testTasks[rubyVersion] = { runJob(rubyVersion) }
               }
               parallel(testTasks)
               }
@@ -217,7 +216,7 @@ def runBenchmark(version){
   }
 }
 
-def runJob(rubyVersion, boolean isCoverage=false){
+def runJob(rubyVersion){
   def branch = env.BRANCH_NAME
 
   if (env.CHANGE_ID) {
@@ -228,8 +227,7 @@ def runJob(rubyVersion, boolean isCoverage=false){
     parameters: [
       string(name: 'RUBY_VERSION', value: "${rubyVersion}"),
       string(name: 'BRANCH_SPECIFIER', value: "${env.GIT_BASE_COMMIT}"),
-      string(name: 'MERGE_TARGET', value: "${branch}"),
-      booleanParam(name: 'POPULATE_COVERAGE', value: isCoverage)
+      string(name: 'MERGE_TARGET', value: "${branch}")
     ],
     quietPeriod: 15
   )

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -69,7 +69,8 @@ pipeline {
               def ruby = readYaml(file: '.ci/.jenkins_ruby.yml')
               def testTasks = [:]
               ruby['RUBY_VERSION'].each{ rubyVersion ->
-                testTasks[rubyVersion] = { runJob(rubyVersion) }
+                isCoverage = rubyVersion.equals('ruby:2.6')
+                testTasks[rubyVersion] = { runJob(rubyVersion, isCoverage) }
               }
               parallel(testTasks)
               }
@@ -197,19 +198,20 @@ def runBenchmark(version){
   }
 }
 
-def runJob(rubyVersion){
+def runJob(rubyVersion, boolean isCoverage=false){
   def branch = env.BRANCH_NAME
 
   if (env.CHANGE_ID) {
     branch = env.CHANGE_TARGET
   }
-  
-  build( job: "apm-agent-ruby/apm-agent-ruby-downstream/${branch}", 
+
+  build( job: "apm-agent-ruby/apm-agent-ruby-downstream/${branch}",
     parameters: [
-      string(name: 'RUBY_VERSION', value: "${rubyVersion}"), 
-      string(name: 'BRANCH_SPECIFIER', value: "${env.GIT_BASE_COMMIT}"), 
-      string(name: 'MERGE_TARGET', value: "${branch}")
-    ], 
+      string(name: 'RUBY_VERSION', value: "${rubyVersion}"),
+      string(name: 'BRANCH_SPECIFIER', value: "${env.GIT_BASE_COMMIT}"),
+      string(name: 'MERGE_TARGET', value: "${branch}"),
+      booleanParam(name: 'POPULATE_COVERAGE', value: isCoverage)
+    ],
     quietPeriod: 15
   )
 }

--- a/.ci/downstreamTests.groovy
+++ b/.ci/downstreamTests.groovy
@@ -169,10 +169,7 @@ def runScript(Map params = [:]){
 */
 def isCodecovEnabled(ruby, framework){
   dir(BASE_DIR){
-    sh 'ls -ltra'
-    sh 'ls -ltra .ci/.jenkins_codecov.yml'
     def codecovVersions = readYaml(file: '.ci/.jenkins_codecov.yml')
-    sh 'cat .ci/.jenkins_codecov.yml'
     return codecovVersions['ENABLED'].any { it.trim() == "${ruby?.trim()}#${framework?.trim()}" }
   }
 }

--- a/.ci/downstreamTests.groovy
+++ b/.ci/downstreamTests.groovy
@@ -175,6 +175,6 @@ def isCodecovEnabled(ruby, framework){
     sh 'ls -ltra .ci/.jenkins_codecov.yml'
     def codecovVersions = readYaml(file: '.ci/.jenkins_codecov.yml')
     sh 'cat .ci/.jenkins_codecov.yml'
-    return codecovVersions['ENABLED'].contains("${ruby?.trim()}#${framework?.trim()}")
+    return codecovVersions['ENABLED'].any { it.trim() == "${ruby?.trim()}#${framework?.trim()}" }
   }
 }

--- a/.ci/downstreamTests.groovy
+++ b/.ci/downstreamTests.groovy
@@ -165,10 +165,13 @@ def runScript(Map params = [:]){
   }
 }
 
-def isCodecovEnabled(x, y){
+/**
+* Whether the given ruby version and framework are in charge of sending the
+* codecov results. It does require the workspace.
+*/
+def isCodecovEnabled(ruby, framework){
   dir(BASE_DIR){
     def codecovVersions = readYaml(file: '.ci/.jenkins_codecov.yml')
-    return codecovVersions['RUBY'].find { ruby -> ruby?.trim().equals(x.trim()) } &&
-           codecovVersions['FRAMEWORK'].find { framework -> framework?.trim().equals(y.trim()) }
+    return codecovVersions['ENABLED'].find { it.trim().equals("${ruby?.trim()}#${framework?.trim()}") }
   }
 }

--- a/.ci/downstreamTests.groovy
+++ b/.ci/downstreamTests.groovy
@@ -171,7 +171,10 @@ def runScript(Map params = [:]){
 */
 def isCodecovEnabled(ruby, framework){
   dir(BASE_DIR){
+    sh 'ls -ltra'
+    sh 'ls -ltra .ci/.jenkins_codecov.yml'
     def codecovVersions = readYaml(file: '.ci/.jenkins_codecov.yml')
-    return codecovVersions['ENABLED'].find { it.trim().equals("${ruby?.trim()}#${framework?.trim()}") }
+    sh 'cat .ci/.jenkins_codecov.yml'
+    return codecovVersions['ENABLED'].contains("${ruby?.trim()}#${framework?.trim()}")
   }
 }

--- a/.ci/downstreamTests.groovy
+++ b/.ci/downstreamTests.groovy
@@ -37,6 +37,7 @@ pipeline {
     string(name: 'RUBY_VERSION', defaultValue: "ruby:2.6", description: "Ruby version to test")
     string(name: 'BRANCH_SPECIFIER', defaultValue: "master", description: "Git branch/tag to use")
     string(name: 'MERGE_TARGET', defaultValue: "master", description: "Git branch/tag to merge before building")
+    booleanParam(name: 'POPULATE_COVERAGE', defaultValue: false, description: 'Whether to send the coverage to codecov.io.')
   }
   stages {
     /**
@@ -47,7 +48,7 @@ pipeline {
       options { skipDefaultCheckout() }
       steps {
         deleteDir()
-        gitCheckout(basedir: "${BASE_DIR}", 
+        gitCheckout(basedir: "${BASE_DIR}",
           branch: "${params.BRANCH_SPECIFIER}",
           repo: "${REPO}",
           credentialsId: "${JOB_GIT_CREDENTIALS}",
@@ -135,8 +136,10 @@ class RubyParallelTaskGenerator extends DefaultParallelTaskGenerator {
           steps.junit(allowEmptyResults: true,
             keepLongStdio: true,
             testResults: "**/spec/ruby-agent-junit.xml")
-          steps.codecov(repo: "${steps.env.REPO}", basedir: "${steps.env.BASE_DIR}",
-            secret: "${steps.env.CODECOV_SECRET}")
+          if (steps.params.POPULATE_COVERAGE) {
+            steps.codecov(repo: "${steps.env.REPO}", basedir: "${steps.env.BASE_DIR}",
+                          secret: "${steps.env.CODECOV_SECRET}")
+          }
         }
       }
     }


### PR DESCRIPTION
## Highlights
- Matrix downstream job does run codecov for each run, let's run only once.

## Test Cases
- Without coverage

![image](https://user-images.githubusercontent.com/2871786/63517146-4f17e900-c4e6-11e9-95c5-7ee42ab87e60.png)

- With coverage

![image](https://user-images.githubusercontent.com/2871786/63519213-72dd2e00-c4ea-11e9-8b01-b426a45bf191.png)

## Tasks
- [ ] Revert https://github.com/elastic/apm-agent-ruby/pull/485/files/d63bf53fa1056c84a80506fe3738f086fe544025#diff-8db37e8fcea0f1a8f2f39667e94ebcc4R208 