### PR TITLE
Decrease default stack_trace_limit to 50

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ No changes are necessary to your app.
 
 - Errors' `message` no longer include their `type` ([#323](https://github.com/elastic/apm-agent-ruby/pull/323/files))
 - External request spans now have type `external.http.{library}` ([#514](https://github.com/elastic/apm-agent-ruby/pull/514))
+- Decrease default `stack_trace_limit` to 50 ([#515](https://github.com/elastic/apm-agent-ruby/pull/515))
 
 ## 2.10.0
 

--- a/lib/elastic_apm/config.rb
+++ b/lib/elastic_apm/config.rb
@@ -67,7 +67,7 @@ module ElasticAPM
     option :source_lines_span_app_frames,      type: :int,    default: 5
     option :source_lines_span_library_frames,  type: :int,    default: 0
     option :span_frames_min_duration,          type: :float,  default: '5ms',   converter: Duration.new(default_unit: 'ms')
-    option :stack_trace_limit,                 type: :int,    default: 999_999
+    option :stack_trace_limit,                 type: :int,    default: 50
     option :transaction_max_spans,             type: :int,    default: 500
     option :transaction_sample_rate,           type: :float,  default: 1.0
     option :verify_server_cert,                type: :bool,   default: true


### PR DESCRIPTION
To align with other agents.