### PR TITLE
ci(jenkins): revert none agent

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -10,14 +10,8 @@ it is need as field to store the results of the tests.
 */
 @Field def rubyTasksGen
 
-/**
-This is the git commit sha which it's required to be used in different stages.
-It does store the env GIT_SHA
-*/
-@Field def gitCommit
-
 pipeline {
-  agent none
+  agent { label 'linux && immutable' }
   environment {
     REPO = 'apm-agent-ruby'
     BASE_DIR = "src/github.com/elastic/${env.REPO}"
@@ -58,9 +52,6 @@ pipeline {
         deleteDir()
         gitCheckout(basedir: "${BASE_DIR}", githubNotifyFirstTimeContributor: true)
         stash allowEmpty: true, name: 'source', useDefaultExcludes: false
-        script {
-          gitCommit = env.GIT_SHA
-        }
       }
     }
     stage('Sanity checks') {
@@ -76,7 +67,7 @@ pipeline {
           unstash 'source'
           dir(BASE_DIR) {
             catchError(buildResult: 'SUCCESS', stageResult: 'UNSTABLE', message: 'Sanity checks failed but keep running the build') {
-              preCommit(commit: "${gitCommit}", junit: true)
+              preCommit(commit: "${GIT_BASE_COMMIT}", junit: true)
             }
           }
         }
@@ -172,10 +163,10 @@ pipeline {
           log(level: 'INFO', text: 'Launching Async ITs')
           build(job: env.ITS_PIPELINE, propagate: false, wait: false,
                 parameters: [string(name: 'AGENT_INTEGRATION_TEST', value: 'Ruby'),
-                             string(name: 'BUILD_OPTS', value: "--ruby-agent-version ${gitCommit} --ruby-agent-version-state ${env.GIT_BUILD_CAUSE} --ruby-agent-repo ${env.CHANGE_FORK?.trim() ?: 'elastic'}/${env.REPO}"),
+                             string(name: 'BUILD_OPTS', value: "--ruby-agent-version ${env.GIT_BASE_COMMIT} --ruby-agent-version-state ${env.GIT_BUILD_CAUSE} --ruby-agent-repo ${env.CHANGE_FORK?.trim() ?: 'elastic'}/${env.REPO}"),
                              string(name: 'GITHUB_CHECK_NAME', value: env.GITHUB_CHECK_ITS_NAME),
                              string(name: 'GITHUB_CHECK_REPO', value: env.REPO),
-                             string(name: 'GITHUB_CHECK_SHA1', value: gitCommit)]
+                             string(name: 'GITHUB_CHECK_SHA1', value: env.GIT_BASE_COMMIT)]
           )
           githubNotify(context: "${env.GITHUB_CHECK_ITS_NAME}", description: "${env.GITHUB_CHECK_ITS_NAME} ...", status: 'PENDING', targetUrl: "${env.JENKINS_URL}search/?q=${env.ITS_PIPELINE.replaceAll('/','+')}")
         }
@@ -229,7 +220,7 @@ def runJob(rubyVersion){
   build( job: "apm-agent-ruby/apm-agent-ruby-downstream/${env.BRANCH_NAME}",
     parameters: [
       string(name: 'RUBY_VERSION', value: "${rubyVersion}"),
-      string(name: 'BRANCH_SPECIFIER', value: "${gitCommit}")
+      string(name: 'BRANCH_SPECIFIER', value: "${env.GIT_BASE_COMMIT}")
     ],
     quietPeriod: 15
   )

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -12,7 +12,7 @@ it is need as field to store the results of the tests.
 
 /**
 This is the git commit sha which it's required to be used in different stages.
-It does store the env GIT_BASE_COMMIT
+It does store the env GIT_SHA
 */
 @Field def gitCommit
 
@@ -59,7 +59,7 @@ pipeline {
         gitCheckout(basedir: "${BASE_DIR}", githubNotifyFirstTimeContributor: true)
         stash allowEmpty: true, name: 'source', useDefaultExcludes: false
         script {
-          gitCommit = env.GIT_BASE_COMMIT
+          gitCommit = env.GIT_SHA
         }
       }
     }


### PR DESCRIPTION
Revert https://github.com/elastic/apm-agent-ruby/pull/508 and https://github.com/elastic/apm-agent-ruby/pull/503

## Highlights
- As long as we use the share step `gitCheckout` we might need to use the agent top-level to share the env variables between stages.
- It's not ideal but even though the changes were quite straight, its behavior was not as expected. 
- Let's keep the pipeline stable for now and we will figure out what's going on.