### PR TITLE
ci(jenkins): avoid using the any as the master-worker should be avoided

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -11,7 +11,7 @@ it is need as field to store the results of the tests.
 @Field def rubyTasksGen
 
 pipeline {
-  agent any
+  agent { label 'immutable' }
   environment {
     REPO = 'apm-agent-ruby'
     BASE_DIR = "src/github.com/elastic/${env.REPO}"

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -11,7 +11,7 @@ it is need as field to store the results of the tests.
 @Field def rubyTasksGen
 
 pipeline {
-  agent { label 'immutable' }
+  agent { label 'linux && immutable' }
   environment {
     REPO = 'apm-agent-ruby'
     BASE_DIR = "src/github.com/elastic/${env.REPO}"

--- a/.ci/downstreamTests.groovy
+++ b/.ci/downstreamTests.groovy
@@ -11,7 +11,7 @@ it is need as field to store the results of the tests.
 @Field def rubyTasksGen
 
 pipeline {
-  agent any
+  agent { label 'linux && immutable' }
   environment {
     REPO="git@github.com:elastic/apm-agent-ruby.git"
     BASE_DIR="src/github.com/elastic/apm-agent-ruby"


### PR DESCRIPTION
## Highlights
- When working with ephemeral workers the only agent which might be always up is the `master` one, besides the static workers if any. So far, we don't have any after moving to windows ephemeral workers.
- This will help to avoid overloading the master, although might consume another worker which will be active from the very beginning of the pipeline until the very end as the post step happens at the `stages` level.
- This particular change will help to scale up when the build queue is long but will increase a bit the wait time.
- In other words, there are three major concepts regarding the overall time:
  - Waste of time for resources during the build
  - Waste of time for resources in the queue
  - Real build time.
- This particular fix will increase the time for the first one but will reduce the time in the queue.

## Follow-ups
- We might need to work on reducing the waste of time for resources during the build if required, but let's say for now, we can keep it simple with this particular fix.