### PR TITLE
Rename disabled_spies to disabled_instrumentations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 
 ## Unreleased
 
+### Changed
+
+- `disabled_spies` renamed to `disabled_instrumentations` with fallback ([#539](https://github.com/elastic/apm-agent-ruby/pull/539))
+
 ### Fixed
 
 - Handles a case where stacktrace frames are empty ([#538](https://github.com/elastic/apm-agent-ruby/pull/538))

--- a/docs/configuration.asciidoc
+++ b/docs/configuration.asciidoc
@@ -284,19 +284,19 @@ Disables sending payloads to APM Server.
 Disables the agent's startup message announcing itself.
 
 [float]
-[[config-disabled-spies]]
-==== `disabled_spies`
+[[config-disabled-instrumentations]]
+==== `disabled_instrumentations`
 
 [options="header"]
 |============
-| Environment                  | `Config` key     | Default
-| `ELASTIC_APM_DISABLED_SPIES` | `disabled_spies` | `['json']`
+| Environment                             | `Config` key                | Default
+| `ELASTIC_APM_DISABLED_INSTRUMENTATIONS` | `disabled_instrumentations` | `['json']`
 |============
 
 Elastic APM automatically instruments select third party libraries.
 Use this option to disable any of these.
 
-Get an array of enabled spies with `ElasticAPM.agent.config.enabled_spies`.
+Get an array of enabled instrumentations with `ElasticAPM.agent.config.enabled_instrumentations`.
 
 [float]
 [[config-environment]]

--- a/lib/elastic_apm/agent.rb
+++ b/lib/elastic_apm/agent.rb
@@ -101,7 +101,7 @@ module ElasticAPM
       instrumenter.start
       metrics.start
 
-      config.enabled_spies.each do |lib|
+      config.enabled_instrumentations.each do |lib|
         debug "Requiring spy: #{lib}"
         require "elastic_apm/spies/#{lib}"
       end

--- a/lib/elastic_apm/config.rb
+++ b/lib/elastic_apm/config.rb
@@ -16,6 +16,7 @@ module ElasticAPM
   # @api private
   class Config
     extend Options
+    extend Deprecations
 
     DEPRECATED_OPTIONS = %i[
       compression_level=
@@ -160,6 +161,31 @@ module ElasticAPM
       end
     end
 
+    def use_ssl?
+      server_url.start_with?('https')
+    end
+
+    def collect_metrics?
+      metrics_interval > 0
+    end
+
+    def span_frames_min_duration?
+      span_frames_min_duration != 0
+    end
+
+    def span_frames_min_duration=(value)
+      super
+      @span_frames_min_duration_us = nil
+    end
+
+    def span_frames_min_duration_us
+      @span_frames_min_duration_us ||= span_frames_min_duration * 1_000_000
+    end
+
+    def inspect
+      super.split.first + '>'
+    end
+
     # DEPRECATED
     # rubocop:disable Metrics/MethodLength
     def capture_body=(value)
@@ -187,41 +213,29 @@ module ElasticAPM
     # rubocop:enable Metrics/MethodLength
 
     # DEPRECATED
+    # The spies methods are only somewhat public and only mentioned briefly in
+    # the docs.
+
     def disabled_spies=(list)
-      warn 'The option disabled_spies has been renamed to ' \
-        'disabled_instrumentations'
       self.disabled_instrumentations = list
     end
 
+    def disabled_spies
+      disabled_instrumentations
+    end
+
     def enabled_spies
-      warn 'enabled_spies has been renamed to enabled_instrumentations'
       enabled_instrumentations
     end
 
-    def use_ssl?
-      server_url.start_with?('https')
+    def available_spies
+      available_instrumentations
     end
 
-    def collect_metrics?
-      metrics_interval > 0
-    end
-
-    def span_frames_min_duration?
-      span_frames_min_duration != 0
-    end
-
-    def span_frames_min_duration=(value)
-      super
-      @span_frames_min_duration_us = nil
-    end
-
-    def span_frames_min_duration_us
-      @span_frames_min_duration_us ||= span_frames_min_duration * 1_000_000
-    end
-
-    def inspect
-      super.split.first + '>'
-    end
+    deprecate :disabled_spies=, :disabled_instrumentations=
+    deprecate :disabled_spies, :disabled_instrumentations
+    deprecate :enabled_spies, :enabled_instrumentations
+    deprecate :available_spies, :available_instrumentations
 
     private
 

--- a/lib/elastic_apm/config.rb
+++ b/lib/elastic_apm/config.rb
@@ -51,6 +51,7 @@ module ElasticAPM
     option :disable_send,                      type: :bool,   default: false
     option :disable_start_message,             type: :bool,   default: false
     option :disabled_instrumentations,         type: :list,   default: %w[json]
+    option :disabled_spies,                    type: :list,   default: []
     option :environment,                       type: :string, default: ENV['RAILS_ENV'] || ENV['RACK_ENV']
     option :framework_name,                    type: :string
     option :framework_version,                 type: :string

--- a/lib/elastic_apm/config.rb
+++ b/lib/elastic_apm/config.rb
@@ -49,7 +49,7 @@ module ElasticAPM
     option :default_tags,                      type: :dict,   default: {}
     option :disable_send,                      type: :bool,   default: false
     option :disable_start_message,             type: :bool,   default: false
-    option :disabled_spies,                    type: :list,   default: %w[json]
+    option :disabled_instrumentations,         type: :list,   default: %w[json]
     option :environment,                       type: :string, default: ENV['RAILS_ENV'] || ENV['RACK_ENV']
     option :framework_name,                    type: :string
     option :framework_version,                 type: :string
@@ -121,7 +121,7 @@ module ElasticAPM
     end
 
     # rubocop:disable Metrics/MethodLength
-    def available_spies
+    def available_instrumentations
       %w[
         delayed_job
         elasticsearch
@@ -140,8 +140,8 @@ module ElasticAPM
     end
     # rubocop:enable Metrics/MethodLength
 
-    def enabled_spies
-      available_spies - disabled_spies
+    def enabled_instrumentations
+      available_instrumentations - disabled_instrumentations
     end
 
     def method_missing(name, *args)
@@ -160,6 +160,7 @@ module ElasticAPM
       end
     end
 
+    # DEPRECATED
     # rubocop:disable Metrics/MethodLength
     def capture_body=(value)
       if value =~ /(all|transactions|errors|off)/
@@ -184,6 +185,18 @@ module ElasticAPM
       end
     end
     # rubocop:enable Metrics/MethodLength
+
+    # DEPRECATED
+    def disabled_spies=(list)
+      warn 'The option disabled_spies has been renamed to ' \
+        'disabled_instrumentations'
+      self.disabled_instrumentations = list
+    end
+
+    def enabled_spies
+      warn 'enabled_spies has been renamed to enabled_instrumentations'
+      enabled_instrumentations
+    end
 
     def use_ssl?
       server_url.start_with?('https')

--- a/lib/elastic_apm/rails.rb
+++ b/lib/elastic_apm/rails.rb
@@ -29,7 +29,9 @@ module ElasticAPM
       end
 
       if ElasticAPM.running? &&
-         !ElasticAPM.agent.config.disabled_spies.include?('action_dispatch')
+         !ElasticAPM.agent.config.disabled_instrumentations.include?(
+           'action_dispatch'
+         )
         require 'elastic_apm/spies/action_dispatch'
       end
       ElasticAPM.running?

--- a/spec/elastic_apm/config_spec.rb
+++ b/spec/elastic_apm/config_spec.rb
@@ -184,15 +184,20 @@ module ElasticAPM
         expect(subject.capture_body).to eq 'off'
       end
 
-      it 'warns about disabled_spies and falls back' do
+      it 'warns about *_spies and falls back' do
         expect(subject).to receive(:warn)
-          .with(/The option disabled_spies.*renamed./)
+          .with(/disabled_spies=.*removed./)
         subject.disabled_spies = ['things']
         expect(subject.disabled_instrumentations).to eq(['things'])
 
-        expect(subject).to receive(:warn)
-          .with(/enabled_spies.*renamed./)
+        expect(subject).to receive(:warn).with(/enabled_spies.*removed./)
         expect(subject.enabled_spies).to_not be_empty
+
+        expect(subject).to receive(:warn).with(/available_spies.*removed./)
+        expect(subject.available_spies).to_not be_empty
+
+        expect(subject).to receive(:warn).with(/disabled_spies.*removed./)
+        expect(subject.disabled_spies).to_not be_empty
       end
     end
 

--- a/spec/elastic_apm/config_spec.rb
+++ b/spec/elastic_apm/config_spec.rb
@@ -42,7 +42,7 @@ module ElasticAPM
         ['ELASTIC_APM_VERIFY_SERVER_CERT', 'true', true],
         ['ELASTIC_APM_VERIFY_SERVER_CERT', '0', false],
         ['ELASTIC_APM_VERIFY_SERVER_CERT', 'false', false],
-        ['ELASTIC_APM_DISABLED_SPIES', 'json,http', %w[json http]],
+        ['ELASTIC_APM_DISABLED_INSTRUMENTATIONS', 'json,http', %w[json http]],
         ['ELASTIC_APM_CUSTOM_KEY_FILTERS', 'Auth,Other', [/Auth/, /Other/]],
         [
           'ELASTIC_APM_DEFAULT_TAGS',
@@ -130,10 +130,10 @@ module ElasticAPM
     end
 
     it 'has spies and may disable them' do
-      expect(Config.new.available_spies).to_not be_empty
+      expect(Config.new.available_instrumentations).to_not be_empty
 
-      config = Config.new disabled_spies: ['json']
-      expect(config.enabled_spies).to_not include('json')
+      config = Config.new disabled_instrumentations: ['json']
+      expect(config.enabled_instrumentations).to_not include('json')
     end
 
     context 'logging' do
@@ -182,6 +182,17 @@ module ElasticAPM
 
         subject.capture_body = :oh_no
         expect(subject.capture_body).to eq 'off'
+      end
+
+      it 'warns about disabled_spies and falls back' do
+        expect(subject).to receive(:warn)
+          .with(/The option disabled_spies.*renamed./)
+        subject.disabled_spies = ['things']
+        expect(subject.disabled_instrumentations).to eq(['things'])
+
+        expect(subject).to receive(:warn)
+          .with(/enabled_spies.*renamed./)
+        expect(subject.enabled_spies).to_not be_empty
       end
     end
 

--- a/spec/elastic_apm/config_spec.rb
+++ b/spec/elastic_apm/config_spec.rb
@@ -184,9 +184,19 @@ module ElasticAPM
         expect(subject.capture_body).to eq 'off'
       end
 
-      it 'warns about *_spies and falls back' do
-        expect(subject).to receive(:warn)
+      it 'accepts disabled_spies via env' do
+        # As soon as we build a config inside with_env `warn' will be called.
+        # This makes sure we don't pollute the test output.
+        allow_any_instance_of(Config).to receive(:warn)
           .with(/disabled_spies=.*removed./)
+
+        with_env('ELASTIC_APM_DISABLED_SPIES' => 'http,json') do
+          expect(subject.disabled_instrumentations).to eq(%w[http json])
+        end
+      end
+
+      it 'warns about *_spies and falls back' do
+        expect(subject).to receive(:warn).with(/disabled_spies=.*removed./)
         subject.disabled_spies = ['things']
         expect(subject.disabled_instrumentations).to eq(['things'])
 

--- a/spec/elastic_apm/spies/json_spec.rb
+++ b/spec/elastic_apm/spies/json_spec.rb
@@ -3,7 +3,7 @@
 module ElasticAPM
   RSpec.xdescribe 'Spy: JSON' do
     before do
-      ElasticAPM.start disabled_spies: [], disable_send: true
+      ElasticAPM.start disabled_instrumentations: [], disable_send: true
     end
 
     after do


### PR DESCRIPTION
Warns and redirects, non-breaking.

Closes elastic/apm-agent-ruby#412 