### PR TITLE
ci(jenkins): parentstream job should trigger the specific downstream jobs

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -220,8 +220,7 @@ def runJob(rubyVersion){
   build( job: "apm-agent-ruby/apm-agent-ruby-downstream/${env.BRANCH_NAME}",
     parameters: [
       string(name: 'RUBY_VERSION', value: "${rubyVersion}"),
-      string(name: 'BRANCH_SPECIFIER', value: "${env.GIT_BASE_COMMIT}"),
-      string(name: 'MERGE_TARGET', value: '')
+      string(name: 'BRANCH_SPECIFIER', value: "${env.GIT_BASE_COMMIT}")
     ],
     quietPeriod: 15
   )

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -198,18 +198,12 @@ def runBenchmark(version){
 }
 
 def runJob(rubyVersion){
-  def branch = env.BRANCH_NAME
-
-  if (env.CHANGE_ID) {
-    branch = env.CHANGE_TARGET
-  }
-  
-  build( job: "apm-agent-ruby/apm-agent-ruby-downstream/${branch}", 
+  build( job: "apm-agent-ruby/apm-agent-ruby-downstream/${env.BRANCH_NAME}",
     parameters: [
-      string(name: 'RUBY_VERSION', value: "${rubyVersion}"), 
-      string(name: 'BRANCH_SPECIFIER', value: "${env.GIT_BASE_COMMIT}"), 
-      string(name: 'MERGE_TARGET', value: "${branch}")
-    ], 
+      string(name: 'RUBY_VERSION', value: "${rubyVersion}"),
+      string(name: 'BRANCH_SPECIFIER', value: "${env.GIT_BASE_COMMIT}"),
+      string(name: 'MERGE_TARGET', value: "${env.BRANCH_NAME}")
+    ],
     quietPeriod: 15
   )
 }

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -202,7 +202,7 @@ def runJob(rubyVersion){
     parameters: [
       string(name: 'RUBY_VERSION', value: "${rubyVersion}"),
       string(name: 'BRANCH_SPECIFIER', value: "${env.GIT_BASE_COMMIT}"),
-      string(name: 'MERGE_TARGET', value: "${env.BRANCH_NAME}")
+      string(name: 'MERGE_TARGET', value: '')
     ],
     quietPeriod: 15
   )

--- a/.ci/downstreamTests.groovy
+++ b/.ci/downstreamTests.groovy
@@ -36,7 +36,6 @@ pipeline {
   parameters {
     string(name: 'RUBY_VERSION', defaultValue: "ruby:2.6", description: "Ruby version to test")
     string(name: 'BRANCH_SPECIFIER', defaultValue: "master", description: "Git branch/tag to use")
-    string(name: 'MERGE_TARGET', defaultValue: "master", description: "Git branch/tag to merge before building")
   }
   stages {
     /**
@@ -50,8 +49,7 @@ pipeline {
         gitCheckout(basedir: "${BASE_DIR}",
           branch: "${params.BRANCH_SPECIFIER}",
           repo: "${REPO}",
-          credentialsId: "${JOB_GIT_CREDENTIALS}",
-          mergeTarget: "${params.MERGE_TARGET}")
+          credentialsId: "${JOB_GIT_CREDENTIALS}")
         stash allowEmpty: true, name: 'source', useDefaultExcludes: false
       }
     }

--- a/.ci/downstreamTests.groovy
+++ b/.ci/downstreamTests.groovy
@@ -47,11 +47,10 @@ pipeline {
       options { skipDefaultCheckout() }
       steps {
         deleteDir()
-        gitCheckout(basedir: "${BASE_DIR}", 
+        gitCheckout(basedir: "${BASE_DIR}",
           branch: "${params.BRANCH_SPECIFIER}",
           repo: "${REPO}",
           credentialsId: "${JOB_GIT_CREDENTIALS}",
-          mergeTarget: "${params.MERGE_TARGET}",
           reference: '/var/lib/jenkins/apm-agent-ruby.git')
         stash allowEmpty: true, name: 'source', useDefaultExcludes: false
       }


### PR DESCRIPTION
### Highlights
- Parentstream used to launch the `target` branch downstream job.
- This solution is trying to avoid the issues when merging PRs with the target branch as we get quite often some errors with `refusing to merge unrelated histories`
