### PR TITLE
ci(jenkins): GitHub check context split in parentstream and downstream

### DIFF
--- a/.ci/jobs/apm-agent-ruby-downstream.yml
+++ b/.ci/jobs/apm-agent-ruby-downstream.yml
@@ -10,7 +10,8 @@
         discover-pr-forks-strategy: merge-current
         discover-pr-forks-trust: permission
         discover-pr-origin: merge-current
-        discover-tags: false
+        discover-tags: true
+        notification-context: 'apm-ci/downstream'
         property-strategies:
           all-branches:
           - suppress-scm-triggering: true


### PR DESCRIPTION
## Highlights
- Enable a new GH check to identify the downstream vs the parentstream executions
- Tags are now required for the downstream as the parentstream does trigger the specific downstream rather than the `master` branch