### PR TITLE
Resolve block binding/class definition race condition

### DIFF
--- a/lib/elastic_apm/agent.rb
+++ b/lib/elastic_apm/agent.rb
@@ -26,30 +26,6 @@ module ElasticAPM
       @instance
     end
 
-    # rubocop:disable Metrics/MethodLength
-    def self.start(config)
-      return @instance if @instance
-
-      config = Config.new(config) unless config.is_a?(Config)
-
-      LOCK.synchronize do
-        return @instance if @instance
-
-        unless config.active?
-          config.logger.debug format(
-            "%sAgent disabled with `active: false'",
-            Logging::PREFIX
-          )
-          return
-        end
-
-        @instance = allocate
-        @instance.send(:initialize, config)
-        @instance.start
-      end
-    end
-    # rubocop:enable Metrics/MethodLength
-
     def self.stop
       LOCK.synchronize do
         return unless @instance
@@ -227,6 +203,28 @@ module ElasticAPM
     def add_filter(key, callback)
       transport.add_filter(key, callback)
     end
+
+    # rubocop:disable Metrics/MethodLength
+    def self.start(config)
+      return @instance if @instance
+
+      config = Config.new(config) unless config.is_a?(Config)
+
+      LOCK.synchronize do
+        return @instance if @instance
+
+        unless config.active?
+          config.logger.debug format(
+                                  "%sAgent disabled with `active: false'",
+                                  Logging::PREFIX
+                              )
+          return
+        end
+
+        @instance = new(config).start
+      end
+    end
+    # rubocop:enable Metrics/MethodLength
   end
   # rubocop:enable Metrics/ClassLength
 end

--- a/lib/elastic_apm/agent.rb
+++ b/lib/elastic_apm/agent.rb
@@ -63,6 +63,7 @@ module ElasticAPM
       !!@instance
     end
 
+    # rubocop:disable Metrics/MethodLength
     def initialize(config)
       @config = config
 
@@ -78,6 +79,7 @@ module ElasticAPM
       ) { |event| enqueue event }
       @metrics = Metrics.new(config) { |event| enqueue event }
     end
+    # rubocop:enable Metrics/MethodLength
 
     attr_reader(
       :central_config,

--- a/lib/elastic_apm/agent.rb
+++ b/lib/elastic_apm/agent.rb
@@ -73,9 +73,10 @@ module ElasticAPM
       @transport = Transport::Base.new(config)
       @instrumenter = Instrumenter.new(
         config,
-        stacktrace_builder: stacktrace_builder
-      ) { |event| enqueue event }
-      @metrics = Metrics.new(config) { |event| enqueue event }
+        stacktrace_builder: stacktrace_builder,
+        agent: self
+      )
+      @metrics = Metrics.new(config, self)
     end
     # rubocop:enable Metrics/MethodLength
 

--- a/lib/elastic_apm/agent.rb
+++ b/lib/elastic_apm/agent.rb
@@ -26,6 +26,28 @@ module ElasticAPM
       @instance
     end
 
+    # rubocop:disable Metrics/MethodLength
+    def self.start(config)
+      return @instance if @instance
+
+      config = Config.new(config) unless config.is_a?(Config)
+
+      LOCK.synchronize do
+        return @instance if @instance
+
+        unless config.active?
+          config.logger.debug format(
+                                  "%sAgent disabled with `active: false'",
+                                  Logging::PREFIX
+                              )
+          return
+        end
+
+        @instance = new(config).start
+      end
+    end
+    # rubocop:enable Metrics/MethodLength
+
     def self.stop
       LOCK.synchronize do
         return unless @instance
@@ -203,28 +225,6 @@ module ElasticAPM
     def add_filter(key, callback)
       transport.add_filter(key, callback)
     end
-
-    # rubocop:disable Metrics/MethodLength
-    def self.start(config)
-      return @instance if @instance
-
-      config = Config.new(config) unless config.is_a?(Config)
-
-      LOCK.synchronize do
-        return @instance if @instance
-
-        unless config.active?
-          config.logger.debug format(
-                                  "%sAgent disabled with `active: false'",
-                                  Logging::PREFIX
-                              )
-          return
-        end
-
-        @instance = new(config).start
-      end
-    end
-    # rubocop:enable Metrics/MethodLength
   end
   # rubocop:enable Metrics/ClassLength
 end

--- a/lib/elastic_apm/agent.rb
+++ b/lib/elastic_apm/agent.rb
@@ -61,7 +61,6 @@ module ElasticAPM
       !!@instance
     end
 
-    # rubocop:disable Metrics/MethodLength
     def initialize(config)
       @config = config
 
@@ -71,24 +70,29 @@ module ElasticAPM
 
       @central_config = CentralConfig.new(config)
       @transport = Transport::Base.new(config)
-      @instrumenter = Instrumenter.new(
-        config,
-        stacktrace_builder: stacktrace_builder
-      ) { |event| enqueue event }
-      @metrics = Metrics.new(config) { |event| enqueue event }
+      @instrumenter = nil
+      @metrics = nil
     end
-    # rubocop:enable Metrics/MethodLength
 
     attr_reader(
       :central_config,
       :config,
       :context_builder,
       :error_builder,
-      :instrumenter,
-      :metrics,
       :stacktrace_builder,
       :transport
     )
+
+    def instrumenter
+      @instrumenter ||= Instrumenter.new(
+        config,
+        stacktrace_builder: stacktrace_builder
+      ) { |event| enqueue event }
+    end
+
+    def metrics
+      @metrics ||= Metrics.new(config) { |event| enqueue event }
+    end
 
     # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
     def start

--- a/lib/elastic_apm/agent.rb
+++ b/lib/elastic_apm/agent.rb
@@ -37,9 +37,9 @@ module ElasticAPM
 
         unless config.active?
           config.logger.debug format(
-                                  "%sAgent disabled with `active: false'",
-                                  Logging::PREFIX
-                              )
+            "%sAgent disabled with `active: false'",
+            Logging::PREFIX
+          )
           return
         end
 

--- a/lib/elastic_apm/instrumenter.rb
+++ b/lib/elastic_apm/instrumenter.rb
@@ -9,6 +9,9 @@ module ElasticAPM
   # rubocop:disable Metrics/ClassLength
   # @api private
   class Instrumenter
+    extend Forwardable
+    def_delegators :@agent, :enqueue
+
     TRANSACTION_KEY = :__elastic_instrumenter_transaction_key
     SPAN_KEY = :__elastic_instrumenter_spans_key
 
@@ -47,7 +50,7 @@ module ElasticAPM
       @current = Current.new
     end
 
-    attr_reader :config, :stacktrace_builder, :agent
+    attr_reader :config, :stacktrace_builder
 
     def start
       debug 'Starting instrumenter'
@@ -117,7 +120,7 @@ module ElasticAPM
 
       transaction.done result
 
-      agent.enqueue transaction
+      enqueue transaction
 
       transaction
     end
@@ -178,7 +181,7 @@ module ElasticAPM
 
       span.done
 
-      agent.enqueue span
+      enqueue span
 
       span
     end

--- a/lib/elastic_apm/instrumenter.rb
+++ b/lib/elastic_apm/instrumenter.rb
@@ -39,15 +39,15 @@ module ElasticAPM
       end
     end
 
-    def initialize(config, stacktrace_builder:, &enqueue)
+    def initialize(config, stacktrace_builder:, agent:)
       @config = config
       @stacktrace_builder = stacktrace_builder
-      @enqueue = enqueue
+      @agent = agent
 
       @current = Current.new
     end
 
-    attr_reader :config, :stacktrace_builder, :enqueue
+    attr_reader :config, :stacktrace_builder, :agent
 
     def start
       debug 'Starting instrumenter'
@@ -117,7 +117,7 @@ module ElasticAPM
 
       transaction.done result
 
-      enqueue.call transaction
+      agent.enqueue transaction
 
       transaction
     end
@@ -178,7 +178,7 @@ module ElasticAPM
 
       span.done
 
-      enqueue.call span
+      agent.enqueue span
 
       span
     end

--- a/lib/elastic_apm/metrics.rb
+++ b/lib/elastic_apm/metrics.rb
@@ -17,6 +17,9 @@ module ElasticAPM
 
     # @api private
     class Collector
+      extend Forwardable
+      def_delegators :@agent, :enqueue
+
       include Logging
 
       TIMEOUT_INTERVAL = 5 # seconds
@@ -31,7 +34,7 @@ module ElasticAPM
         @agent = agent
       end
 
-      attr_reader :config, :samplers, :agent, :tags
+      attr_reader :config, :samplers, :tags
 
       # rubocop:disable Metrics/MethodLength
       def start
@@ -79,7 +82,7 @@ module ElasticAPM
         metricset = Metricset.new(tags: tags, **collect)
         return if metricset.empty?
 
-        agent.enqueue metricset
+        enqueue metricset
       end
 
       def collect

--- a/lib/elastic_apm/opentracing.rb
+++ b/lib/elastic_apm/opentracing.rb
@@ -77,7 +77,7 @@ module ElasticAPM
           instrumenter.current_spans.delete(elastic_span)
         end
 
-        instrumenter.enqueue.call elastic_span
+        instrumenter.agent.enqueue elastic_span
       end
 
       private

--- a/lib/elastic_apm/opentracing.rb
+++ b/lib/elastic_apm/opentracing.rb
@@ -77,7 +77,7 @@ module ElasticAPM
           instrumenter.current_spans.delete(elastic_span)
         end
 
-        instrumenter.agent.enqueue elastic_span
+        instrumenter.enqueue elastic_span
       end
 
       private

--- a/spec/elastic_apm/instrumenter_spec.rb
+++ b/spec/elastic_apm/instrumenter_spec.rb
@@ -4,14 +4,13 @@ module ElasticAPM
   RSpec.describe Instrumenter, :intercept do
     let(:config) { Config.new }
     let(:stacktrace_builder) { StacktraceBuilder.new(config) }
-    let(:callback) { ->(*_) {} }
-    before { allow(callback).to receive(:call) }
+    let(:agent) {double('agent', enqueue: true) }
 
     subject do
       Instrumenter.new(
         config,
         stacktrace_builder: stacktrace_builder,
-        &callback
+        agent: agent
       )
     end
 
@@ -99,7 +98,7 @@ module ElasticAPM
         expect(transaction).to be_stopped
         expect(transaction.result).to eq 'result'
         expect(subject.current_transaction).to be nil
-        expect(callback).to have_received(:call).with(transaction)
+        expect(agent).to have_received(:enqueue).with(transaction)
       end
     end
 
@@ -195,7 +194,7 @@ module ElasticAPM
           expect(return_value).to be span
           expect(span).to be_stopped
           expect(subject.current_span).to be nil
-          expect(callback).to have_received(:call).with(span)
+          expect(agent).to have_received(:enqueue).with(span)
         end
 
         context 'inside another span' do

--- a/spec/elastic_apm/instrumenter_spec.rb
+++ b/spec/elastic_apm/instrumenter_spec.rb
@@ -4,7 +4,7 @@ module ElasticAPM
   RSpec.describe Instrumenter, :intercept do
     let(:config) { Config.new }
     let(:stacktrace_builder) { StacktraceBuilder.new(config) }
-    let(:agent) {double('agent', enqueue: true) }
+    let(:agent) { double('agent', enqueue: true) }
 
     subject do
       Instrumenter.new(

--- a/spec/elastic_apm/metrics_spec.rb
+++ b/spec/elastic_apm/metrics_spec.rb
@@ -5,8 +5,8 @@ require 'spec_helper'
 module ElasticAPM
   RSpec.describe Metrics do
     let(:config) { Config.new }
-    let(:callback) { ->(_) {} }
-    subject { described_class.new(config, &callback) }
+    let(:agent) { double('agent', enqueue: true) }
+    subject { described_class.new(config, agent) }
 
     describe 'life cycle' do
       describe '#start' do
@@ -49,20 +49,20 @@ module ElasticAPM
 
     describe '.collect_and_send' do
       context 'when samples' do
-        it 'calls callback' do
+        it 'calls enqueue on the agent' do
           expect(subject.samplers.first).to receive(:collect) { { thing: 1 } }
-          expect(callback).to receive(:call).with(Metricset)
+          expect(agent).to receive(:enqueue).with(Metricset)
 
           subject.collect_and_send
         end
       end
 
       context 'when no samples' do
-        it 'calls callback' do
+        it 'does not call enqueue on the agent' do
           subject.samplers.each do |sampler|
             expect(sampler).to receive(:collect) { nil }
           end
-          expect(callback).to_not receive(:call)
+          expect(agent).to_not receive(:enqueue)
 
           subject.collect_and_send
         end


### PR DESCRIPTION
This is an attempt to resolve an occasional error on JRuby:
```
NoMethodError: undefined method `enqueue' for #<ElasticAPM::Agent:0xc9518ee>
 # ./lib/elastic_apm/agent.rb:77:in `block in initialize'
```