### PR TITLE
Split span.type into type, subtype, action

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 - Add `Rails` module with `#start` method to run Rails setup explicitly ([#522](https://github.com/elastic/apm-agent-ruby/pull/522))
 - Support for log/trace correlation ([#527](https://github.com/elastic/apm-agent-ruby/pull/527))
 
+### Changed
+
+- Split dot-separated `span.type` into `.type`, `.subtype` and `.action` (auto-upgrades dot style) ([#531](https://github.com/elastic/apm-agent-ruby/pull/531))
+
 ## 2.10.1
 
 ### Fixed

--- a/docs/api.asciidoc
+++ b/docs/api.asciidoc
@@ -141,7 +141,9 @@ end
 Arguments:
 
   * `name`: A name for your span. **Required**.
-  * `type`: The type of work eg. `db.postgresql.query`.
+  * `type`: The type of span eg. `db`.
+  * `type`: The subtype of span eg. `postgresql`.
+  * `type`: The action type of span eg. `connect` or `query`.
   * `context`: An instance of `Span::Context`.
   * `include_stacktrace`: Whether or not to collect a Stacktrace.
   * `&block`: An optional block to wrap with the span.

--- a/docs/api.asciidoc
+++ b/docs/api.asciidoc
@@ -142,8 +142,8 @@ Arguments:
 
   * `name`: A name for your span. **Required**.
   * `type`: The type of span eg. `db`.
-  * `type`: The subtype of span eg. `postgresql`.
-  * `type`: The action type of span eg. `connect` or `query`.
+  * `subtype`: The subtype of span eg. `postgresql`.
+  * `action`: The action type of span eg. `connect` or `query`.
   * `context`: An instance of `Span::Context`.
   * `include_stacktrace`: Whether or not to collect a Stacktrace.
   * `&block`: An optional block to wrap with the span.
@@ -166,7 +166,9 @@ Wraps a block in a Span.
 Arguments:
 
   * `name`: A name for your span. **Required**.
-  * `type`: The type of work eg. `db.postgresql.query`.
+  * `type`: The type of span eg. `db`.
+  * `subtype`: The subtype of span eg. `postgresql`.
+  * `action`: The action type of span eg. `connect` or `query`.
   * `context`: An instance of `Span::Context`.
   * `include_stacktrace`: Whether or not to collect a Stacktrace.
   * `&block`: An optional block to wrap with the span.

--- a/lib/elastic_apm.rb
+++ b/lib/elastic_apm.rb
@@ -227,16 +227,21 @@ module ElasticAPM # rubocop:disable Metrics/ModuleLength
 
     deprecate :span, :with_span
 
+    # rubocop:disable Metrics/MethodLength, Metrics/ParameterLists
     # Start a new span
     #
     # @param name [String] A description of the span, eq `SELECT FROM "users"`
-    # @param type [String] The kind of span, eq `db.mysql2.query`
+    # @param type [String] The span type, eq `db`
+    # @param subtype [String] The span subtype, eq `postgresql`
+    # @param action [String] The span action type, eq `connect` or `query`
     # @param context [Span::Context] Context information about the span
     # @param include_stacktrace [Boolean] Whether or not to capture a stacktrace
     # @return [Span]
     def start_span(
       name,
       type = nil,
+      subtype: nil,
+      action: nil,
       context: nil,
       include_stacktrace: true,
       trace_context: nil
@@ -244,6 +249,8 @@ module ElasticAPM # rubocop:disable Metrics/ModuleLength
       agent&.start_span(
         name,
         type,
+        subtype: subtype,
+        action: action,
         context: context,
         trace_context: trace_context
       ).tap do |span|
@@ -253,6 +260,7 @@ module ElasticAPM # rubocop:disable Metrics/ModuleLength
         span.original_backtrace ||= caller
       end
     end
+    # rubocop:enable Metrics/MethodLength, Metrics/ParameterLists
 
     # Ends the current span
     #
@@ -261,7 +269,7 @@ module ElasticAPM # rubocop:disable Metrics/ModuleLength
       agent&.end_span
     end
 
-    # rubocop:disable Metrics/MethodLength
+    # rubocop:disable Metrics/MethodLength, Metrics/ParameterLists
     # Wrap a block in a Span, ending it after the block
     #
     # @param name [String] A description of the span, eq `SELECT FROM "users"`
@@ -273,6 +281,8 @@ module ElasticAPM # rubocop:disable Metrics/ModuleLength
     def with_span(
       name,
       type = nil,
+      subtype: nil,
+      action: nil,
       context: nil,
       include_stacktrace: true,
       trace_context: nil
@@ -289,6 +299,8 @@ module ElasticAPM # rubocop:disable Metrics/ModuleLength
           start_span(
             name,
             type,
+            subtype: subtype,
+            action: action,
             context: context,
             include_stacktrace: include_stacktrace,
             trace_context: trace_context
@@ -298,7 +310,7 @@ module ElasticAPM # rubocop:disable Metrics/ModuleLength
         end_span
       end
     end
-    # rubocop:enable Metrics/MethodLength
+    # rubocop:enable Metrics/MethodLength, Metrics/ParameterLists
 
     # Build a [Context] from a Rack `env`. The context may include information
     # about the request, response, current user and more

--- a/lib/elastic_apm/agent.rb
+++ b/lib/elastic_apm/agent.rb
@@ -159,9 +159,12 @@ module ElasticAPM
       instrumenter.end_transaction(result)
     end
 
+    # rubocop:disable Metrics/ParameterLists
     def start_span(
       name = nil,
       type = nil,
+      subtype: nil,
+      action: nil,
       backtrace: nil,
       context: nil,
       trace_context: nil
@@ -169,11 +172,14 @@ module ElasticAPM
       instrumenter.start_span(
         name,
         type,
+        subtype: subtype,
+        action: action,
         backtrace: backtrace,
         context: context,
         trace_context: trace_context
       )
     end
+    # rubocop:enable Metrics/ParameterLists
 
     def end_span
       instrumenter.end_span

--- a/lib/elastic_apm/instrumenter.rb
+++ b/lib/elastic_apm/instrumenter.rb
@@ -134,9 +134,12 @@ module ElasticAPM
 
     # rubocop:disable Metrics/MethodLength, Metrics/CyclomaticComplexity
     # rubocop:disable Metrics/AbcSize, Metrics/PerceivedComplexity
+    # rubocop:disable Metrics/ParameterLists
     def start_span(
       name,
       type = nil,
+      subtype: nil,
+      action: nil,
       backtrace: nil,
       context: nil,
       trace_context: nil
@@ -155,6 +158,8 @@ module ElasticAPM
 
       span = Span.new(
         name: name,
+        subtype: subtype,
+        action: action,
         transaction_id: transaction.id,
         trace_context: trace_context || parent.trace_context.child,
         type: type,
@@ -170,6 +175,7 @@ module ElasticAPM
 
       span.start
     end
+    # rubocop:enable Metrics/ParameterLists
     # rubocop:enable Metrics/AbcSize, Metrics/PerceivedComplexity
     # rubocop:enable Metrics/MethodLength, Metrics/CyclomaticComplexity
 

--- a/lib/elastic_apm/normalizers/action_controller.rb
+++ b/lib/elastic_apm/normalizers/action_controller.rb
@@ -6,11 +6,14 @@ module ElasticAPM
       # @api private
       class ProcessActionNormalizer < Normalizer
         register 'process_action.action_controller'
-        TYPE = 'app.controller.action'
+
+        TYPE = 'app'
+        SUBTYPE = 'controller'
+        ACTION = 'action'
 
         def normalize(transaction, _name, payload)
           transaction.name = endpoint(payload)
-          [transaction.name, TYPE, nil]
+          [transaction.name, TYPE, SUBTYPE, ACTION, nil]
         end
 
         private

--- a/lib/elastic_apm/normalizers/action_mailer.rb
+++ b/lib/elastic_apm/normalizers/action_mailer.rb
@@ -6,10 +6,13 @@ module ElasticAPM
       # @api private
       class ProcessActionNormalizer < Normalizer
         register 'process.action_mailer'
-        TYPE = 'app.mailer.action'
+
+        TYPE = 'app'
+        SUBTYPE = 'mailer'
+        ACTION = 'action'
 
         def normalize(_transaction, _name, payload)
-          [endpoint(payload), TYPE, nil]
+          [endpoint(payload), TYPE, SUBTYPE, ACTION, nil]
         end
 
         private

--- a/lib/elastic_apm/normalizers/action_view.rb
+++ b/lib/elastic_apm/normalizers/action_view.rb
@@ -7,8 +7,8 @@ module ElasticAPM
       class RenderNormalizer < Normalizer
         private
 
-        def normalize_render(payload, type)
-          [path_for(payload[:identifier]), type, nil]
+        def normalize_render(payload, type, subtype, action)
+          [path_for(payload[:identifier]), type, subtype, action, nil]
         end
 
         def path_for(path)
@@ -41,30 +41,35 @@ module ElasticAPM
       # @api private
       class RenderTemplateNormalizer < RenderNormalizer
         register 'render_template.action_view'
-        TYPE = 'template.view'
+        TYPE = 'template'
+        SUBTYPE = 'view'
 
         def normalize(_transaction, _name, payload)
-          normalize_render(payload, TYPE)
+          normalize_render(payload, TYPE, SUBTYPE, nil)
         end
       end
 
       # @api private
       class RenderPartialNormalizer < RenderNormalizer
         register 'render_partial.action_view'
-        TYPE = 'template.view.partial'
+        TYPE = 'template'
+        SUBTYPE = 'view'
+        ACTION = 'partial'
 
         def normalize(_transaction, _name, payload)
-          normalize_render(payload, TYPE)
+          normalize_render(payload, TYPE, SUBTYPE, ACTION)
         end
       end
 
       # @api private
       class RenderCollectionNormalizer < RenderNormalizer
         register 'render_collection.action_view'
-        TYPE = 'template.view.collection'
+        TYPE = 'template'
+        SUBTYPE = 'view'
+        ACTION = 'collection'
 
         def normalize(_transaction, _name, payload)
-          normalize_render(payload, TYPE)
+          normalize_render(payload, TYPE, SUBTYPE, ACTION)
         end
       end
     end

--- a/lib/elastic_apm/normalizers/active_record.rb
+++ b/lib/elastic_apm/normalizers/active_record.rb
@@ -9,10 +9,13 @@ module ElasticAPM
       class SqlNormalizer < Normalizer
         register 'sql.active_record'
 
+        TYPE = 'db'
+        ACTION = 'sql'
+
         def initialize(*args)
           super
 
-          @type = format('db.%s.sql', lookup_adapter || 'unknown').freeze
+          @subtype = lookup_adapter || 'unknown'
           @summarizer = SqlSummarizer.new
         end
 
@@ -22,7 +25,7 @@ module ElasticAPM
           name = summarize(payload[:sql]) || payload[:name]
           context =
             Span::Context.new(db: { statement: payload[:sql], type: 'sql' })
-          [name, @type, context]
+          [name, TYPE, @subtype, ACTION, context]
         end
 
         private

--- a/lib/elastic_apm/span.rb
+++ b/lib/elastic_apm/span.rb
@@ -14,17 +14,26 @@ module ElasticAPM
 
     DEFAULT_TYPE = 'custom'
 
-    # rubocop:disable Metrics/ParameterLists
+    # rubocop:disable Metrics/ParameterLists, Metrics/MethodLength
     def initialize(
       name:,
       transaction_id:,
       trace_context:,
       type: nil,
+      subtype: nil,
+      action: nil,
       context: nil,
       stacktrace_builder: nil
     )
       @name = name
-      @type = type || DEFAULT_TYPE
+
+      if subtype.nil? && type&.include?('.')
+        @type, @subtype, @action = type.split('.')
+      else
+        @type = type || DEFAULT_TYPE
+        @subtype = subtype
+        @action = action
+      end
 
       @transaction_id = transaction_id
       @trace_context = trace_context
@@ -32,10 +41,23 @@ module ElasticAPM
       @context = context || Span::Context.new
       @stacktrace_builder = stacktrace_builder
     end
-    # rubocop:enable Metrics/ParameterLists
+    # rubocop:enable Metrics/ParameterLists, Metrics/MethodLength
 
-    attr_accessor :name, :type, :original_backtrace, :trace_context
-    attr_reader :context, :stacktrace, :duration, :timestamp, :transaction_id
+    attr_accessor(
+      :action,
+      :name,
+      :original_backtrace,
+      :subtype,
+      :trace_context,
+      :type
+    )
+    attr_reader(
+      :context,
+      :duration,
+      :stacktrace,
+      :timestamp,
+      :transaction_id
+    )
 
     # life cycle
 

--- a/lib/elastic_apm/spies/faraday.rb
+++ b/lib/elastic_apm/spies/faraday.rb
@@ -5,6 +5,9 @@ module ElasticAPM
   module Spies
     # @api private
     class FaradaySpy
+      TYPE = 'ext'
+      SUBTYPE = 'faraday'
+
       def self.without_net_http
         return yield unless defined?(NetHTTPSpy)
 
@@ -37,9 +40,13 @@ module ElasticAPM
                    end
 
             name = "#{method.upcase} #{host}"
-            type = "ext.faraday.#{method}"
 
-            ElasticAPM.with_span name, type do |span|
+            ElasticAPM.with_span(
+              name,
+              TYPE,
+              subtype: SUBTYPE,
+              action: method.to_s
+            ) do |span|
               ElasticAPM::Spies::FaradaySpy.without_net_http do
                 trace_context = span&.trace_context || transaction.trace_context
 

--- a/lib/elastic_apm/spies/http.rb
+++ b/lib/elastic_apm/spies/http.rb
@@ -5,6 +5,9 @@ module ElasticAPM
   module Spies
     # @api private
     class HTTPSpy
+      TYPE = 'ext'
+      SUBTYPE = 'http_rb'
+
       # rubocop:disable Metrics/MethodLength
       def install
         ::HTTP::Client.class_eval do
@@ -19,9 +22,13 @@ module ElasticAPM
             host = req.uri.host
 
             name = "#{method} #{host}"
-            type = "ext.http_rb.#{method}"
 
-            ElasticAPM.with_span name, type do |span|
+            ElasticAPM.with_span(
+              name,
+              TYPE,
+              subtype: SUBTYPE,
+              action: method
+            ) do |span|
               trace_context = span&.trace_context || transaction.trace_context
               req['Elastic-Apm-Traceparent'] = trace_context.to_header
               perform_without_apm(req, options)

--- a/lib/elastic_apm/spies/mongo.rb
+++ b/lib/elastic_apm/spies/mongo.rb
@@ -14,7 +14,9 @@ module ElasticAPM
 
       # @api private
       class Subscriber
-        TYPE = 'db.mongodb.query'
+        TYPE = 'db'
+        SUBTYPE = 'mongodb'
+        ACTION = 'query'
 
         def initialize
           @events = {}
@@ -51,6 +53,8 @@ module ElasticAPM
             ElasticAPM.start_span(
               name,
               TYPE,
+              subtype: SUBTYPE,
+              action: ACTION,
               context: build_context(event)
             )
 

--- a/lib/elastic_apm/spies/net_http.rb
+++ b/lib/elastic_apm/spies/net_http.rb
@@ -6,6 +6,8 @@ module ElasticAPM
     # @api private
     class NetHTTPSpy
       KEY = :__elastic_apm_net_http_disabled
+      TYPE = 'ext'
+      SUBTYPE = 'net_http'
 
       # rubocop:disable Metrics/MethodLength, Metrics/AbcSize
       class << self
@@ -46,9 +48,13 @@ module ElasticAPM
             host ||= address
 
             name = "#{method} #{host}"
-            type = "ext.net_http.#{method}"
 
-            ElasticAPM.with_span name, type do |span|
+            ElasticAPM.with_span(
+              name,
+              TYPE,
+              subtype: SUBTYPE,
+              action: method.to_s
+            ) do |span|
               trace_context = span&.trace_context || transaction.trace_context
               req['Elastic-Apm-Traceparent'] = trace_context.to_header
               request_without_apm(req, body, &block)

--- a/lib/elastic_apm/subscriber.rb
+++ b/lib/elastic_apm/subscriber.rb
@@ -29,8 +29,8 @@ module ElasticAPM
 
     Notification = Struct.new(:id, :span)
 
+    # rubocop:disable Metrics/MethodLength
     def start(name, id, payload)
-      # debug "AS::Notification#start:#{name}:#{id}"
       return unless (transaction = @agent.current_transaction)
 
       normalized = @normalizers.normalize(transaction, name, payload)
@@ -39,12 +39,20 @@ module ElasticAPM
         if normalized == :skip
           nil
         else
-          name, type, context = normalized
-          @agent.start_span(name, type, context: context)
+          name, type, subtype, action, context = normalized
+
+          @agent.start_span(
+            name,
+            type,
+            subtype: subtype,
+            action: action,
+            context: context
+          )
         end
 
       transaction.notifications << Notification.new(id, span)
     end
+    # rubocop:enable Metrics/MethodLength
 
     def finish(_name, id, _payload)
       # debug "AS::Notification#finish:#{name}:#{id}"

--- a/lib/elastic_apm/transport/serializers/span_serializer.rb
+++ b/lib/elastic_apm/transport/serializers/span_serializer.rb
@@ -21,9 +21,7 @@ module ElasticAPM
               transaction_id: span.transaction_id,
               parent_id: span.parent_id,
               name: keyword_field(span.name),
-              type: keyword_field(span.type),
-              subtype: keyword_field(span.subtype),
-              action: keyword_field(span.action),
+              type: join_type(span),
               duration: ms(span.duration),
               context: context_serializer.build(span.context),
               stacktrace: span.stacktrace.to_a,
@@ -67,6 +65,12 @@ module ElasticAPM
               method: keyword_field(http.method)
             }
           end
+        end
+
+        private
+
+        def join_type(span)
+          [span.type, span.subtype, span.action].tap(&:compact!).join('.')
         end
       end
     end

--- a/lib/elastic_apm/transport/serializers/span_serializer.rb
+++ b/lib/elastic_apm/transport/serializers/span_serializer.rb
@@ -22,6 +22,8 @@ module ElasticAPM
               parent_id: span.parent_id,
               name: keyword_field(span.name),
               type: keyword_field(span.type),
+              subtype: keyword_field(span.subtype),
+              action: keyword_field(span.action),
               duration: ms(span.duration),
               context: context_serializer.build(span.context),
               stacktrace: span.stacktrace.to_a,

--- a/lib/elastic_apm/transport/serializers/span_serializer.rb
+++ b/lib/elastic_apm/transport/serializers/span_serializer.rb
@@ -13,7 +13,7 @@ module ElasticAPM
 
         attr_reader :context_serializer
 
-        # rubocop:disable Metrics/MethodLength, Metrics/AbcSize
+        # rubocop:disable Metrics/MethodLength
         def build(span)
           {
             span: {
@@ -30,7 +30,7 @@ module ElasticAPM
             }
           }
         end
-        # rubocop:enable Metrics/MethodLength, Metrics/AbcSize
+        # rubocop:enable Metrics/MethodLength
 
         # @api private
         class ContextSerializer < Serializer
@@ -70,7 +70,9 @@ module ElasticAPM
         private
 
         def join_type(span)
-          [span.type, span.subtype, span.action].tap(&:compact!).join('.')
+          combined = [span.type, span.subtype, span.action]
+          combined.compact!
+          combined.join '.'
         end
       end
     end

--- a/spec/elastic_apm/agent_spec.rb
+++ b/spec/elastic_apm/agent_spec.rb
@@ -73,7 +73,13 @@ module ElasticAPM
           start_span: [
             nil,
             nil,
-            { backtrace: nil, context: nil, trace_context: nil }
+            {
+              subtype: nil,
+              action: nil,
+              backtrace: nil,
+              context: nil,
+              trace_context: nil
+            }
           ],
           end_span: nil,
           set_tag: [nil, nil],

--- a/spec/elastic_apm/normalizers/action_controller_spec.rb
+++ b/spec/elastic_apm/normalizers/action_controller_spec.rb
@@ -24,7 +24,13 @@ module ElasticAPM
               'process_action.action_controller',
               controller: 'UsersController', action: 'index'
             )
-            expected = ['UsersController#index', 'app.controller.action', nil]
+            expected = [
+              'UsersController#index',
+              'app',
+              'controller',
+              'action',
+              nil
+            ]
 
             expect(result).to eq expected
           end

--- a/spec/elastic_apm/normalizers/action_view_spec.rb
+++ b/spec/elastic_apm/normalizers/action_view_spec.rb
@@ -17,7 +17,8 @@ module ElasticAPM
           it 'normalizes an unknown template' do
             result = subject.normalize(nil, key, {})
             type = described_class.const_get(:TYPE)
-            expected = ['Unknown template', type, nil]
+            subtype = described_class.const_get(:SUBTYPE)
+            expected = ['Unknown template', type, subtype, action, nil]
 
             expect(result).to eq expected
           end
@@ -49,18 +50,21 @@ module ElasticAPM
       end
 
       describe ActionView::RenderTemplateNormalizer do
+        let(:action) { nil }
         subject { normalizers.for('render_template.action_view') }
         it { expect(subject).to be_a ActionView::RenderTemplateNormalizer }
         it_should_behave_like :action_view_normalizer
       end
 
       describe ActionView::RenderPartialNormalizer do
+        let(:action) { 'partial' }
         subject { normalizers.for('render_partial.action_view') }
         it { expect(subject).to be_a ActionView::RenderPartialNormalizer }
         it_should_behave_like :action_view_normalizer
       end
 
       describe ActionView::RenderCollectionNormalizer do
+        let(:action) { 'collection' }
         subject { normalizers.for('render_collection.action_view') }
         it { expect(subject).to be_a ActionView::RenderCollectionNormalizer }
         it_should_behave_like :action_view_normalizer

--- a/spec/elastic_apm/normalizers/active_record_spec.rb
+++ b/spec/elastic_apm/normalizers/active_record_spec.rb
@@ -25,9 +25,10 @@ module ElasticAPM
 
             subject = SqlNormalizer.new nil
 
-            _, type, = subject.normalize(nil, nil, sql: 'DROP * FROM users')
+            _, _, subtype, =
+              subject.normalize(nil, nil, sql: 'DROP * FROM users')
 
-            expect(type).to eq 'db.mysql.sql'
+            expect(subtype).to eq 'mysql'
           end
         end
 
@@ -43,10 +44,12 @@ module ElasticAPM
             sql = 'SELECT  "hotdogs".* FROM "hotdogs" ' \
               'WHERE "hotdogs"."topping" = $1 LIMIT 1'
 
-            name, type, context = normalize_payload(sql: sql)
+            name, type, subtype, action, context_ = normalize_payload(sql: sql)
             expect(name).to eq 'SELECT FROM hotdogs'
-            expect(type).to eq 'db.unknown.sql'
-            expect(context.db.statement).to eq sql
+            expect(type).to eq 'db'
+            expect(subtype).to eq 'unknown'
+            expect(action).to eq 'sql'
+            expect(context_.db.statement).to eq sql
           end
 
           it 'skips cache queries' do

--- a/spec/elastic_apm/span_spec.rb
+++ b/spec/elastic_apm/span_spec.rb
@@ -3,9 +3,11 @@
 module ElasticAPM
   RSpec.describe Span do
     subject do
-      described_class.new(name: 'Spannest name',
-                          transaction_id: transaction_id,
-                          trace_context: trace_context)
+      described_class.new(
+        name: 'Spannest name',
+        transaction_id: transaction_id,
+        trace_context: trace_context
+      )
     end
     let(:trace_context) do
       TraceContext.parse("00-#{'1' * 32}-#{'2' * 16}-01")
@@ -15,6 +17,8 @@ module ElasticAPM
     describe '#initialize' do
       its(:name) { should eq 'Spannest name' }
       its(:type) { should eq 'custom' }
+      its(:subtype) { should be nil }
+      its(:action) { should be nil }
       its(:transaction_id) { should eq transaction_id }
       its(:trace_context) { should eq trace_context }
       its(:timestamp) { should be_nil }
@@ -22,6 +26,22 @@ module ElasticAPM
       its(:trace_id) { should eq trace_context.trace_id }
       its(:id) { should eq trace_context.id }
       its(:parent_id) { should eq trace_context.parent_id }
+
+      context 'with a dot-separated type' do
+        it 'splits type' do
+          span =
+            described_class.new(
+              name: 'Spannest name',
+              type: 'typest.subest.actionest',
+              transaction_id: transaction_id,
+              trace_context: trace_context
+            )
+
+          expect(span.type).to eq 'typest'
+          expect(span.subtype).to eq 'subest'
+          expect(span.action).to eq 'actionest'
+        end
+      end
     end
 
     describe '#start', :mock_time do

--- a/spec/elastic_apm/spies/faraday_spec.rb
+++ b/spec/elastic_apm/spies/faraday_spec.rb
@@ -20,7 +20,9 @@ module ElasticAPM
 
       expect(span).to_not be nil
       expect(span.name).to eq 'GET example.com'
-      expect(span.type).to eq 'ext.faraday.get'
+      expect(span.type).to eq 'ext'
+      expect(span.subtype).to eq 'faraday'
+      expect(span.action).to eq 'get'
 
       ElasticAPM.stop
       WebMock.reset!
@@ -38,7 +40,9 @@ module ElasticAPM
 
       expect(span).to_not be nil
       expect(span.name).to eq 'GET example.com'
-      expect(span.type).to eq 'ext.faraday.get'
+      expect(span.type).to eq 'ext'
+      expect(span.subtype).to eq 'faraday'
+      expect(span.action).to eq 'get'
 
       ElasticAPM.stop
       WebMock.reset!
@@ -58,7 +62,9 @@ module ElasticAPM
 
       expect(span).to_not be nil
       expect(span.name).to eq 'GET example.com'
-      expect(span.type).to eq 'ext.faraday.get'
+      expect(span.type).to eq 'ext'
+      expect(span.subtype).to eq 'faraday'
+      expect(span.action).to eq 'get'
 
       ElasticAPM.stop
       WebMock.reset!

--- a/spec/elastic_apm/spies/mongo_spec.rb
+++ b/spec/elastic_apm/spies/mongo_spec.rb
@@ -42,7 +42,9 @@ module ElasticAPM
       span, = @intercepted.spans
 
       expect(span.name).to eq 'elastic-apm-test.listCollections'
-      expect(span.type).to eq 'db.mongodb.query'
+      expect(span.type).to eq 'db'
+      expect(span.subtype).to eq 'mongodb'
+      expect(span.action).to eq 'query'
       expect(span.duration).to_not be_nil
 
       db = span.context.db
@@ -77,7 +79,9 @@ module ElasticAPM
       span, = @intercepted.spans
 
       expect(span.name).to eq 'elastic-apm-test.testing.parallelCollectionScan'
-      expect(span.type).to eq 'db.mongodb.query'
+      expect(span.type).to eq 'db'
+      expect(span.subtype).to eq 'mongodb'
+      expect(span.action).to eq 'query'
       expect(span.duration).to_not be_nil
 
       db = span.context.db
@@ -112,7 +116,9 @@ module ElasticAPM
       span, = @intercepted.spans
 
       expect(span.name).to eq 'elastic-apm-test.testing.find'
-      expect(span.type).to eq 'db.mongodb.query'
+      expect(span.type).to eq 'db'
+      expect(span.subtype).to eq 'mongodb'
+      expect(span.action).to eq 'query'
       expect(span.duration).to_not be_nil
 
       db = span.context.db

--- a/spec/elastic_apm/spies/net_http_spec.rb
+++ b/spec/elastic_apm/spies/net_http_spec.rb
@@ -84,7 +84,9 @@ module ElasticAPM
 
       span, = @intercepted.spans
       expect(span.name).to eq 'POST example.com'
-      expect(span.type).to eq 'ext.net_http.POST'
+      expect(span.type).to eq 'ext'
+      expect(span.subtype).to eq 'net_http'
+      expect(span.action).to eq 'POST'
 
       ElasticAPM.stop
       WebMock.reset!

--- a/spec/elastic_apm/transport/serializers/span_serializer_spec.rb
+++ b/spec/elastic_apm/transport/serializers/span_serializer_spec.rb
@@ -38,6 +38,8 @@ module ElasticAPM
                 trace_id: span.trace_id,
                 name: 'Span',
                 type: 'custom',
+                subtype: nil,
+                action: nil,
                 context: { sync: true },
                 stacktrace: [],
                 timestamp: 694_224_000_000_000,

--- a/spec/elastic_apm/transport/serializers/span_serializer_spec.rb
+++ b/spec/elastic_apm/transport/serializers/span_serializer_spec.rb
@@ -38,8 +38,6 @@ module ElasticAPM
                 trace_id: span.trace_id,
                 name: 'Span',
                 type: 'custom',
-                subtype: nil,
-                action: nil,
                 context: { sync: true },
                 stacktrace: [],
                 timestamp: 694_224_000_000_000,
@@ -83,6 +81,23 @@ module ElasticAPM
 
               statement = result.dig(:span, :context, :db, :statement)
               expect(statement.length).to be(10_000)
+            end
+          end
+
+          context 'with split types' do
+            let(:span) do
+              Span.new(
+                name: 'Span',
+                transaction_id: transaction.id,
+                trace_context: trace_context,
+                type: 'a',
+                subtype: 'b',
+                action: 'c'
+              )
+            end
+
+            it 'joins them for sending' do
+              expect(result[:span][:type]).to eq 'a.b.c'
             end
           end
         end


### PR DESCRIPTION
_Upgrades_ legacy values by splitting by `'.'` if no `subtype` is passed.

Currently, APM Server updates the dot-separated types for us, so this will not change how data looks in ES.

When we do breaking changes, I think we should make the top-level `type` argument in `start_span` into a keyword argument. If you agree, @estolfo, perhaps we should deprecate it now in a minor version to warn users in a cycle before the upgrade.

This is sort-of needed for the breakdown graphs too, so rebasing that branch on this.