### PR TITLE
Drop MongoDB test collection before creation and at end of spec

### DIFF
--- a/spec/elastic_apm/spies/mongo_spec.rb
+++ b/spec/elastic_apm/spies/mongo_spec.rb
@@ -68,6 +68,7 @@ module ElasticAPM
         )
 
       # ParallelCollectionScan can only be run on an existing collection.
+      client['testing'].drop
       client['testing'].create
       ElasticAPM.with_transaction 'Mongo test' do
         client['testing'].parallel_scan(1).to_a
@@ -88,6 +89,7 @@ module ElasticAPM
         '"numCursors"=>1}'
       expect(db.user).to be nil
 
+      client['testing'].drop
       client.close
 
       ElasticAPM.stop


### PR DESCRIPTION
MongoDB will raise an OperationFailure if `createCollection` is called for an existing collection.