### PR TITLE
Return Error object from report

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 
 ### Changed
 
-- `ElasticAPM.report` and `ElasticAPM.report_message` now return the generated `Error` objects ([#]())
+- `ElasticAPM.report` and `ElasticAPM.report_message` now return the generated `Error` objects ([#507](https://github.com/elastic/apm-agent-ruby/pull/507))
 
 ## 2.9.1 (2019-06-28)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 - Change span name format and add command to context's db.statement for `MongoSpy` ([#488](https://github.com/elastic/apm-agent-ruby/pull/490))
 - Support for APM Agent Configuration via Kibana ([#464](https://github.com/elastic/apm-agent-ruby/pull/464))
 
+### Changed
+
+- `ElasticAPM.report` and `ElasticAPM.report_message` now return the generated `Error` objects ([#]())
+
 ## 2.9.1 (2019-06-28)
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 
 ### Changed
 
-- `ElasticAPM.report` and `ElasticAPM.report_message` now return the generated `Error` objects ([#507](https://github.com/elastic/apm-agent-ruby/pull/507))
+- `ElasticAPM.report` and `ElasticAPM.report_message` return the string ID of the generated `Error` objects ([#507](https://github.com/elastic/apm-agent-ruby/pull/507))
 
 ## 2.9.1 (2019-06-28)
 

--- a/docs/api.asciidoc
+++ b/docs/api.asciidoc
@@ -212,7 +212,7 @@ Arguments:
   * `handled`: Whether the error was _handled_ eg. wasn't rescued and was represented
   to the user. Default: `true`.
 
-Returns `[ElasticAPM::Error]`.
+Returns `[String]` ID of the generated `[ElasticAPM::Error]` object.
 
 [float]
 [[api-agent-report-message]]
@@ -231,7 +231,7 @@ Arguments:
 
   * `message`: A custom error string. **Required**.
 
-Returns `[ElasticAPM::Error]`.
+Returns `[String]` ID of the generated `[ElasticAPM::Error]` object.
 
 [float]
 [[api-context]]

--- a/lib/elastic_apm.rb
+++ b/lib/elastic_apm.rb
@@ -305,7 +305,7 @@ module ElasticAPM # rubocop:disable Metrics/ModuleLength
     # @param exception [Exception] The exception
     # @param context [Context] An optional [Context]
     # @param handled [Boolean] Whether the exception was rescued
-    # @return [Error] The generated [Error]
+    # @return [String] ID of the generated [Error]
     def report(exception, context: nil, handled: true)
       agent&.report(exception, context: context, handled: handled)
     end
@@ -314,7 +314,7 @@ module ElasticAPM # rubocop:disable Metrics/ModuleLength
     #
     # @param message [String] The message
     # @param context [Context] An optional [Context]
-    # @return [Error] The generated [Error]
+    # @return [String] ID of the generated [Error]
     def report_message(message, context: nil, **attrs)
       agent&.report_message(
         message,

--- a/lib/elastic_apm/agent.rb
+++ b/lib/elastic_apm/agent.rb
@@ -196,6 +196,7 @@ module ElasticAPM
         handled: handled
       )
       enqueue error
+      error
     end
 
     def report_message(message, context: nil, backtrace: nil, **attrs)
@@ -206,6 +207,7 @@ module ElasticAPM
         **attrs
       )
       enqueue error
+      error
     end
 
     # filters

--- a/lib/elastic_apm/agent.rb
+++ b/lib/elastic_apm/agent.rb
@@ -196,7 +196,7 @@ module ElasticAPM
         handled: handled
       )
       enqueue error
-      error
+      error.id
     end
 
     def report_message(message, context: nil, backtrace: nil, **attrs)
@@ -207,7 +207,7 @@ module ElasticAPM
         **attrs
       )
       enqueue error
-      error
+      error.id
     end
 
     # filters

--- a/spec/elastic_apm/agent_spec.rb
+++ b/spec/elastic_apm/agent_spec.rb
@@ -75,6 +75,11 @@ module ElasticAPM
             .to change(@intercepted.errors, :length).by 1
         end
 
+        it 'returns error object' do
+          result = subject.report(actual_exception)
+          expect(result).to be_an ElasticAPM::Error
+        end
+
         context 'with filtered exception types' do
           class AgentTestError < StandardError; end
 
@@ -95,6 +100,11 @@ module ElasticAPM
         it 'queues a request' do
           expect { subject.report_message('Everything went 💥') }
             .to change(@intercepted.errors, :length).by 1
+        end
+
+        it 'returns error object' do
+          result = subject.report_message(actual_exception)
+          expect(result).to be_an ElasticAPM::Error
         end
       end
     end

--- a/spec/elastic_apm/agent_spec.rb
+++ b/spec/elastic_apm/agent_spec.rb
@@ -77,7 +77,7 @@ module ElasticAPM
 
         it 'returns error object' do
           result = subject.report(actual_exception)
-          expect(result).to be_an ElasticAPM::Error
+          expect(result).to be_a String
         end
 
         context 'with filtered exception types' do
@@ -104,7 +104,7 @@ module ElasticAPM
 
         it 'returns error object' do
           result = subject.report_message(actual_exception)
-          expect(result).to be_an ElasticAPM::Error
+          expect(result).to be_a String
         end
       end
     end


### PR DESCRIPTION
Suggested in https://discuss.elastic.co/t/make-elasticapm-report-return-an-error-or-error-id-instead-of-true/196504.