### PR TITLE
ci(jenkins): when for tags requires pattern but branch doesn't allow regex

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -40,6 +40,7 @@ pipeline {
   parameters {
     booleanParam(name: 'Run_As_Master_Branch', defaultValue: false, description: 'Allow to run any steps on a PR, some steps normally only run on master branch.')
     booleanParam(name: 'bench_ci', defaultValue: true, description: 'Enable run benchmarks.')
+    booleanParam(name: 'tests_ci', defaultValue: true, description: 'Enable tests.')
   }
   stages {
     /**
@@ -86,6 +87,10 @@ pipeline {
     stage('Test') {
       agent { label 'linux && immutable' }
       options { skipDefaultCheckout() }
+      when {
+        beforeAgent true
+        expression { return params.tests_ci }
+      }
       steps {
         withGithubNotify(context: 'Tests', tab: 'tests') {
           deleteDir()
@@ -110,9 +115,7 @@ pipeline {
           allOf {
             anyOf {
               branch 'master'
-              branch "\\d+\\.\\d+"
-              branch "v\\d?"
-              tag "v\\d+\\.\\d+\\.\\d+*"
+              tag pattern: 'v\\d+\\.\\d+\\.\\d+.*', comparator: 'REGEXP'
               expression { return params.Run_As_Master_Branch }
             }
             expression { return params.bench_ci }


### PR DESCRIPTION
### Highlights
- Enable param to skip tests.
- branch in the when doesn't allow using regex. See https://github.com/jenkinsci/pipeline-model-definition-plugin/pull/351
