### PR TITLE
feat: disable shallow cloning when using downstream pipelines

### DIFF
--- a/.ci/downstreamTests.groovy
+++ b/.ci/downstreamTests.groovy
@@ -49,7 +49,9 @@ pipeline {
         gitCheckout(basedir: "${BASE_DIR}",
           branch: "${params.BRANCH_SPECIFIER}",
           repo: "${REPO}",
-          credentialsId: "${JOB_GIT_CREDENTIALS}")
+          credentialsId: "${JOB_GIT_CREDENTIALS}",
+          shallow: false
+        )
         stash allowEmpty: true, name: 'source', useDefaultExcludes: false
       }
     }


### PR DESCRIPTION
## Highlights
- Shallow cloning with a mergeTarget causes` the refusing to merge unrelated histories` issue.
- Avoid shallow cloning then.