### PR TITLE
ci(jenkins): let's speed up builds by running in immutable pipelines

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -46,7 +46,7 @@ pipeline {
     Checkout the code and stash it, to use it on other stages.
     */
     stage('Checkout') {
-      agent { label 'master || immutable' }
+      agent { label 'immutable' }
       options { skipDefaultCheckout() }
       steps {
         deleteDir()

--- a/.ci/downstreamTests.groovy
+++ b/.ci/downstreamTests.groovy
@@ -42,7 +42,7 @@ pipeline {
     Checkout the code and stash it, to use it on other stages.
     */
     stage('Checkout') {
-      agent { label 'master || immutable' }
+      agent { label 'immutable' }
       options { skipDefaultCheckout() }
       steps {
         deleteDir()


### PR DESCRIPTION
## Highlights
- Master node might cause some issues as the number of parallel executors is quite small then it can cause some bottlenecks.
- Master node is always up and running and workers are ephemeral and run on demand.
- This particular PR will help to have more builds running in parallel and less in the build queue waiting for the master executor to be available.

## Notes
- https://github.com/elastic/apm-agent-ruby/pull/349 was the one which changed the behavior to use `master`
- `gobld` does not support `||` -> https://github.com/elastic/infra/blob/02d09a8a6bcf0a4ed4e4ed07e3a2638143ced10d/flavortown/gobld/gobld.go#L112-L113