### PR TITLE
ci(jenkins): decouple test frameworks in stable and master

### DIFF
--- a/.ci/.jenkins_framework.yml
+++ b/.ci/.jenkins_framework.yml
@@ -7,6 +7,3 @@ FRAMEWORK:
 
   - sinatra-2.0
   - sinatra-1.4
-
-  - rails-master
-  - sinatra-master

--- a/.ci/.jenkins_master_framework.yml
+++ b/.ci/.jenkins_master_framework.yml
@@ -1,0 +1,3 @@
+FRAMEWORK:
+  - rails-master
+  - sinatra-master

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -15,7 +15,7 @@ pipeline {
   environment {
     REPO = 'apm-agent-ruby'
     BASE_DIR = "src/github.com/elastic/${env.REPO}"
-    PIPELINE_LOG_LEVEL='INFO'
+    PIPELINE_LOG_LEVEL='DEBUG'
     NOTIFY_TO = credentials('notify-to')
     JOB_GCS_BUCKET = credentials('gcs-bucket')
     CODECOV_SECRET = 'secret/apm-team/ci/apm-agent-ruby-codecov'


### PR DESCRIPTION
Closes https://github.com/elastic/apm-agent-ruby/issues/496

## Highlights
- Split the tests in those which are based on stable versions and those which are based on the master branch.
- Tests will run in two sequential buckets, the first bucket for the stable versions and the second one with the master branches.
- The reason for splitting into two stages is to help with the visualization of the pipeline in the UI, we could potentially run more in parallel if required but the UI won't be so helpful, IMO.
- If master test bucket fails then it won't fail the build/pipeline but notify the build status as unstable. This will help to keep the attention of failures in the stable test frameworks and identify easily when a master test framework got issues

