### PR TITLE
Allow non-String tag values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+- Allow non-String tag values ([#541](https://github.com/elastic/apm-agent-ruby/pull/541))
+
 ## 2.11.0 (2019-09-23)
 
 ### Added

--- a/lib/elastic_apm.rb
+++ b/lib/elastic_apm.rb
@@ -361,7 +361,7 @@ module ElasticAPM # rubocop:disable Metrics/ModuleLength
     # Set a _tag_ value for the current transaction
     #
     # @param key [String,Symbol] A key
-    # @param value [Object] A value (will be converted to string)
+    # @param value [Object] A value
     # @return [Object] The given value
     def set_tag(key, value)
       agent&.set_tag(key, value)

--- a/lib/elastic_apm/instrumenter.rb
+++ b/lib/elastic_apm/instrumenter.rb
@@ -195,7 +195,7 @@ module ElasticAPM
       return unless current_transaction
 
       key = key.to_s.gsub(/[\."\*]/, '_').to_sym
-      current_transaction.context.tags[key] = value.to_s
+      current_transaction.context.tags[key] = value
     end
 
     def set_custom_context(context)

--- a/lib/elastic_apm/transport/serializers.rb
+++ b/lib/elastic_apm/transport/serializers.rb
@@ -34,6 +34,16 @@ module ElasticAPM
             h.each { |k, v| hash[k] = keyword_field(v) }
           end
         end
+
+        def mixed_object(hash)
+          return unless hash
+
+          hash.tap do |h|
+            h.each do |k, v|
+              hash[k] = v.is_a?(String) ? keyword_field(v) : v
+            end
+          end
+        end
       end
 
       # @api private

--- a/lib/elastic_apm/transport/serializers/context_serializer.rb
+++ b/lib/elastic_apm/transport/serializers/context_serializer.rb
@@ -10,7 +10,7 @@ module ElasticAPM
 
           {
             custom: context.custom,
-            tags: keyword_object(context.tags),
+            tags: mixed_object(context.tags),
             request: build_request(context.request),
             response: build_response(context.response),
             user: build_user(context.user)

--- a/spec/elastic_apm/instrumenter_spec.rb
+++ b/spec/elastic_apm/instrumenter_spec.rb
@@ -231,6 +231,20 @@ module ElasticAPM
           thin_gs: 'are all good!'
         )
       end
+
+      it 'allows boolean values' do
+        transaction = subject.start_transaction 'Test'
+        subject.set_tag :things, true
+
+        expect(transaction.context.tags).to match(things: true)
+      end
+
+      it 'allows numerical values' do
+        transaction = subject.start_transaction 'Test'
+        subject.set_tag :things, 123
+
+        expect(transaction.context.tags).to match(things: 123)
+      end
     end
 
     describe '#set_custom_context' do

--- a/spec/elastic_apm/transport/serializers_spec.rb
+++ b/spec/elastic_apm/transport/serializers_spec.rb
@@ -57,6 +57,24 @@ module ElasticAPM
           expect(thing[:test]).to match(/X{1023}…/)
         end
       end
+
+      describe '#mixed_object' do
+        class TruncateSerializer < Serializers::Serializer
+          def serialize(obj)
+            mixed_object(obj)
+          end
+        end
+
+        it 'truncates string values to 1024 chars and leaves others unchanged' do
+          obj = { string: 'X' * 2000,
+                  bool: true,
+                  numerical: 123 }
+          thing = TruncateSerializer.new(Config.new).serialize(obj)
+          expect(thing[:string]).to match(/X{1023}…/)
+          expect(thing[:bool]).to match(true)
+          expect(thing[:numerical]).to match(123)
+        end
+      end
     end
   end
 end

--- a/spec/integration/rails_spec.rb
+++ b/spec/integration/rails_spec.rb
@@ -174,7 +174,7 @@ if defined?(Rails)
         wait_for transactions: 1, spans: 2
 
         context = @mock_intake.transactions.first['context']
-        expect(context['tags']).to eq('things' => '1')
+        expect(context['tags']).to eq('things' => 1)
         expect(context['custom']).to eq('nested' => { 'banana' => 'explosion' })
       end
 


### PR DESCRIPTION
This is a breaking change - tag values were previously always converted to a string. This PR allows non-String tag values, while still truncating String values.