### PR TITLE
Support Global labels

### DIFF
--- a/docs/configuration.asciidoc
+++ b/docs/configuration.asciidoc
@@ -259,6 +259,10 @@ Add default tags to add to every transaction.
 
 WARNING: Be aware that tags are indexed in Elasticsearch. Using too many unique keys will result in *https://www.elastic.co/blog/found-crash-elasticsearch#mapping-explosion[Mapping explosion]*.
 
+NOTE: `global_labels` are supported as of APM server version 7.2. `default_tags` will eventually be
+deprecated to please transition to using `global_labels` instead. In the meantime, any `default_tags`
+that are set will override `global_labels`.
+
 [float]
 [[config-disable-send]]
 ==== `disable_send`
@@ -348,9 +352,22 @@ otherwise defaults to `nil`.
 | `ELASTIC_APM_FRAMEWORK_VERSION` | `framework_version` | Depending on framework
 |============
 
-Version number of the used framework.
-For Ruby on Rails and Sinatra, this defaults to the used version of the framework,
-otherwise, the default is `nil`.
+[float]
+[[config-global-labels]]
+==== `global_labels`
+
+[options="header"]
+|============
+| Environment                 | `Config` key    | Default  | Example
+| `ELASTIC_APM_GLOBAL_LABELS` | `global_labels` | `nil`    | `dept=engineering,rack=number8`
+|============
+
+Labels added to all events, with the format key=value[,key=value[,...]].
+
+NOTE: This option requires APM Server 7.2 or greater, and will have no effect when using older
+server versions. `default_tags` will eventually be deprecated but in the meantime, their value
+will override any `global_labels`. Please transition to using `global_labels` instead of
+`default_tags` in light of this deprecation.
 
 [float]
 [[config-hostname]]

--- a/docs/configuration.asciidoc
+++ b/docs/configuration.asciidoc
@@ -352,6 +352,10 @@ otherwise defaults to `nil`.
 | `ELASTIC_APM_FRAMEWORK_VERSION` | `framework_version` | Depending on framework
 |============
 
+Version number of the used framework.
+For Ruby on Rails and Sinatra, this defaults to the used version of the framework,
+otherwise, the default is `nil`.
+
 [float]
 [[config-global-labels]]
 ==== `global_labels`

--- a/docs/configuration.asciidoc
+++ b/docs/configuration.asciidoc
@@ -260,7 +260,7 @@ Add default tags to add to every transaction.
 WARNING: Be aware that tags are indexed in Elasticsearch. Using too many unique keys will result in *https://www.elastic.co/blog/found-crash-elasticsearch#mapping-explosion[Mapping explosion]*.
 
 NOTE: `global_labels` are supported as of APM server version 7.2. `default_tags` will eventually be
-deprecated to please transition to using `global_labels` instead. In the meantime, any `default_tags`
+deprecated so please transition to using `global_labels` instead. In the meantime, any `default_tags`
 that are set will override `global_labels`.
 
 [float]

--- a/lib/elastic_apm/config.rb
+++ b/lib/elastic_apm/config.rb
@@ -54,6 +54,7 @@ module ElasticAPM
     option :framework_name,                    type: :string
     option :framework_version,                 type: :string
     option :filter_exception_types,            type: :list,   default: []
+    option :global_labels,                     type: :dict
     option :hostname,                          type: :string
     option :http_compression,                  type: :bool,   default: true
     option :ignore_url_patterns,               type: :list,   default: [],      converter: RegexpList.new

--- a/lib/elastic_apm/metadata.rb
+++ b/lib/elastic_apm/metadata.rb
@@ -7,9 +7,10 @@ module ElasticAPM
       @service = ServiceInfo.new(config)
       @process = ProcessInfo.new(config)
       @system = SystemInfo.new(config)
+      @labels = config.global_labels
     end
 
-    attr_reader :service, :process, :system
+    attr_reader :service, :process, :system, :labels
   end
 end
 

--- a/lib/elastic_apm/transport/serializers/metadata_serializer.rb
+++ b/lib/elastic_apm/transport/serializers/metadata_serializer.rb
@@ -10,7 +10,8 @@ module ElasticAPM
             metadata: {
               service: build_service(metadata.service),
               process: build_process(metadata.process),
-              system: build_system(metadata.system)
+              system: build_system(metadata.system),
+              labels: build_labels(metadata.labels)
             }
           }
         end
@@ -58,6 +59,10 @@ module ElasticAPM
             platform: keyword_field(system.platform),
             kubernetes: keyword_object(system.kubernetes)
           }
+        end
+
+        def build_labels(labels)
+          keyword_object(labels)
         end
       end
     end

--- a/spec/elastic_apm/config_spec.rb
+++ b/spec/elastic_apm/config_spec.rb
@@ -48,6 +48,11 @@ module ElasticAPM
           'ELASTIC_APM_DEFAULT_TAGS',
           'test=something something&other=ok',
           { 'test' => 'something something', 'other' => 'ok' }
+        ],
+        [
+          'ELASTIC_APM_GLOBAL_LABELS',
+          'why=hello goodbye,apple=orange',
+          { 'why' => 'hello goodbye', 'apples' => 'oranges' }
         ]
       ].each do |(key, val, expected)|
         with_env(key => val) do

--- a/spec/elastic_apm/config_spec.rb
+++ b/spec/elastic_apm/config_spec.rb
@@ -51,7 +51,7 @@ module ElasticAPM
         ],
         [
           'ELASTIC_APM_GLOBAL_LABELS',
-          'why=hello goodbye,apple=orange',
+          'why=hello goodbye,apples=oranges',
           { 'why' => 'hello goodbye', 'apples' => 'oranges' }
         ]
       ].each do |(key, val, expected)|

--- a/spec/elastic_apm/metadata_spec.rb
+++ b/spec/elastic_apm/metadata_spec.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+module ElasticAPM
+  RSpec.describe Metadata do
+    let(:config) { Config.new(global_labels: { apples: 'oranges' }) }
+    subject { described_class.new(config) }
+
+    describe '#labels' do
+      it 'accesses the config\'s labels' do
+        expect(subject.labels).to eq(apples: 'oranges')
+      end
+    end
+  end
+end

--- a/spec/elastic_apm/transport/serializers/metadata_serializer_spec.rb
+++ b/spec/elastic_apm/transport/serializers/metadata_serializer_spec.rb
@@ -7,17 +7,31 @@ module ElasticAPM
     module Serializers
       RSpec.describe MetadataSerializer do
         subject { described_class.new Config.new }
+        let(:result) { subject.build(metadata) }
 
         describe '#build' do
           let(:metadata) { Metadata.new Config.new }
-          let(:result) { subject.build(metadata) }
 
-          it 'is a bunch of hashes' do
+          it 'is a bunch of hashes and no labels' do
             expect(result[:metadata]).to be_a Hash
             expect(result[:metadata][:service]).to be_a Hash
             expect(result[:metadata][:process]).to be_a Hash
             expect(result[:metadata][:system]).to be_a Hash
             expect(result[:metadata][:labels]).to be_nil
+          end
+
+          context 'when there are global_labels' do
+            let(:metadata) do
+              Metadata.new Config.new(global_labels: { apples: 'oranges' })
+            end
+
+            it 'is a bunch of hashes' do
+              expect(result[:metadata]).to be_a Hash
+              expect(result[:metadata][:service]).to be_a Hash
+              expect(result[:metadata][:process]).to be_a Hash
+              expect(result[:metadata][:system]).to be_a Hash
+              expect(result[:metadata][:labels]).to be_a Hash
+            end
           end
         end
       end

--- a/spec/elastic_apm/transport/serializers/metadata_serializer_spec.rb
+++ b/spec/elastic_apm/transport/serializers/metadata_serializer_spec.rb
@@ -17,6 +17,7 @@ module ElasticAPM
             expect(result[:metadata][:service]).to be_a Hash
             expect(result[:metadata][:process]).to be_a Hash
             expect(result[:metadata][:system]).to be_a Hash
+            expect(result[:metadata][:labels]).to be_nil
           end
         end
       end


### PR DESCRIPTION
Add support for global labels.
Closes https://github.com/elastic/apm-agent-ruby/issues/385

1. Support `ELASTIC_APM_GLOBAL_LABELS` configuration option. Global labels are in the format `key=value[,key=value[,...]]`. Only accepted in APM server >= 7.2 so `default_tags` are still supported, as long as the server accepts `tags` in events' `context`. Will be deprecated at a later point.
2. Include configured `global_labels` in the `labels` field of a `metadata` object.
3. Documentation