### PR TITLE
ci(jenkins): fix the unrelated error when using a reference repo

### DIFF
--- a/.ci/downstreamTests.groovy
+++ b/.ci/downstreamTests.groovy
@@ -47,12 +47,11 @@ pipeline {
       options { skipDefaultCheckout() }
       steps {
         deleteDir()
-        gitCheckout(basedir: "${BASE_DIR}", 
+        gitCheckout(basedir: "${BASE_DIR}",
           branch: "${params.BRANCH_SPECIFIER}",
           repo: "${REPO}",
           credentialsId: "${JOB_GIT_CREDENTIALS}",
-          mergeTarget: "${params.MERGE_TARGET}",
-          reference: '/var/lib/jenkins/apm-agent-ruby.git')
+          mergeTarget: "${params.MERGE_TARGET}")
         stash allowEmpty: true, name: 'source', useDefaultExcludes: false
       }
     }


### PR DESCRIPTION
## Highlights
- I think when the reference repo is not up to date the merge cannot be done without getting the error `refusing to merge unrelated histories`.

## Test cases
- Let's merge another PR into master to see whether this PR gets built as expected.

## Tasks
- [x] Wait for a merge into master to see whether this particular PR solves the issue. 
  - https://github.com/elastic/apm-agent-ruby/pull/489 has been merged and I triggered manually the [build](https://apm-ci.elastic.co/job/apm-agent-ruby/job/apm-agent-ruby-downstream/view/change-requests/job/PR-492/2/), as the parentstream-downstream relation is based on the `master` branch (as designed initially)

