### PR TITLE
ci(jenkins): decouple sanity check from CI pipeline

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -56,6 +56,13 @@ pipeline {
     }
     stage('Sanity checks') {
       agent { label 'linux && immutable && docker' }
+      when {
+        beforeAgent true
+        anyOf {
+          not { changeRequest() }
+          expression { return params.Run_As_Master_Branch }
+        }
+      }
       options { skipDefaultCheckout() }
       environment {
         HOME = "${env.WORKSPACE}"

--- a/.ci/jobs/apm-agent-ruby-linting-mbp.yml
+++ b/.ci/jobs/apm-agent-ruby-linting-mbp.yml
@@ -1,0 +1,38 @@
+---
+- job:
+    name: apm-agent-ruby/apm-agent-ruby-linting-mbp
+    display-name: APM Agent Ruby Linting
+    description: APM Agent Ruby Linting
+    script-path: .ci/linting.groovy
+    scm:
+    - github:
+        branch-discovery: no-pr
+        discover-pr-forks-strategy: merge-current
+        discover-pr-forks-trust: permission
+        discover-pr-origin: merge-current
+        discover-tags: false
+        notification-context: 'apm-ci/linting'
+        head-filter-regex: '^PR-.*$'
+        repo: apm-agent-ruby
+        repo-owner: elastic
+        credentials-id: 2a9602aa-ab9f-4e52-baf3-b71ca88469c7-UserAndToken
+        ssh-checkout:
+          credentials: f6c7695a-671e-4f4f-a331-acdce44ff9ba
+        build-strategies:
+        - change-request:
+            ignore-target-only-changes: false
+        clean:
+          after: true
+          before: true
+        prune: true
+        shallow-clone: true
+        depth: 3
+        do-not-fetch-tags: true
+        submodule:
+          disable: false
+          recursive: true
+          parent-credentials: true
+          timeout: 100
+        timeout: '15'
+        use-author: true
+        wipe-workspace: 'True'

--- a/.ci/linting.groovy
+++ b/.ci/linting.groovy
@@ -1,0 +1,32 @@
+#!/usr/bin/env groovy
+@Library('apm@current') _
+
+pipeline {
+  agent { label 'docker && linux && immutable' }
+  options {
+    buildDiscarder(logRotator(numToKeepStr: '20', artifactNumToKeepStr: '20', daysToKeepStr: '30'))
+    timestamps()
+    ansiColor('xterm')
+    disableResume()
+    durabilityHint('PERFORMANCE_OPTIMIZED')
+    rateLimitBuilds(throttle: [count: 60, durationName: 'hour', userBoost: true])
+    quietPeriod(10)
+  }
+  triggers {
+    issueCommentTrigger('(?i).*(?:jenkins\\W+)?run\\W+(?:the\\W+)?lint(?:\\W+please)?.*')
+  }
+  stages {
+    stage('Sanity checks') {
+      environment {
+        HOME = "${env.WORKSPACE}"
+        PATH = "${env.WORKSPACE}/bin:${env.PATH}"
+      }
+      steps {
+        script {
+          def sha = getGitCommitSha()
+          preCommit(commit: "${sha}", junit: true)
+        }
+      }
+    }
+  }
+}

--- a/.ci/linting.groovy
+++ b/.ci/linting.groovy
@@ -24,7 +24,7 @@ pipeline {
       steps {
         script {
           def sha = getGitCommitSha()
-          preCommit(commit: "${sha}", junit: true, registry: '')
+          preCommit(commit: "${sha}", junit: true)
         }
       }
     }

--- a/.ci/linting.groovy
+++ b/.ci/linting.groovy
@@ -24,7 +24,7 @@ pipeline {
       steps {
         script {
           def sha = getGitCommitSha()
-          preCommit(commit: "${sha}", junit: true)
+          preCommit(commit: "${sha}", junit: true, registry: '')
         }
       }
     }


### PR DESCRIPTION
## Highlights
- The main pipeline has been split into two `pipelines`.
- The main pipeline will evaluate the `Sanity check` stage in the branches only.
- The new pipeline will run the `Sanity check` for the PRs only.
- The new pipeline will create a new GitHub check called `apm-ci/linting/pr-merge`
- GitHub comment for running this pipeline: `jenkins run the lint please`

## Test Cases

- When a PR is created then, a new GH check has been added

![image](https://user-images.githubusercontent.com/2871786/64536050-4f025080-d310-11e9-827e-d5e315938659.png)

- When a PR does contain a linting issue then GH check failed

![image](https://user-images.githubusercontent.com/2871786/64536095-65a8a780-d310-11e9-9c91-4d0a40f80394.png)

- When a PR does not contain a linting issue then GH check passed

![image](https://user-images.githubusercontent.com/2871786/64537774-61ca5480-d313-11e9-9c98-9396748a7903.png)

![image](https://user-images.githubusercontent.com/2871786/64537813-70b10700-d313-11e9-97cf-9e390839b226.png)

![image](https://user-images.githubusercontent.com/2871786/64537852-7eff2300-d313-11e9-968c-2d59370dd80d.png)





## Tasks
- [x] Validate locally