### PR TITLE
Extract Rails setup code into its own module so it can be called without Railtie

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 
 ### Added
 
+- Add `Rails` module with `#start` method to run Rails setup explicitly ([#522](https://github.com/elastic/apm-agent-ruby/pull/522))
 - Support for chained exceptions ([#488](https://github.com/elastic/apm-agent-ruby/pull/488))
 - Add Ruby specific metrics ([#437](https://github.com/elastic/apm-agent-ruby/pull/437))
 - Support for APM Agent Configuration via Kibana ([#464](https://github.com/elastic/apm-agent-ruby/pull/464))

--- a/docs/api.asciidoc
+++ b/docs/api.asciidoc
@@ -31,8 +31,10 @@ ElasticAPM.start(server_url: 'http://localhost:8200')
   options.  See <<configuration,Configuration>>.
 
 If you are using <<getting-started-rails,Ruby on Rails>> this is done
-automatically for you.
-If not see <<getting-started-rack,Getting started with Rack>>.
+automatically for you. If you skip requiring the `elastic_apm` gem and want to start the
+agent and hook into Rails manually, see the section on
+<<rails-start,hooking into Rails explicitly.>>
+If you're not using Rails, see <<getting-started-rack,Getting started with Rack>>.
 
 [float]
 [[api-agent-stop]]
@@ -185,6 +187,18 @@ Arguments:
   * `for_type`: Symbol representing type of event, eg. `:transaction` or `error`
 
 Returns the built context.
+
+[float]
+[[rails-start]]
+=== Manually hooking into Rails
+
+Start the agent and hook into Rails explicitly. This is useful if you skip requiring
+the gem and using the `Railtie`.
+
+[source,ruby]
+----
+ElasticAPM::Rails.start(server_url: 'http://localhost:8200')
+----
 
 [float]
 === Errors

--- a/docs/api.asciidoc
+++ b/docs/api.asciidoc
@@ -30,10 +30,9 @@ ElasticAPM.start(server_url: 'http://localhost:8200')
   * `config`: An optional hash or `ElasticAPM::Config` instance with configuration
   options.  See <<configuration,Configuration>>.
 
-If you are using <<getting-started-rails,Ruby on Rails>> this is done
-automatically for you. If you skip requiring the `elastic_apm` gem and want to start the
-agent and hook into Rails manually, see the section on
-<<rails-start,hooking into Rails explicitly.>>
+If you are using <<getting-started-rails,Ruby on Rails>> this is done automatically for you.
+If you choose not to require the `elastic_apm` gem and instead want to start the
+agent and hook into Rails manually, see <<rails-start,hooking into Rails explicitly>>.
 If you're not using Rails, see <<getting-started-rack,Getting started with Rack>>.
 
 [float]

--- a/lib/elastic_apm/config.rb
+++ b/lib/elastic_apm/config.rb
@@ -234,7 +234,7 @@ module ElasticAPM
     end
 
     def app_type?(app)
-      if defined?(Rails::Application) && app.is_a?(Rails::Application)
+      if defined?(::Rails::Application) && app.is_a?(::Rails::Application)
         return :rails
       end
 
@@ -255,15 +255,15 @@ module ElasticAPM
     def set_rails(app) # rubocop:disable Metrics/AbcSize
       self.service_name ||= format_name(service_name || rails_app_name(app))
       self.framework_name ||= 'Ruby on Rails'
-      self.framework_version ||= Rails::VERSION::STRING
-      self.logger ||= Rails.logger
+      self.framework_version ||= ::Rails::VERSION::STRING
+      self.logger ||= ::Rails.logger
 
-      self.__root_path = Rails.root.to_s
+      self.__root_path = ::Rails.root.to_s
       self.__view_paths = app.config.paths['app/views'].existent
     end
 
     def rails_app_name(app)
-      if Rails::VERSION::MAJOR >= 6
+      if ::Rails::VERSION::MAJOR >= 6
         app.class.module_parent_name
       else
         app.class.parent_name

--- a/lib/elastic_apm/rails.rb
+++ b/lib/elastic_apm/rails.rb
@@ -7,6 +7,7 @@ module ElasticAPM
   module Rails
     extend self
     # rubocop:disable Metrics/MethodLength, Metrics/AbcSize
+    # rubocop:disable Metrics/CyclomaticComplexity
     def start(config)
       config = Config.new(config) unless config.is_a?(Config)
       if (reason = should_skip?(config))
@@ -31,6 +32,7 @@ module ElasticAPM
       config.logger.debug "Backtrace:\n" + e.backtrace.join("\n")
     end
     # rubocop:enable Metrics/MethodLength, Metrics/AbcSize
+    # rubocop:enable Metrics/CyclomaticComplexity
 
     private
 

--- a/lib/elastic_apm/rails.rb
+++ b/lib/elastic_apm/rails.rb
@@ -24,7 +24,8 @@ module ElasticAPM
       if ElasticAPM.running? &&
          !ElasticAPM.agent.config.disabled_spies.include?('action_dispatch')
         require 'elastic_apm/spies/action_dispatch'
-      end || ElasticAPM.running?
+      end
+      ElasticAPM.running?
     rescue StandardError => e
       config.logger.error format('Failed to start: %s', e.message)
       config.logger.debug "Backtrace:\n" + e.backtrace.join("\n")

--- a/lib/elastic_apm/rails.rb
+++ b/lib/elastic_apm/rails.rb
@@ -3,11 +3,17 @@
 require 'elastic_apm/subscriber'
 
 module ElasticAPM
-  # @api private
+  # Module for explicitly starting the ElasticAPM agent and hooking into Rails.
+  # It is recommended to use the Railtie instead.
   module Rails
     extend self
     # rubocop:disable Metrics/MethodLength, Metrics/AbcSize
     # rubocop:disable Metrics/CyclomaticComplexity
+    # Start the ElasticAPM agent and hook into Rails.
+    # Note that the agent won't be started if the Rails console is being used.
+    #
+    # @param config [Config, Hash] An instance of Config or a Hash config.
+    # @return [true, nil] true if the agent was started, nil otherwise.
     def start(config)
       config = Config.new(config) unless config.is_a?(Config)
       if (reason = should_skip?(config))

--- a/lib/elastic_apm/rails.rb
+++ b/lib/elastic_apm/rails.rb
@@ -24,7 +24,7 @@ module ElasticAPM
       if ElasticAPM.running? &&
          !ElasticAPM.agent.config.disabled_spies.include?('action_dispatch')
         require 'elastic_apm/spies/action_dispatch'
-      end
+      end || ElasticAPM.running?
     rescue StandardError => e
       config.logger.error format('Failed to start: %s', e.message)
       config.logger.debug "Backtrace:\n" + e.backtrace.join("\n")

--- a/lib/elastic_apm/rails.rb
+++ b/lib/elastic_apm/rails.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+require 'elastic_apm/subscriber'
+
+module ElasticAPM
+  # @api private
+  module Rails
+    extend self
+    # rubocop:disable Metrics/MethodLength, Metrics/AbcSize
+    def start(config)
+      config = Config.new(config) unless config.is_a?(Config)
+      if (reason = should_skip?(config))
+        unless config.disable_start_message?
+          config.logger.info "Skipping because: #{reason}. " \
+            "Start manually with `ElasticAPM.start'"
+        end
+        return
+      end
+
+      ElasticAPM.start(config).tap do |agent|
+        attach_subscriber(agent)
+      end
+
+      if ElasticAPM.running? &&
+         !ElasticAPM.agent.config.disabled_spies.include?('action_dispatch')
+        require 'elastic_apm/spies/action_dispatch'
+      end
+    rescue StandardError => e
+      config.logger.error format('Failed to start: %s', e.message)
+      config.logger.debug "Backtrace:\n" + e.backtrace.join("\n")
+    end
+    # rubocop:enable Metrics/MethodLength, Metrics/AbcSize
+
+    private
+
+    def should_skip?(_config)
+      if ::Rails.const_defined? 'Rails::Console'
+        return 'Rails console'
+      end
+
+      nil
+    end
+
+    def attach_subscriber(agent)
+      return unless agent
+
+      agent.instrumenter.subscriber = ElasticAPM::Subscriber.new(agent)
+    end
+  end
+end

--- a/lib/elastic_apm/railtie.rb
+++ b/lib/elastic_apm/railtie.rb
@@ -1,10 +1,10 @@
 # frozen_string_literal: true
 
-require 'elastic_apm/subscriber'
+require 'elastic_apm/rails'
 
 module ElasticAPM
   # @api private
-  class Railtie < Rails::Railtie
+  class Railtie < ::Rails::Railtie
     config.elastic_apm = ActiveSupport::OrderedOptions.new
 
     Config.schema.each do |key, args|
@@ -18,55 +18,13 @@ module ElasticAPM
 
         # Prepend Rails.root to log_path if present
         if c.log_path && !c.log_path.start_with?('/')
-          c.log_path = Rails.root.join(c.log_path)
+          c.log_path = ::Rails.root.join(c.log_path)
         end
       end
 
-      if start(config)
+      if Rails.start(config)
         app.middleware.insert 0, Middleware
       end
-    end
-
-    config.after_initialize do
-      if ElasticAPM.running? &&
-         !ElasticAPM.agent.config.disabled_spies.include?('action_dispatch')
-        require 'elastic_apm/spies/action_dispatch'
-      end
-    end
-
-    private
-
-    # rubocop:disable Metrics/MethodLength, Metrics/AbcSize
-    def start(config)
-      if (reason = should_skip?(config))
-        unless config.disable_start_message?
-          config.logger.info "Skipping because: #{reason}. " \
-            "Start manually with `ElasticAPM.start'"
-        end
-        return
-      end
-
-      ElasticAPM.start(config).tap do |agent|
-        attach_subscriber(agent)
-      end
-    rescue StandardError => e
-      config.logger.error format('Failed to start: %s', e.message)
-      config.logger.debug "Backtrace:\n" + e.backtrace.join("\n")
-    end
-    # rubocop:enable Metrics/MethodLength, Metrics/AbcSize
-
-    def should_skip?(_config)
-      if Rails.const_defined? 'Rails::Console'
-        return 'Rails console'
-      end
-
-      nil
-    end
-
-    def attach_subscriber(agent)
-      return unless agent
-
-      agent.instrumenter.subscriber = ElasticAPM::Subscriber.new(agent)
     end
   end
 end

--- a/spec/elastic_apm/rails_spec.rb
+++ b/spec/elastic_apm/rails_spec.rb
@@ -2,43 +2,41 @@
 
 if defined?(Rails)
   require 'elastic_apm/rails'
-  module ElasticAPM
-    RSpec.describe Rails do
-      describe '.start' do
-        before :all do
-          ElasticAPM::Rails.start({})
-        end
-
-        it 'starts the agent' do
-          expect(ElasticAPM::Agent).to be_running
-        end
-
-        it 'registers the ActionDispatchSpy' do
-          expect(ElasticAPM::Agent).to be_running
-        end
-
-        after :all do
-          ElasticAPM.stop
-        end
+  RSpec.describe Rails do
+    describe '.start' do
+      before :all do
+        ElasticAPM::Rails.start({})
       end
 
-      describe 'Rails console' do
-        before :all do
-          module ::Rails
-            class Console; end
-          end
+      it 'starts the agent' do
+        expect(ElasticAPM::Agent).to be_running
+      end
 
-          ElasticAPM::Rails.start({})
+      it 'registers the ActionDispatchSpy' do
+        expect(ElasticAPM::Agent).to be_running
+      end
+
+      after :all do
+        ElasticAPM.stop
+      end
+    end
+
+    describe 'Rails console' do
+      before :all do
+        module Rails
+          class Console; end
         end
 
-        after :all do
-          ElasticAPM.stop
-          ::Rails.send(:remove_const, :Console)
-        end
+        ElasticAPM::Rails.start({})
+      end
 
-        it "doesn't start when console" do
-          expect(ElasticAPM.agent).to be nil
-        end
+      after :all do
+        ElasticAPM.stop
+        Rails.send(:remove_const, :Console)
+      end
+
+      it "doesn't start when console" do
+        expect(ElasticAPM.agent).to be nil
       end
     end
   end

--- a/spec/elastic_apm/rails_spec.rb
+++ b/spec/elastic_apm/rails_spec.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+if defined?(Rails)
+  require 'elastic_apm/rails'
+  module ElasticAPM
+    RSpec.describe Rails do
+      describe '.start' do
+        before :all do
+          ElasticAPM::Rails.start({})
+        end
+
+        it 'starts the agent' do
+          expect(ElasticAPM::Agent).to be_running
+        end
+
+        it 'registers the ActionDispatchSpy' do
+          expect(ElasticAPM::Agent).to be_running
+        end
+
+        after :all do
+          ElasticAPM.stop
+        end
+      end
+
+      describe 'Rails console' do
+        before :all do
+          module ::Rails
+            class Console; end
+          end
+
+          ElasticAPM::Rails.start({})
+        end
+
+        after :all do
+          ElasticAPM.stop
+          ::Rails.send(:remove_const, :Console)
+        end
+
+        it "doesn't start when console" do
+          expect(ElasticAPM.agent).to be nil
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
The `start` method originally in the railtie is extracted into a `ElasticAPM::Rails` module so it can be called explicitly. The user will have to require `elastic_apm/rails` in order to call `ElasticAPM::Rails.start(config)`.

Note that all references to `Rails` in the codebase must refer to the module from the `rails` gem as `::Rails`. 
Simply writing `Rails` would refer to the `ElasticAPM::Rails` module.

Closes elastic/apm-agent-ruby#409