### PR TITLE
ci(jenkins): change the github comment for the linters

### DIFF
--- a/.ci/linting.groovy
+++ b/.ci/linting.groovy
@@ -13,7 +13,7 @@ pipeline {
     quietPeriod(10)
   }
   triggers {
-    issueCommentTrigger('(?i).*(?:jenkins\\W+)?run\\W+(?:the\\W+)?lint(?:\\W+please)?.*')
+    issueCommentTrigger('(?i).*(?:jenkins\\W+)?run\\W+(?:the\\W+)?linters(?:\\W+please)?.*')
   }
   stages {
     stage('Sanity checks') {


### PR DESCRIPTION
## Highlights
- `jenkins run the linters` or `jenkins run linters` rather than `jenkins run lint`