### PR TITLE
Handle empty stacktrace frames when setting culprit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Fixed
+
+- Handles a case where stacktrace frames are empty ([#538](https://github.com/elastic/apm-agent-ruby/pull/538))
+
 ## 2.11.0 (2019-09-23)
 
 ### Added

--- a/lib/elastic_apm/error_builder.rb
+++ b/lib/elastic_apm/error_builder.rb
@@ -49,7 +49,7 @@ module ElasticAPM
         error.log.stacktrace = stacktrace
       end
 
-      error.culprit = stacktrace.frames.first.function
+      error.culprit = stacktrace.frames.first&.function
     end
 
     # rubocop:disable Metrics/MethodLength, Metrics/AbcSize


### PR DESCRIPTION
Fixes https://github.com/elastic/apm-agent-ruby/issues/476