### PR TITLE
Support log/trace correlation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 ### Added
 
 - Add `Rails` module with `#start` method to run Rails setup explicitly ([#522](https://github.com/elastic/apm-agent-ruby/pull/522))
+- Support for log/trace correlation ([#527](https://github.com/elastic/apm-agent-ruby/pull/527))
 
 ## 2.10.1
 

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -18,7 +18,7 @@ include::./getting-started-rack.asciidoc[]
 
 include::./configuration.asciidoc[]
 
-include::./logging-configuration.asciidoc[]
+include::./log-correlation.asciidoc[]
 
 include::./metrics.asciidoc[]
 

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -18,6 +18,8 @@ include::./getting-started-rack.asciidoc[]
 
 include::./configuration.asciidoc[]
 
+include::./logging-configuration.asciidoc[]
+
 include::./metrics.asciidoc[]
 
 include::./advanced.asciidoc[]

--- a/docs/log-correlation.asciidoc
+++ b/docs/log-correlation.asciidoc
@@ -3,16 +3,8 @@ NOTE: For the best reading experience,
 please view this documentation at https://www.elastic.co/guide/en/apm/agent/ruby[elastic.co]
 endif::[]
 
-[[logging-configuration]]
-== Logging configuration
-
-The Ruby agent allows you to set logging options as well as configure trace/log correlation.
-Please see the <<configuration,configuration documentation>> to learn how to set <<config-logger,a logger>>, <<config-log-path,
-a log path>> and <<config-log-level,log level>>.
-
-[float]
-[[trace-log-correlation]]
-==== Trace/log correlation
+[[log-correlation]]
+== Log correlation
 
 Trace/log correlation can be set up in three different ways.
 

--- a/docs/log-correlation.asciidoc
+++ b/docs/log-correlation.asciidoc
@@ -41,9 +41,9 @@ configuration file. The returned `Hash` will be included in the structured Logra
 ----
 config.lograge.custom_options = lambda do |event|
   ElasticAPM.log_ids do |transaction_id, span_id, trace_id|
-    { transaction_id: transaction_id,
-      span_id: span_id,
-      trace_id: trace_id }
+    { :'transaction.id' => transaction_id,
+      :'span.id' => span_id,
+      :'trace.id' => trace_id }
   end
 end
 
@@ -58,9 +58,9 @@ You can also nest the ids in a separate document as in the following example:
 ----
 config.lograge.custom_options = lambda do |event|
   ElasticAPM.log_ids do |transaction_id, span_id, trace_id|
-    { elastic_apm: { transaction_id: transaction_id,
-                     span_id: span_id,
-                     trace_id: trace_id } }
+    { elastic_apm: { :'transaction.id' => transaction_id,
+                     :'span.id' => span_id,
+                     :'trace.id' => trace_id } }
   end
 end
 

--- a/docs/log-correlation.asciidoc
+++ b/docs/log-correlation.asciidoc
@@ -13,12 +13,11 @@ Trace/log correlation can be set up in three different ways.
 ==== Rails TaggedLogging
 
 Rails applications configured with an `ActiveSupport::TaggedLogging` logger can append the correlation IDs to log output.
-Add the following to the Rails environment configuration file:
+For example in your `config/environments/production.rb` file, add the following:
 
 [source,ruby]
 ----
-config.logger = ActiveSupport::TaggedLogging.new(my_logger)
-config.log_tags = [proc { ElasticAPM.log_ids }]
+config.log_tags = [ :request_id, proc { ElasticAPM.log_ids } ]
 
 # Logs will then include the correlation IDs:
 #

--- a/docs/logging-configuration.asciidoc
+++ b/docs/logging-configuration.asciidoc
@@ -1,0 +1,105 @@
+ifdef::env-github[]
+NOTE: For the best reading experience,
+please view this documentation at https://www.elastic.co/guide/en/apm/agent/ruby[elastic.co]
+endif::[]
+
+[[logging-configuration]]
+== Logging configuration
+
+The Ruby agent allows you to set logging options as well as configure trace/log correlation.
+Please see the <<configuration,configuration documentation>> to learn how to set <<config-logger,a logger>>, <<config-log-path,
+a log path>> and <<config-log-level,log level>>.
+
+[float]
+[[trace-log-correlation]]
+==== Trace/log correlation
+
+Trace/log correlation can be set up in three different ways.
+
+[float]
+[[rails-tagged-logging]]
+==== Rails TaggedLogging
+
+Rails applications configured with an `ActiveSupport::TaggedLogging` logger can append the correlation IDs to log output.
+Add the following to the Rails environment configuration file:
+
+[source,ruby]
+----
+config.logger = ActiveSupport::TaggedLogging.new(my_logger)
+config.log_tags = [proc { ElasticAPM.log_ids }]
+
+# Logs will then include the correlation IDs:
+#
+# [transaction.id=c1ae84c8642891eb trace.id=b899fc7915e801b7558e336e4952bafe] Started GET "/" for 127.0.0.1 at 2019-09-16 11:28:46 +0200
+# [transaction.id=c1ae84c8642891eb trace.id=b899fc7915e801b7558e336e4952bafe] Processing by ApplicationController#index as HTML
+# [transaction.id=c1ae84c8642891eb trace.id=b899fc7915e801b7558e336e4952bafe]   Rendering text template
+# [transaction.id=c1ae84c8642891eb trace.id=b899fc7915e801b7558e336e4952bafe]   Rendered text template (Duration: 0.1ms | Allocations: 17)
+# [transaction.id=c1ae84c8642891eb trace.id=b899fc7915e801b7558e336e4952bafe] Completed 200 OK in 1ms (Views: 0.4ms | Allocations: 171)
+----
+**Note:** Because of the order in which Rails computes the tags for logs and executes the request, the span id might not be included.
+Consider using `Lograge` instead, as the timing of its hooks allow the span id to be captured in logs.
+
+[float]
+[[lograge]]
+==== Lograge
+
+With `lograge` enabled and set up in your Rails application, modify the `custom_options` block in the Rails environment
+configuration file. The returned `Hash` will be included in the structured Lograge logs.
+
+[source,ruby]
+----
+config.lograge.custom_options = lambda do |event|
+  ElasticAPM.log_ids do |transaction_id, span_id, trace_id|
+    { transaction_id: transaction_id,
+      span_id: span_id,
+      trace_id: trace_id }
+  end
+end
+
+# Logs will then include the correlation IDs:
+#
+# I, [2019-09-16T11:59:05.439602 #8674]  INFO -- : method=GET path=/ format=html controller=ApplicationController action=index status=200 duration=0.36 view=0.20 transaction.id=56a9186a9257aa08 span.id=8e84a786ab0abbb2 trace.id=1bbab8ac4c7c9584f53eb882ff0dfdd8
+----
+
+You can also nest the ids in a separate document as in the following example:
+
+[source,ruby]
+----
+config.lograge.custom_options = lambda do |event|
+  ElasticAPM.log_ids do |transaction_id, span_id, trace_id|
+    { elastic_apm: { transaction_id: transaction_id,
+                     span_id: span_id,
+                     trace_id: trace_id } }
+  end
+end
+
+# Logs will then include the correlation IDs in a separate document:
+#
+# I, [2019-09-16T13:39:35.962603 #9327]  INFO -- : method=GET path=/ format=html controller=ApplicationController action=index status=200 duration=0.37 view=0.20 elastic_apm={:transaction_id=>"2fb84f5d0c48a296", :span_id=>"2e5c5a7c85f83be7", :trace_id=>"43e1941c4a6fff343a4e018ff7b92000"}
+----
+
+[float]
+[[manually-formatting-logs]]
+==== Manually formatting logs
+
+You can access the correlation ids directly and add them through the log formatter.
+
+[source,ruby]
+----
+require 'elastic_apm'
+require 'logger'
+
+logger = Logger.new(STDOUT)
+logger.progname = 'TestRubyApp'
+logger.formatter  = proc do |severity, datetime, progname, msg|
+  "[#{datetime}][#{progname}][#{severity}][#{ElasticAPM.log_ids}] #{msg}\n"
+end
+
+# Logs will then include the correlation IDs:
+#
+# [2019-09-16 11:54:59 +0200][RailsTestApp][INFO][transaction.id=3b92edcccc0a6d1e trace.id=1275686e35de91f776557637e799651e] Started GET "/" for 127.0.0.1 at 2019-09-16 11:54:59 +0200
+# [2019-09-16 11:54:59 +0200][RailsTestApp][INFO][transaction.id=3b92edcccc0a6d1e trace.id=1275686e35de91f776557637e799651e] Processing by ApplicationController#index as HTML
+# [2019-09-16 11:54:59 +0200][RailsTestApp][INFO][transaction.id=3b92edcccc0a6d1e span.id=3bde4e9c85ab359c trace.id=1275686e35de91f776557637e799651e]   Rendering text template
+# [2019-09-16 11:54:59 +0200][RailsTestApp][INFO][transaction.id=3b92edcccc0a6d1e span.id=f3d7e32f176d4c93 trace.id=1275686e35de91f776557637e799651e]   Rendered text template (Duration: 0.1ms | Allocations: 17)
+# [2019-09-16 11:54:59 +0200][RailsTestApp][INFO][transaction.id=3b92edcccc0a6d1e span.id=3bde4e9c85ab359c trace.id=1275686e35de91f776557637e799651e] Completed 200 OK in 1ms (Views: 0.3ms | Allocations: 187)
+----

--- a/lib/elastic_apm.rb
+++ b/lib/elastic_apm.rb
@@ -62,6 +62,7 @@ module ElasticAPM # rubocop:disable Metrics/ModuleLength
       agent&.current_span
     end
 
+    # rubocop:disable Metrics/AbcSize
     # Get a formatted string containing transaction, span, and trace ids.
     # If a block is provided, the ids are yielded.
     #
@@ -79,6 +80,7 @@ module ElasticAPM # rubocop:disable Metrics/ModuleLength
       ids << "trace.id=#{trace_id}" if trace_id
       ids.join(' ')
     end
+    # rubocop:enable Metrics/AbcSize
 
     # Start a new transaction or return the currently running
     #

--- a/lib/elastic_apm.rb
+++ b/lib/elastic_apm.rb
@@ -66,7 +66,7 @@ module ElasticAPM # rubocop:disable Metrics/ModuleLength
     # Get a formatted string containing transaction, span, and trace ids.
     # If a block is provided, the ids are yielded.
     #
-    # @yield [String, String, String] The transaction, span, and trace ids.
+    # @yield [String|nil, String|nil, String|nil] The transaction, span, and trace ids.
     # @return [String] Unless block given
     def log_ids
       trace_id = (current_transaction || current_span)&.trace_id

--- a/lib/elastic_apm.rb
+++ b/lib/elastic_apm.rb
@@ -62,6 +62,24 @@ module ElasticAPM # rubocop:disable Metrics/ModuleLength
       agent&.current_span
     end
 
+    # Get a formatted string containing transaction, span, and trace ids.
+    # If a block is provided, the ids are yielded.
+    #
+    # @yield [String, String, String] The transaction, span, and trace ids.
+    # @return [String] Unless block given
+    def log_ids
+      trace_id = (current_transaction || current_span)&.trace_id
+      if block_given?
+        yield(current_transaction&.id, current_span&.id, trace_id)
+      else
+        ids = []
+        ids << "transaction=#{current_transaction.id}" if current_transaction
+        ids << "span=#{current_span.id}" if current_span
+        ids << "trace=#{trace_id}" if trace_id
+        ids.compact.join(' ')
+      end
+    end
+
     # Start a new transaction or return the currently running
     #
     # @param name [String] A description of the transaction, eg

--- a/lib/elastic_apm.rb
+++ b/lib/elastic_apm.rb
@@ -70,14 +70,14 @@ module ElasticAPM # rubocop:disable Metrics/ModuleLength
     def log_ids
       trace_id = (current_transaction || current_span)&.trace_id
       if block_given?
-        yield(current_transaction&.id, current_span&.id, trace_id)
-      else
-        ids = []
-        ids << "transaction=#{current_transaction.id}" if current_transaction
-        ids << "span=#{current_span.id}" if current_span
-        ids << "trace=#{trace_id}" if trace_id
-        ids.compact.join(' ')
+        return yield(current_transaction&.id, current_span&.id, trace_id)
       end
+
+      ids = []
+      ids << "transaction.id=#{current_transaction.id}" if current_transaction
+      ids << "span.id=#{current_span.id}" if current_span
+      ids << "trace.id=#{trace_id}" if trace_id
+      ids.join(' ')
     end
 
     # Start a new transaction or return the currently running

--- a/spec/elastic_apm_spec.rb
+++ b/spec/elastic_apm_spec.rb
@@ -23,15 +23,15 @@ RSpec.describe ElasticAPM do
     describe '.log_ids' do
       context 'with no current_transaction' do
         it 'returns empty string' do
-          expect(ElasticAPM.log_ids).to match(//)
+          expect(ElasticAPM.log_ids).to eq('')
         end
       end
 
       context 'with a current transaction' do
         it 'includes transaction and trace ids' do
           transaction = ElasticAPM.start_transaction 'Test'
-          expect(ElasticAPM.log_ids).to match(
-            /transaction.id=#{transaction.id} trace.id=#{transaction.trace_id}/
+          expect(ElasticAPM.log_ids).to eq(
+            "transaction.id=#{transaction.id} trace.id=#{transaction.trace_id}"
           )
         end
       end
@@ -40,8 +40,9 @@ RSpec.describe ElasticAPM do
         it 'includes transaction, span and trace ids' do
           trans = ElasticAPM.start_transaction
           span = ElasticAPM.start_span 'Test'
-          expect(ElasticAPM.log_ids).to match(
-            /transaction.id=#{trans.id} span.id=#{span.id} trace.id=#{trans.trace_id}/
+          expect(ElasticAPM.log_ids).to eq(
+            "transaction.id=#{trans.id} span.id=#{span.id} " \
+              "trace.id=#{trans.trace_id}"
           )
         end
       end

--- a/spec/elastic_apm_spec.rb
+++ b/spec/elastic_apm_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe ElasticAPM do
         it 'includes transaction and trace ids' do
           transaction = ElasticAPM.start_transaction 'Test'
           expect(ElasticAPM.log_ids).to match(
-            /transaction=#{transaction.id} trace=#{transaction.trace_id}/
+            /transaction.id=#{transaction.id} trace.id=#{transaction.trace_id}/
           )
         end
       end
@@ -41,7 +41,7 @@ RSpec.describe ElasticAPM do
           trans = ElasticAPM.start_transaction
           span = ElasticAPM.start_span 'Test'
           expect(ElasticAPM.log_ids).to match(
-            /transaction=#{trans.id} span=#{span.id} trace=#{trans.trace_id}/
+            /transaction.id=#{trans.id} span.id=#{span.id} trace.id=#{trans.trace_id}/
           )
         end
       end

--- a/spec/elastic_apm_spec.rb
+++ b/spec/elastic_apm_spec.rb
@@ -20,6 +20,45 @@ RSpec.describe ElasticAPM do
 
     let(:agent) { ElasticAPM.agent }
 
+    describe '.log_ids' do
+      context 'with no current_transaction' do
+        it 'returns empty string' do
+          expect(ElasticAPM.log_ids).to match(//)
+        end
+      end
+
+      context 'with a current transaction' do
+        it 'includes transaction and trace ids' do
+          transaction = ElasticAPM.start_transaction 'Test'
+          expect(ElasticAPM.log_ids).to match(
+            /transaction=#{transaction.id} trace=#{transaction.trace_id}/
+          )
+        end
+      end
+
+      context 'with a current_span' do
+        it 'includes transaction, span and trace ids' do
+          trans = ElasticAPM.start_transaction
+          span = ElasticAPM.start_span 'Test'
+          expect(ElasticAPM.log_ids).to match(
+            /transaction=#{trans.id} span=#{span.id} trace=#{trans.trace_id}/
+          )
+        end
+      end
+
+      context 'when passed a block' do
+        it 'yields each id' do
+          transaction = ElasticAPM.start_transaction
+          span = ElasticAPM.start_span 'Test'
+          ElasticAPM.log_ids do |transaction_id, span_id, trace_id|
+            expect(transaction_id).to eq(transaction.id)
+            expect(span_id).to eq(span.id)
+            expect(trace_id).to eq(transaction.trace_id)
+          end
+        end
+      end
+    end
+
     describe '.start_transaction' do
       it 'starts a transaction' do
         transaction = ElasticAPM.start_transaction 'Test'


### PR DESCRIPTION
End-to-end testing needs to be done before this is merged.
Closes https://github.com/elastic/apm-agent-ruby/issues/462

Update: merging this so that end-to-end testing can use the code from master.