### PR TITLE
ci(jenkins): use none as it's not required

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -10,6 +10,12 @@ it is need as field to store the results of the tests.
 */
 @Field def rubyTasksGen
 
+/**
+This is the git commit sha which it's required to be used in different stages.
+It does store the env GIT_BASE_COMMIT
+*/
+@Field def gitBaseCommit
+
 pipeline {
   agent none
   environment {
@@ -67,7 +73,7 @@ pipeline {
           unstash 'source'
           dir(BASE_DIR) {
             catchError(buildResult: 'SUCCESS', stageResult: 'UNSTABLE', message: 'Sanity checks failed but keep running the build') {
-              preCommit(commit: "${GIT_BASE_COMMIT}", junit: true)
+              preCommit(commit: "${gitBaseCommit}", junit: true)
             }
           }
         }
@@ -163,10 +169,10 @@ pipeline {
           log(level: 'INFO', text: 'Launching Async ITs')
           build(job: env.ITS_PIPELINE, propagate: false, wait: false,
                 parameters: [string(name: 'AGENT_INTEGRATION_TEST', value: 'Ruby'),
-                             string(name: 'BUILD_OPTS', value: "--ruby-agent-version ${env.GIT_BASE_COMMIT} --ruby-agent-version-state ${env.GIT_BUILD_CAUSE} --ruby-agent-repo ${env.CHANGE_FORK?.trim() ?: 'elastic'}/${env.REPO}"),
+                             string(name: 'BUILD_OPTS', value: "--ruby-agent-version ${gitBaseCommit} --ruby-agent-version-state ${env.GIT_BUILD_CAUSE} --ruby-agent-repo ${env.CHANGE_FORK?.trim() ?: 'elastic'}/${env.REPO}"),
                              string(name: 'GITHUB_CHECK_NAME', value: env.GITHUB_CHECK_ITS_NAME),
                              string(name: 'GITHUB_CHECK_REPO', value: env.REPO),
-                             string(name: 'GITHUB_CHECK_SHA1', value: env.GIT_BASE_COMMIT)]
+                             string(name: 'GITHUB_CHECK_SHA1', value: gitBaseCommit)]
           )
           githubNotify(context: "${env.GITHUB_CHECK_ITS_NAME}", description: "${env.GITHUB_CHECK_ITS_NAME} ...", status: 'PENDING', targetUrl: "${env.JENKINS_URL}search/?q=${env.ITS_PIPELINE.replaceAll('/','+')}")
         }
@@ -220,7 +226,7 @@ def runJob(rubyVersion){
   build( job: "apm-agent-ruby/apm-agent-ruby-downstream/${env.BRANCH_NAME}",
     parameters: [
       string(name: 'RUBY_VERSION', value: "${rubyVersion}"),
-      string(name: 'BRANCH_SPECIFIER', value: "${env.GIT_BASE_COMMIT}")
+      string(name: 'BRANCH_SPECIFIER', value: "${gitBaseCommit}")
     ],
     quietPeriod: 15
   )

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -12,9 +12,9 @@ it is need as field to store the results of the tests.
 
 /**
 This is the git commit sha which it's required to be used in different stages.
-It does store the env GIT_BASE_COMMIT
+It does store the env GIT_SHA
 */
-@Field def gitBaseCommit
+@Field def gitCommit
 
 pipeline {
   agent none
@@ -59,7 +59,7 @@ pipeline {
         gitCheckout(basedir: "${BASE_DIR}", githubNotifyFirstTimeContributor: true)
         stash allowEmpty: true, name: 'source', useDefaultExcludes: false
         script {
-          gitBaseCommit = env.GIT_BASE_COMMIT
+          gitCommit = env.GIT_SHA
         }
       }
     }
@@ -76,7 +76,7 @@ pipeline {
           unstash 'source'
           dir(BASE_DIR) {
             catchError(buildResult: 'SUCCESS', stageResult: 'UNSTABLE', message: 'Sanity checks failed but keep running the build') {
-              preCommit(commit: "${gitBaseCommit}", junit: true)
+              preCommit(commit: "${gitCommit}", junit: true)
             }
           }
         }
@@ -172,10 +172,10 @@ pipeline {
           log(level: 'INFO', text: 'Launching Async ITs')
           build(job: env.ITS_PIPELINE, propagate: false, wait: false,
                 parameters: [string(name: 'AGENT_INTEGRATION_TEST', value: 'Ruby'),
-                             string(name: 'BUILD_OPTS', value: "--ruby-agent-version ${gitBaseCommit} --ruby-agent-version-state ${env.GIT_BUILD_CAUSE} --ruby-agent-repo ${env.CHANGE_FORK?.trim() ?: 'elastic'}/${env.REPO}"),
+                             string(name: 'BUILD_OPTS', value: "--ruby-agent-version ${gitCommit} --ruby-agent-version-state ${env.GIT_BUILD_CAUSE} --ruby-agent-repo ${env.CHANGE_FORK?.trim() ?: 'elastic'}/${env.REPO}"),
                              string(name: 'GITHUB_CHECK_NAME', value: env.GITHUB_CHECK_ITS_NAME),
                              string(name: 'GITHUB_CHECK_REPO', value: env.REPO),
-                             string(name: 'GITHUB_CHECK_SHA1', value: gitBaseCommit)]
+                             string(name: 'GITHUB_CHECK_SHA1', value: gitCommit)]
           )
           githubNotify(context: "${env.GITHUB_CHECK_ITS_NAME}", description: "${env.GITHUB_CHECK_ITS_NAME} ...", status: 'PENDING', targetUrl: "${env.JENKINS_URL}search/?q=${env.ITS_PIPELINE.replaceAll('/','+')}")
         }
@@ -229,7 +229,7 @@ def runJob(rubyVersion){
   build( job: "apm-agent-ruby/apm-agent-ruby-downstream/${env.BRANCH_NAME}",
     parameters: [
       string(name: 'RUBY_VERSION', value: "${rubyVersion}"),
-      string(name: 'BRANCH_SPECIFIER', value: "${gitBaseCommit}")
+      string(name: 'BRANCH_SPECIFIER', value: "${gitCommit}")
     ],
     quietPeriod: 15
   )

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -61,7 +61,6 @@ pipeline {
         script {
           gitCommit = env.GIT_SHA
         }
-        sh 'env | sort'
       }
     }
     stage('Sanity checks') {

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -11,7 +11,7 @@ it is need as field to store the results of the tests.
 @Field def rubyTasksGen
 
 pipeline {
-  agent { label 'linux && immutable' }
+  agent none
   environment {
     REPO = 'apm-agent-ruby'
     BASE_DIR = "src/github.com/elastic/${env.REPO}"

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -61,6 +61,7 @@ pipeline {
         script {
           gitCommit = env.GIT_SHA
         }
+        sh 'env | sort'
       }
     }
     stage('Sanity checks') {

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -12,9 +12,9 @@ it is need as field to store the results of the tests.
 
 /**
 This is the git commit sha which it's required to be used in different stages.
-It does store the env GIT_SHA
+It does store the env GIT_BASE_COMMIT
 */
-@Field def gitCommit
+@Field def gitBaseCommit
 
 pipeline {
   agent none
@@ -59,7 +59,7 @@ pipeline {
         gitCheckout(basedir: "${BASE_DIR}", githubNotifyFirstTimeContributor: true)
         stash allowEmpty: true, name: 'source', useDefaultExcludes: false
         script {
-          gitCommit = env.GIT_SHA
+          gitBaseCommit = env.GIT_BASE_COMMIT
         }
       }
     }
@@ -76,7 +76,7 @@ pipeline {
           unstash 'source'
           dir(BASE_DIR) {
             catchError(buildResult: 'SUCCESS', stageResult: 'UNSTABLE', message: 'Sanity checks failed but keep running the build') {
-              preCommit(commit: "${gitCommit}", junit: true)
+              preCommit(commit: "${gitBaseCommit}", junit: true)
             }
           }
         }
@@ -172,10 +172,10 @@ pipeline {
           log(level: 'INFO', text: 'Launching Async ITs')
           build(job: env.ITS_PIPELINE, propagate: false, wait: false,
                 parameters: [string(name: 'AGENT_INTEGRATION_TEST', value: 'Ruby'),
-                             string(name: 'BUILD_OPTS', value: "--ruby-agent-version ${gitCommit} --ruby-agent-version-state ${env.GIT_BUILD_CAUSE} --ruby-agent-repo ${env.CHANGE_FORK?.trim() ?: 'elastic'}/${env.REPO}"),
+                             string(name: 'BUILD_OPTS', value: "--ruby-agent-version ${gitBaseCommit} --ruby-agent-version-state ${env.GIT_BUILD_CAUSE} --ruby-agent-repo ${env.CHANGE_FORK?.trim() ?: 'elastic'}/${env.REPO}"),
                              string(name: 'GITHUB_CHECK_NAME', value: env.GITHUB_CHECK_ITS_NAME),
                              string(name: 'GITHUB_CHECK_REPO', value: env.REPO),
-                             string(name: 'GITHUB_CHECK_SHA1', value: gitCommit)]
+                             string(name: 'GITHUB_CHECK_SHA1', value: gitBaseCommit)]
           )
           githubNotify(context: "${env.GITHUB_CHECK_ITS_NAME}", description: "${env.GITHUB_CHECK_ITS_NAME} ...", status: 'PENDING', targetUrl: "${env.JENKINS_URL}search/?q=${env.ITS_PIPELINE.replaceAll('/','+')}")
         }
@@ -229,7 +229,7 @@ def runJob(rubyVersion){
   build( job: "apm-agent-ruby/apm-agent-ruby-downstream/${env.BRANCH_NAME}",
     parameters: [
       string(name: 'RUBY_VERSION', value: "${rubyVersion}"),
-      string(name: 'BRANCH_SPECIFIER', value: "${gitCommit}")
+      string(name: 'BRANCH_SPECIFIER', value: "${gitBaseCommit}")
     ],
     quietPeriod: 15
   )

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -58,6 +58,9 @@ pipeline {
         deleteDir()
         gitCheckout(basedir: "${BASE_DIR}", githubNotifyFirstTimeContributor: true)
         stash allowEmpty: true, name: 'source', useDefaultExcludes: false
+        script {
+          gitBaseCommit = env.GIT_BASE_COMMIT
+        }
       }
     }
     stage('Sanity checks') {

--- a/.ci/downstreamTests.groovy
+++ b/.ci/downstreamTests.groovy
@@ -159,7 +159,10 @@ def runScript(Map params = [:]){
 * codecov results. It does require the workspace.
 */
 def isCodecovEnabled(ruby, framework){
+  sh 'ls -ltra'
   dir(BASE_DIR){
+    sh 'ls -ltra'
+    sh 'cat .ci/.jenkins_codecov.yml'
     def codecovVersions = readYaml(file: '.ci/.jenkins_codecov.yml')
     return codecovVersions['ENABLED'].any { it.trim() == "${ruby?.trim()}#${framework?.trim()}" }
   }


### PR DESCRIPTION
## Highlights
- So far I don't see it's required to use the agent at the top level, the post action already provided the node internally within the step defined in the shared library.
- This PR will reduce the number of required workers and therefore more parallel builds.
- GIT_SHA rather than GIT_BASE_COMMIT as the last one is caused when doing a merge within a PR.