### PR TITLE
feat: enable access to the jdk internals for the jruby docker images

### DIFF
--- a/spec/scripts/spec.sh
+++ b/spec/scripts/spec.sh
@@ -23,10 +23,18 @@ cd spec
 
 docker-compose up -d mongodb
 
+## Customise the docker container to enable the access to the internal of the jdk
+## for the jruby docker images.
+JDK_JAVA_OPTIONS=''
+if [[ $RUBY_IMAGE == *"jruby"* ]]; then
+  JDK_JAVA_OPTIONS='--illegal-access=permit'
+fi
+
 docker build --pull --build-arg "RUBY_IMAGE=${RUBY_IMAGE}" -t "apm-agent-ruby:${VERSION}" .
 RUBY_VERSION=${VERSION} docker-compose run \
   -e FRAMEWORK="${FRAMEWORK}" \
   -e INCLUDE_SCHEMA_SPECS=1 \
+  -e JDK_JAVA_OPTIONS="${JDK_JAVA_OPTIONS}" \
   -v "$(dirname "$(pwd)"):/app" \
   --rm ruby_rspec \
   /bin/bash -c "\


### PR DESCRIPTION
Closes https://github.com/elastic/apm-agent-ruby/issues/501

## Highlights
- Enable access to the JDK internals as requested.
- This PR doesn't modify the base JRuby docker images.

## Test cases
- [build](https://apm-ci.elastic.co/blue/organizations/jenkins/apm-agent-ruby%2Fapm-agent-ruby-downstream/detail/PR-502/7/pipeline/84#step-294-log-575) populated the `illegal-access` flag

```
[2019-08-22T12:05:10.288Z] + docker-compose run -e FRAMEWORK=rails-5.0 -e INCLUDE_SCHEMA_SPECS=1 -e JDK_JAVA_OPTIONS=--illegal-access=permit -v /var/lib/jenkins/workspace/apm-agent-ruby-downstream_PR-502/src/github.com/elastic/apm-agent-ruby:/app --rm ruby_rspec /bin/bash -c '    bundle install &&     timeout -s9 5m bundle exec rspec -f progress -f JUnit -o spec/ruby-agent-junit.xml spec'

[2019-08-22T12:05:10.288Z] NOTE: Picked up JDK_JAVA_OPTIONS: --illegal-access=permit
```

- [build](https://apm-ci.elastic.co/blue/organizations/jenkins/apm-agent-ruby%2Fapm-agent-ruby-downstream/detail/PR-502/4/pipeline/84#step-233-log-119) did not populate the flag:

```
[2019-08-22T12:02:36.857Z] + RUBY_VERSION=2.3
[2019-08-22T12:02:36.857Z] + docker-compose run -e FRAMEWORK=rails-4.2 -e INCLUDE_SCHEMA_SPECS=1 -e JDK_JAVA_OPTIONS= -v /var/lib/jenkins/workspace/apm-agent-ruby-downstream_PR-502/src/github.com/elastic/apm-agent-ruby:/app --rm ruby_rspec /bin/bash -c '    bundle install &&     timeout -s9 5m bundle exec rspec -f progress -f JUnit -o spec/ruby-agent-junit.xml spec'
```