### PR TITLE
Rename set_tag to set_label

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 ### Changed
 
 - Split dot-separated `span.type` into `.type`, `.subtype` and `.action` (auto-upgrades dot style) ([#531](https://github.com/elastic/apm-agent-ruby/pull/531))
+- Rename `set_tag` to `set_label` and deprecate `set_tag` ([#543](https://github.com/elastic/apm-agent-ruby/pull/543))
 
 ## 2.10.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 ### Changed
 
 - `disabled_spies` renamed to `disabled_instrumentations` with fallback ([#539](https://github.com/elastic/apm-agent-ruby/pull/539))
+- Rename `set_tag` to `set_label` and deprecate `set_tag` ([#543](https://github.com/elastic/apm-agent-ruby/pull/543))
+- Allow non-String label values ([#543](https://github.com/elastic/apm-agent-ruby/pull/543))
 
 ### Fixed
 
@@ -24,8 +26,6 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 ### Changed
 
 - Split dot-separated `span.type` into `.type`, `.subtype` and `.action` (auto-upgrades dot style) ([#531](https://github.com/elastic/apm-agent-ruby/pull/531))
-- Rename `set_tag` to `set_label` ([#543](https://github.com/elastic/apm-agent-ruby/pull/543))
-- Allow non-String label values ([#543](https://github.com/elastic/apm-agent-ruby/pull/543))
 
 ### Deprecated
 - Deprecate `set_tag` ([#543](https://github.com/elastic/apm-agent-ruby/pull/543))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,10 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 ### Changed
 
 - Split dot-separated `span.type` into `.type`, `.subtype` and `.action` (auto-upgrades dot style) ([#531](https://github.com/elastic/apm-agent-ruby/pull/531))
-- Rename `set_tag` to `set_label` and deprecate `set_tag` ([#543](https://github.com/elastic/apm-agent-ruby/pull/543))
+- Rename `set_tag` to `set_label` ([#543](https://github.com/elastic/apm-agent-ruby/pull/543))
+
+### Deprecated
+- Deprecate `set_tag` ([#543](https://github.com/elastic/apm-agent-ruby/pull/543))
 
 ## 2.10.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 
 - Handles a case where stacktrace frames are empty ([#538](https://github.com/elastic/apm-agent-ruby/pull/538))
 
+### Deprecated
+- Deprecate `set_tag` ([#543](https://github.com/elastic/apm-agent-ruby/pull/543))
+
 ## 2.11.0 (2019-09-23)
 
 ### Added
@@ -26,9 +29,6 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 ### Changed
 
 - Split dot-separated `span.type` into `.type`, `.subtype` and `.action` (auto-upgrades dot style) ([#531](https://github.com/elastic/apm-agent-ruby/pull/531))
-
-### Deprecated
-- Deprecate `set_tag` ([#543](https://github.com/elastic/apm-agent-ruby/pull/543))
 
 ## 2.10.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 
 - Split dot-separated `span.type` into `.type`, `.subtype` and `.action` (auto-upgrades dot style) ([#531](https://github.com/elastic/apm-agent-ruby/pull/531))
 - Rename `set_tag` to `set_label` ([#543](https://github.com/elastic/apm-agent-ruby/pull/543))
+- Allow non-String label values ([#543](https://github.com/elastic/apm-agent-ruby/pull/543))
 
 ### Deprecated
 - Deprecate `set_tag` ([#543](https://github.com/elastic/apm-agent-ruby/pull/543))

--- a/docs/api.asciidoc
+++ b/docs/api.asciidoc
@@ -260,7 +260,7 @@ Returns `[String]` ID of the generated `[ElasticAPM::Error]` object.
 
 Add a tag to the current transaction.
 Tags are basic key-value pairs that are indexed in your Elasticsearch database
-and therefore searchable.
+and therefore searchable. The value will always be converted to a String.
 
 TIP: Before using custom tags, ensure you understand the different types of
 {apm-overview-ref-v}/metadata.html[metadata] that are available.
@@ -280,6 +280,36 @@ Arguments:
 Returns the set `value`.
 
 WARNING: Be aware that tags are indexed in Elasticsearch. Using too many unique keys will result in *https://www.elastic.co/blog/found-crash-elasticsearch#mapping-explosion[Mapping explosion]*.
+
+NOTE: This method has been deprecated in favor of `set_label`, which does not convert values to Strings.
+
+[float]
+[[api-agent-set-label]]
+==== `ElasticAPM.set_label`
+
+Add a label to the current transaction.
+Labels are equivalent to what were previously called `tags`. They are basic key-value pairs that
+are indexed in your Elasticsearch database and therefore searchable.
+The value can be any type and will not be converted to Strings.
+
+TIP: Before using custom labels, ensure you understand the different types of
+{apm-overview-ref-v}/metadata.html[metadata] that are available.
+
+[source,ruby]
+----
+before_action do
+  ElasticAPM.set_label(:company_id, current_user.company.id)
+end
+----
+
+Arguments:
+
+  * `key`: A string key. Note that `.`, `*` or `"` will be converted to `_`.
+  * `value`: A value.
+
+Returns the set `value`.
+
+WARNING: Be aware that labels are indexed in Elasticsearch. Using too many unique keys will result in *https://www.elastic.co/blog/found-crash-elasticsearch#mapping-explosion[Mapping explosion]*.
 
 [float]
 [[api-agent-set-custom-context]]

--- a/docs/api.asciidoc
+++ b/docs/api.asciidoc
@@ -289,7 +289,7 @@ NOTE: This method has been deprecated in favor of `set_label`, which does not co
 
 Add a label to the current transaction.
 Labels are basic key-value pairs that are indexed in your Elasticsearch database and therefore searchable.
-The value can be any type and will not be converted to Strings.
+The value can be a string, nil, numeric or boolean.
 
 TIP: Before using custom labels, ensure you understand the different types of
 {apm-overview-ref-v}/metadata.html[metadata] that are available.

--- a/docs/api.asciidoc
+++ b/docs/api.asciidoc
@@ -288,8 +288,7 @@ NOTE: This method has been deprecated in favor of `set_label`, which does not co
 ==== `ElasticAPM.set_label`
 
 Add a label to the current transaction.
-Labels are equivalent to what were previously called `tags`. They are basic key-value pairs that
-are indexed in your Elasticsearch database and therefore searchable.
+Labels are basic key-value pairs that are indexed in your Elasticsearch database and therefore searchable.
 The value can be any type and will not be converted to Strings.
 
 TIP: Before using custom labels, ensure you understand the different types of

--- a/docs/configuration.asciidoc
+++ b/docs/configuration.asciidoc
@@ -255,8 +255,7 @@ Eg. `ELASTIC_APM_CUSTOM_KEY_FILTERS="a,b" # => [/a/, /b/]`
 | `ELASTIC_APM_DEFAULT_LABELS` | `default_labels` | `{}`    | `region=us1`
 |============
 
-Add default labels to every transaction. Note that this is equivalent to the default tags option but that it
-will also eventually be deprecated in favor of `global_labels`.
+Add default labels to every transaction. Note that this will eventually be deprecated in favor of `global_labels`.
 
 WARNING: Be aware that labels are indexed in Elasticsearch. Using too many unique keys will result in *https://www.elastic.co/blog/found-crash-elasticsearch#mapping-explosion[Mapping explosion]*.
 
@@ -270,8 +269,7 @@ that are set will override `global_labels`.
 | `ELASTIC_APM_DEFAULT_TAGS` | `default_tags` | `{}`    | `region=us1`
 |============
 
-Add default tags to add to every transaction. Note that this is equivalent to the default labels option but that it
-will also eventually be deprecated in favor of `global_labels`.
+Add default tags to add to every transaction. Note that this option has been deprecated in favor of `default_labels`.
 
 WARNING: Be aware that tags are indexed in Elasticsearch. Using too many unique keys will result in *https://www.elastic.co/blog/found-crash-elasticsearch#mapping-explosion[Mapping explosion]*.
 

--- a/docs/configuration.asciidoc
+++ b/docs/configuration.asciidoc
@@ -251,15 +251,31 @@ Eg. `ELASTIC_APM_CUSTOM_KEY_FILTERS="a,b" # => [/a/, /b/]`
 
 [options="header"]
 |============
+| Environment                  | `Config` key     | Default | Example
+| `ELASTIC_APM_DEFAULT_LABELS` | `default_labels` | `{}`    | `region=us1`
+|============
+
+Add default labels to every transaction. Note that this is equivalent to the default tags option but that it
+will also eventually be deprecated in favor of `global_labels`.
+
+WARNING: Be aware that labels are indexed in Elasticsearch. Using too many unique keys will result in *https://www.elastic.co/blog/found-crash-elasticsearch#mapping-explosion[Mapping explosion]*.
+
+NOTE: `global_labels` are supported as of APM server version 7.2. `default_tags` and `default_labels` will eventually be
+deprecated so please transition to using `global_labels` instead. In the meantime, any `default_labels`
+that are set will override `global_labels`.
+
+[options="header"]
+|============
 | Environment                | `Config` key   | Default | Example
 | `ELASTIC_APM_DEFAULT_TAGS` | `default_tags` | `{}`    | `region=us1`
 |============
 
-Add default tags to add to every transaction.
+Add default tags to add to every transaction. Note that this is equivalent to the default labels option but that it
+will also eventually be deprecated in favor of `global_labels`.
 
 WARNING: Be aware that tags are indexed in Elasticsearch. Using too many unique keys will result in *https://www.elastic.co/blog/found-crash-elasticsearch#mapping-explosion[Mapping explosion]*.
 
-NOTE: `global_labels` are supported as of APM server version 7.2. `default_tags` will eventually be
+NOTE: `global_labels` are supported as of APM server version 7.2. `default_tags` and `default_labels` will eventually be
 deprecated so please transition to using `global_labels` instead. In the meantime, any `default_tags`
 that are set will override `global_labels`.
 

--- a/lib/elastic_apm.rb
+++ b/lib/elastic_apm.rb
@@ -363,6 +363,7 @@ module ElasticAPM # rubocop:disable Metrics/ModuleLength
     # @param key [String,Symbol] A key
     # @param value [Object] A value (will be converted to string)
     # @return [Object] The given value
+    # @deprecated See `set_label` instead
     def set_tag(key, value)
       agent&.set_label(key, value)
     end

--- a/lib/elastic_apm.rb
+++ b/lib/elastic_apm.rb
@@ -66,7 +66,8 @@ module ElasticAPM # rubocop:disable Metrics/ModuleLength
     # Get a formatted string containing transaction, span, and trace ids.
     # If a block is provided, the ids are yielded.
     #
-    # @yield [String|nil, String|nil, String|nil] The transaction, span, and trace ids.
+    # @yield [String|nil, String|nil, String|nil] The transaction, span,
+    # and trace ids.
     # @return [String] Unless block given
     def log_ids
       trace_id = (current_transaction || current_span)&.trace_id
@@ -376,7 +377,16 @@ module ElasticAPM # rubocop:disable Metrics/ModuleLength
     # @param value [Object] A value
     # @return [Object] The given value
     def set_label(key, value)
-      agent&.set_label(key, value)
+      case value
+      when TrueClass,
+           FalseClass,
+           Numeric,
+           NilClass,
+           String
+        agent&.set_label(key, value)
+      else
+        agent&.set_label(key, value.to_s)
+      end
     end
 
     # Provide further context for the current transaction

--- a/lib/elastic_apm.rb
+++ b/lib/elastic_apm.rb
@@ -365,7 +365,7 @@ module ElasticAPM # rubocop:disable Metrics/ModuleLength
     # @return [Object] The given value
     # @deprecated See `set_label` instead
     def set_tag(key, value)
-      agent&.set_label(key, value)
+      set_label(key, value.to_s)
     end
 
     deprecate :set_tag, :set_label

--- a/lib/elastic_apm.rb
+++ b/lib/elastic_apm.rb
@@ -364,7 +364,18 @@ module ElasticAPM # rubocop:disable Metrics/ModuleLength
     # @param value [Object] A value (will be converted to string)
     # @return [Object] The given value
     def set_tag(key, value)
-      agent&.set_tag(key, value)
+      agent&.set_label(key, value)
+    end
+
+    deprecate :set_tag, :set_label
+
+    # Set a _label_ value for the current transaction
+    #
+    # @param key [String,Symbol] A key
+    # @param value [Object] A value
+    # @return [Object] The given value
+    def set_label(key, value)
+      agent&.set_label(key, value)
     end
 
     # Provide further context for the current transaction

--- a/lib/elastic_apm/agent.rb
+++ b/lib/elastic_apm/agent.rb
@@ -185,8 +185,8 @@ module ElasticAPM
       instrumenter.end_span
     end
 
-    def set_tag(key, value)
-      instrumenter.set_tag(key, value)
+    def set_label(key, value)
+      instrumenter.set_label(key, value)
     end
 
     def set_custom_context(context)

--- a/lib/elastic_apm/config.rb
+++ b/lib/elastic_apm/config.rb
@@ -239,9 +239,14 @@ module ElasticAPM
     deprecate :enabled_spies, :enabled_instrumentations
     deprecate :available_spies, :available_instrumentations
 
-    def default_labels
-      default_tags.merge(@options[:default_labels].value)
+    # DEPRECATED
+
+    def default_tags=(tags)
+      super
+      send(:default_labels=, tags)
     end
+
+    deprecate :default_tags=, :default_labels=
 
     private
 

--- a/lib/elastic_apm/config.rb
+++ b/lib/elastic_apm/config.rb
@@ -239,11 +239,25 @@ module ElasticAPM
     deprecate :enabled_spies, :enabled_instrumentations
     deprecate :available_spies, :available_instrumentations
 
+    LABELS_AND_TAGS_CONFLICT = 'You have both \'default_labels\' and ' \
+      '\'default_tags\' set. \'default_tags\' has been deprecated in favor '\
+      'of \'default_labels. Please consider upgrading.'.freeze
+
+    def default_labels=(labels)
+      @options[:default_tags].value.empty? || (raise LABELS_AND_TAGS_CONFLICT)
+      super
+    end
+
     # DEPRECATED
 
     def default_tags=(tags)
+      @options[:default_labels].value.empty? || (raise LABELS_AND_TAGS_CONFLICT)
       super
-      send(:default_labels=, tags)
+      @options[:default_labels].set(tags)
+    end
+
+    def default_tags
+      default_labels
     end
 
     deprecate :default_tags=, :default_labels=

--- a/lib/elastic_apm/config.rb
+++ b/lib/elastic_apm/config.rb
@@ -241,7 +241,7 @@ module ElasticAPM
 
     LABELS_AND_TAGS_CONFLICT = 'You have both \'default_labels\' and ' \
       '\'default_tags\' set. \'default_tags\' has been deprecated in favor '\
-      'of \'default_labels. Please consider upgrading.'.freeze
+      'of \'default_labels\'. Please consider upgrading.'.freeze
 
     def default_labels=(labels)
       @options[:default_tags].value.empty? || (raise LABELS_AND_TAGS_CONFLICT)

--- a/lib/elastic_apm/config.rb
+++ b/lib/elastic_apm/config.rb
@@ -48,6 +48,7 @@ module ElasticAPM
     option :current_user_username_method,      type: :string, default: 'username'
     option :custom_key_filters,                type: :list,   default: [],      converter: RegexpList.new
     option :default_tags,                      type: :dict,   default: {}
+    option :default_labels,                    type: :dict,   default: {}
     option :disable_send,                      type: :bool,   default: false
     option :disable_start_message,             type: :bool,   default: false
     option :disabled_instrumentations,         type: :list,   default: %w[json]
@@ -237,6 +238,10 @@ module ElasticAPM
     deprecate :disabled_spies, :disabled_instrumentations
     deprecate :enabled_spies, :enabled_instrumentations
     deprecate :available_spies, :available_instrumentations
+
+    def default_labels
+      default_tags.merge(@options[:default_labels].value)
+    end
 
     private
 

--- a/lib/elastic_apm/context.rb
+++ b/lib/elastic_apm/context.rb
@@ -9,9 +9,9 @@ require 'elastic_apm/context/user'
 module ElasticAPM
   # @api private
   class Context
-    def initialize(custom: {}, tags: {}, user: nil)
+    def initialize(custom: {}, labels: {}, user: nil)
       @custom = custom
-      @tags = tags
+      @labels = labels
       @user = user || User.new
     end
 
@@ -19,10 +19,10 @@ module ElasticAPM
     attr_accessor :response
     attr_accessor :user
     attr_reader :custom
-    attr_reader :tags
+    attr_reader :labels
 
     def empty?
-      return false if tags.any?
+      return false if labels.any?
       return false if custom.any?
       return false if user.any?
       return false if request || response

--- a/lib/elastic_apm/error_builder.rb
+++ b/lib/elastic_apm/error_builder.rb
@@ -11,7 +11,7 @@ module ElasticAPM
       error = Error.new context: context || Context.new
       error.exception = Error::Exception.new(exception, handled: handled)
 
-      Util.reverse_merge!(error.context.tags, @agent.config.default_tags)
+      Util.reverse_merge!(error.context.labels, @agent.config.default_labels)
 
       if exception.backtrace
         add_stacktrace error, :exception, exception.backtrace
@@ -66,7 +66,7 @@ module ElasticAPM
 
       return unless transaction.context
 
-      Util.reverse_merge!(error.context.tags, transaction.context.tags)
+      Util.reverse_merge!(error.context.labels, transaction.context.labels)
       Util.reverse_merge!(error.context.custom, transaction.context.custom)
     end
     # rubocop:enable Metrics/MethodLength, Metrics/AbcSize

--- a/lib/elastic_apm/instrumenter.rb
+++ b/lib/elastic_apm/instrumenter.rb
@@ -195,7 +195,7 @@ module ElasticAPM
       return unless current_transaction
 
       key = key.to_s.gsub(/[\."\*]/, '_').to_sym
-      current_transaction.context.labels[key] = value.to_s
+      current_transaction.context.labels[key] = value
     end
 
     def set_custom_context(context)

--- a/lib/elastic_apm/instrumenter.rb
+++ b/lib/elastic_apm/instrumenter.rb
@@ -101,7 +101,7 @@ module ElasticAPM
           context: context,
           trace_context: trace_context,
           sampled: sampled,
-          tags: config.default_tags
+          labels: config.default_labels
         )
 
       transaction.start
@@ -191,11 +191,11 @@ module ElasticAPM
 
     # metadata
 
-    def set_tag(key, value)
+    def set_label(key, value)
       return unless current_transaction
 
       key = key.to_s.gsub(/[\."\*]/, '_').to_sym
-      current_transaction.context.tags[key] = value.to_s
+      current_transaction.context.labels[key] = value.to_s
     end
 
     def set_custom_context(context)

--- a/lib/elastic_apm/metrics.rb
+++ b/lib/elastic_apm/metrics.rb
@@ -21,9 +21,9 @@ module ElasticAPM
 
       TIMEOUT_INTERVAL = 5 # seconds
 
-      def initialize(config, tags: nil, &block)
+      def initialize(config, labels: nil, &block)
         @config = config
-        @tags = tags
+        @labels = labels
         @samplers = [CpuMem, VM].map do |kls|
           debug "Adding metrics collector '#{kls}'"
           kls.new(config)
@@ -31,7 +31,7 @@ module ElasticAPM
         @callback = block
       end
 
-      attr_reader :config, :samplers, :callback, :tags
+      attr_reader :config, :samplers, :callback, :labels
 
       # rubocop:disable Metrics/MethodLength
       def start
@@ -76,7 +76,7 @@ module ElasticAPM
       end
 
       def collect_and_send
-        metricset = Metricset.new(tags: tags, **collect)
+        metricset = Metricset.new(labels: labels, **collect)
         return if metricset.empty?
 
         callback.call(metricset)

--- a/lib/elastic_apm/metricset.rb
+++ b/lib/elastic_apm/metricset.rb
@@ -3,14 +3,14 @@
 module ElasticAPM
   # @api private
   class Metricset
-    def initialize(timestamp: Util.micros, tags: nil, **samples)
+    def initialize(timestamp: Util.micros, labels: nil, **samples)
       @timestamp = timestamp
-      @tags = tags
+      @labels = labels
       @samples = samples
     end
 
     attr_accessor :timestamp
-    attr_reader :samples, :tags
+    attr_reader :samples, :labels
 
     def empty?
       samples.empty?

--- a/lib/elastic_apm/opentracing.rb
+++ b/lib/elastic_apm/opentracing.rb
@@ -191,7 +191,6 @@ module ElasticAPM
         child_of: nil,
         references: nil,
         start_time: Time.now,
-        tags: {},
         labels: {},
         ignore_active_scope: false,
         finish_on_close: true,
@@ -202,7 +201,7 @@ module ElasticAPM
           child_of: child_of,
           references: references,
           start_time: start_time,
-          labels: tags.merge(labels),
+          labels: labels,
           ignore_active_scope: ignore_active_scope
         )
         scope = scope_manager.activate(span, finish_on_close: finish_on_close)

--- a/lib/elastic_apm/opentracing.rb
+++ b/lib/elastic_apm/opentracing.rb
@@ -23,7 +23,7 @@ module ElasticAPM
       end
 
       # rubocop:disable Metrics/MethodLength
-      def set_tag(key, val)
+      def set_label(key, val)
         if elastic_span.is_a?(Transaction)
           case key.to_s
           when 'type'
@@ -33,10 +33,10 @@ module ElasticAPM
           when /user\.(\w+)/
             set_user_value($1, val)
           else
-            elastic_span.context.tags[key] = val
+            elastic_span.context.labels[key] = val
           end
         else
-          elastic_span.context.tags[key] = val
+          elastic_span.context.labels[key] = val
         end
       end
       # rubocop:enable Metrics/MethodLength
@@ -192,6 +192,7 @@ module ElasticAPM
         references: nil,
         start_time: Time.now,
         tags: {},
+        labels: {},
         ignore_active_scope: false,
         finish_on_close: true,
         **
@@ -201,7 +202,7 @@ module ElasticAPM
           child_of: child_of,
           references: references,
           start_time: start_time,
-          tags: tags,
+          labels: tags.merge(labels),
           ignore_active_scope: ignore_active_scope
         )
         scope = scope_manager.activate(span, finish_on_close: finish_on_close)
@@ -225,7 +226,7 @@ module ElasticAPM
         child_of: nil,
         references: nil,
         start_time: Time.now,
-        tags: {},
+        labels: {},
         ignore_active_scope: false,
         **
       )
@@ -263,8 +264,8 @@ module ElasticAPM
         span_context ||=
           SpanContext.from_trace_context(elastic_span.trace_context)
 
-        tags.each do |key, value|
-          elastic_span.context.tags[key] = value
+        labels.each do |key, value|
+          elastic_span.context.labels[key] = value
         end
 
         elastic_span.start Util.micros(start_time)

--- a/lib/elastic_apm/span/context.rb
+++ b/lib/elastic_apm/span/context.rb
@@ -4,14 +4,14 @@ module ElasticAPM
   class Span
     # @api private
     class Context
-      def initialize(db: nil, http: nil, tags: {})
+      def initialize(db: nil, http: nil, labels: {})
         @sync = true
         @db = db && Db.new(db)
         @http = http && Http.new(http)
-        @tags = tags
+        @labels = labels
       end
 
-      attr_accessor :sync, :db, :http, :tags
+      attr_accessor :sync, :db, :http, :labels
 
       # @api private
       class Db

--- a/lib/elastic_apm/spies/sidekiq.rb
+++ b/lib/elastic_apm/spies/sidekiq.rb
@@ -14,7 +14,7 @@ module ElasticAPM
         def call(_worker, job, queue)
           name = SidekiqSpy.name_for(job)
           transaction = ElasticAPM.start_transaction(name, 'Sidekiq')
-          ElasticAPM.set_tag(:queue, queue)
+          ElasticAPM.set_label(:queue, queue)
 
           yield
 

--- a/lib/elastic_apm/spies/sidekiq.rb
+++ b/lib/elastic_apm/spies/sidekiq.rb
@@ -14,7 +14,8 @@ module ElasticAPM
         def call(_worker, job, queue)
           name = SidekiqSpy.name_for(job)
           transaction = ElasticAPM.start_transaction(name, 'Sidekiq')
-          ElasticAPM.set_label(:queue, queue)
+          # TODO: Remove #to_s when #set_tag is removed in v3.0
+          ElasticAPM.set_label(:queue, queue.to_s)
 
           yield
 

--- a/lib/elastic_apm/transaction.rb
+++ b/lib/elastic_apm/transaction.rb
@@ -20,7 +20,7 @@ module ElasticAPM
       type = nil,
       sampled: true,
       context: nil,
-      tags: nil,
+      labels: nil,
       trace_context: nil
     )
       @name = name
@@ -29,7 +29,7 @@ module ElasticAPM
       @sampled = sampled
 
       @context = context || Context.new # TODO: Lazy generate this?
-      Util.reverse_merge!(@context.tags, tags) if tags
+      Util.reverse_merge!(@context.labels, labels) if labels
 
       @trace_context = trace_context || TraceContext.new(recorded: sampled)
 

--- a/lib/elastic_apm/transport/serializers.rb
+++ b/lib/elastic_apm/transport/serializers.rb
@@ -34,6 +34,16 @@ module ElasticAPM
             h.each { |k, v| hash[k] = keyword_field(v) }
           end
         end
+
+        def mixed_object(hash)
+          return unless hash
+
+          hash.tap do |h|
+            h.each do |k, v|
+              hash[k] = v.is_a?(String) ? keyword_field(v) : v
+            end
+          end
+        end
       end
 
       # @api private

--- a/lib/elastic_apm/transport/serializers/context_serializer.rb
+++ b/lib/elastic_apm/transport/serializers/context_serializer.rb
@@ -10,7 +10,7 @@ module ElasticAPM
 
           {
             custom: context.custom,
-            tags: keyword_object(context.tags),
+            tags: keyword_object(context.labels),
             request: build_request(context.request),
             response: build_response(context.response),
             user: build_user(context.user)

--- a/lib/elastic_apm/transport/serializers/context_serializer.rb
+++ b/lib/elastic_apm/transport/serializers/context_serializer.rb
@@ -10,7 +10,7 @@ module ElasticAPM
 
           {
             custom: context.custom,
-            tags: keyword_object(context.labels),
+            tags: mixed_object(context.labels),
             request: build_request(context.request),
             response: build_response(context.response),
             user: build_user(context.user)

--- a/lib/elastic_apm/transport/serializers/metricset_serializer.rb
+++ b/lib/elastic_apm/transport/serializers/metricset_serializer.rb
@@ -9,7 +9,7 @@ module ElasticAPM
           {
             metricset: {
               timestamp: metricset.timestamp.to_i,
-              tags: keyword_object(metricset.tags),
+              tags: keyword_object(metricset.labels),
               samples: build_samples(metricset.samples)
             }
           }

--- a/spec/elastic_apm/agent_spec.rb
+++ b/spec/elastic_apm/agent_spec.rb
@@ -82,7 +82,7 @@ module ElasticAPM
             }
           ],
           end_span: nil,
-          set_tag: [nil, nil],
+          set_label: [nil, nil],
           set_custom_context: [nil],
           set_user: [nil]
         }.each do |name, args|

--- a/spec/elastic_apm/config_spec.rb
+++ b/spec/elastic_apm/config_spec.rb
@@ -30,11 +30,10 @@ module ElasticAPM
       end
     end
 
-    it 'merges ELASTIC_APM_DEFAULT_TAGS and ELASTIC_APM_DEFAULT_LABELS' do
+    it 'favors ELASTIC_APM_DEFAULT_LABELS over ELASTIC_APM_DEFAULT_TAGS' do
       with_env('ELASTIC_APM_DEFAULT_TAGS' => 'wave=something',
                'ELASTIC_APM_DEFAULT_LABELS' => 'brother=ok') do
-        expect(Config.new.default_labels).to eq('wave' => 'something',
-                                                'brother' => 'ok')
+        expect(Config.new.default_labels).to eq('brother' => 'ok')
       end
     end
 
@@ -174,11 +173,19 @@ module ElasticAPM
       end
     end
 
-    context 'default tags and label set' do
+    context 'default tags and labels set' do
       let(:config) { Config.new(default_tags: { tags: 1 }, default_labels: { labels: 2 }) }
 
-      it 'merges the tags and labels' do
-        expect(config.default_labels).to eq(tags: 1, labels: 2)
+      it 'favors the default labels' do
+        expect(config.default_labels).to eq(labels: 2)
+      end
+    end
+
+    context 'default tags set' do
+      let(:config) { Config.new(default_tags: { tags: 1 }) }
+
+      it 'sets the default labels' do
+        expect(config.default_labels).to eq(tags: 1)
       end
     end
 

--- a/spec/elastic_apm/config_spec.rb
+++ b/spec/elastic_apm/config_spec.rb
@@ -30,6 +30,14 @@ module ElasticAPM
       end
     end
 
+    it 'merges ELASTIC_APM_DEFAULT_TAGS and ELASTIC_APM_DEFAULT_LABELS' do
+      with_env('ELASTIC_APM_DEFAULT_TAGS' => 'wave=something',
+               'ELASTIC_APM_DEFAULT_LABELS' => 'brother=ok') do
+        expect(Config.new.default_labels).to eq('wave' => 'something',
+                                                'brother' => 'ok')
+      end
+    end
+
     it 'converts certain env values to Ruby types' do
       [
         # [ 'NAME', 'VALUE', 'EXPECTED' ]
@@ -48,6 +56,11 @@ module ElasticAPM
           'ELASTIC_APM_DEFAULT_TAGS',
           'test=something something&other=ok',
           { 'test' => 'something something', 'other' => 'ok' }
+        ],
+        [
+          'ELASTIC_APM_DEFAULT_LABELS',
+          'wave=something erlking&brother=ok',
+          { 'wave' => 'something erlking', 'brother' => 'ok' }
         ],
         [
           'ELASTIC_APM_GLOBAL_LABELS',

--- a/spec/elastic_apm/config_spec.rb
+++ b/spec/elastic_apm/config_spec.rb
@@ -30,7 +30,7 @@ module ElasticAPM
       end
     end
 
-    it 'favors ELASTIC_APM_DEFAULT_LABELS over ELASTIC_APM_DEFAULT_TAGS' do
+    it 'sets default labels for both *_DEFAULT_LABELS and *_DEFAULT_TAGS' do
       with_env('ELASTIC_APM_DEFAULT_TAGS' => 'wave=something',
                'ELASTIC_APM_DEFAULT_LABELS' => 'brother=ok') do
         expect(Config.new.default_labels).to eq('brother' => 'ok')
@@ -174,10 +174,12 @@ module ElasticAPM
     end
 
     context 'default tags and labels set' do
-      let(:config) { Config.new(default_tags: { tags: 1 }, default_labels: { labels: 2 }) }
+      let(:config) do
+        Config.new(default_labels: { labels: 2 }, default_tags: { tags: 1 })
+      end
 
-      it 'favors the default labels' do
-        expect(config.default_labels).to eq(labels: 2)
+      it 'favors the last one set' do
+        expect(config.default_labels).to eq(tags: 1)
       end
     end
 

--- a/spec/elastic_apm/config_spec.rb
+++ b/spec/elastic_apm/config_spec.rb
@@ -30,10 +30,12 @@ module ElasticAPM
       end
     end
 
-    it 'sets default labels for both *_DEFAULT_LABELS and *_DEFAULT_TAGS' do
+    it 'raises an exception when *_DEFAULT_LABELS and *_DEFAULT_TAGS are set' do
       with_env('ELASTIC_APM_DEFAULT_TAGS' => 'wave=something',
                'ELASTIC_APM_DEFAULT_LABELS' => 'brother=ok') do
-        expect(Config.new.default_labels).to eq('brother' => 'ok')
+        expect {
+          Config.new.default_labels
+        }.to raise_exception(Exception, Config::LABELS_AND_TAGS_CONFLICT)
       end
     end
 
@@ -174,12 +176,11 @@ module ElasticAPM
     end
 
     context 'default tags and labels set' do
-      let(:config) do
-        Config.new(default_labels: { labels: 2 }, default_tags: { tags: 1 })
-      end
-
-      it 'favors the last one set' do
-        expect(config.default_labels).to eq(tags: 1)
+      it 'raises an exception' do
+        expect {
+          Config.new(default_labels: { labels: 2 },
+                     default_tags: { tags: 1 })
+        }.to raise_exception(Exception, Config::LABELS_AND_TAGS_CONFLICT)
       end
     end
 

--- a/spec/elastic_apm/config_spec.rb
+++ b/spec/elastic_apm/config_spec.rb
@@ -161,6 +161,14 @@ module ElasticAPM
       end
     end
 
+    context 'default tags and label set' do
+      let(:config) { Config.new(default_tags: { tags: 1 }, default_labels: { labels: 2 }) }
+
+      it 'merges the tags and labels' do
+        expect(config.default_labels).to eq(tags: 1, labels: 2)
+      end
+    end
+
     describe 'deprecations' do
       it 'warns about removed options' do
         expect(subject).to receive(:warn).with(/has been removed/)

--- a/spec/elastic_apm/context_spec.rb
+++ b/spec/elastic_apm/context_spec.rb
@@ -2,8 +2,8 @@
 
 module ElasticAPM
   RSpec.describe Context do
-    it 'initializes with tags and context' do
-      expect(subject.tags).to eq({})
+    it 'initializes with labels and context' do
+      expect(subject.labels).to eq({})
       expect(subject.custom).to eq({})
     end
 
@@ -13,7 +13,7 @@ module ElasticAPM
       end
 
       it "isn't when it has data" do
-        expect(Context.new(tags: { a: 1 })).to_not be_empty
+        expect(Context.new(labels: { a: 1 })).to_not be_empty
         expect(Context.new(custom: { a: 1 })).to_not be_empty
         expect(Context.new(user: { a: 1 })).to_not be_empty
         expect(Context.new.tap { |c| c.request = 1 }).to_not be_empty

--- a/spec/elastic_apm/error_builder_spec.rb
+++ b/spec/elastic_apm/error_builder_spec.rb
@@ -31,7 +31,7 @@ module ElasticAPM
               ElasticAPM.build_context rack_env: env, for_type: :transaction
 
             ElasticAPM.with_transaction context: context do |txn|
-              ElasticAPM.set_tag(:my_tag, '123')
+              ElasticAPM.set_label(:my_tag, '123')
               ElasticAPM.set_custom_context(all_the_other_things: 'blah blah')
               ElasticAPM.set_user(Struct.new(:id).new(321))
               ElasticAPM.report actual_exception

--- a/spec/elastic_apm/error_builder_spec.rb
+++ b/spec/elastic_apm/error_builder_spec.rb
@@ -44,7 +44,7 @@ module ElasticAPM
         expect(error.transaction).to eq(sampled: true, type: 'custom')
         expect(error.transaction_id).to eq transaction.id
         expect(error.trace_id).to eq transaction.trace_id
-        expect(error.context.tags).to match(my_tag: '123', more: 'totes')
+        expect(error.context.labels).to match(my_tag: '123', more: 'totes')
         expect(error.context.custom)
           .to match(all_the_other_things: 'blah blah')
       end

--- a/spec/elastic_apm/instrumenter_spec.rb
+++ b/spec/elastic_apm/instrumenter_spec.rb
@@ -221,7 +221,7 @@ module ElasticAPM
     end
 
     describe '#set_label' do
-      it 'sets tag on currenct transaction' do
+      it 'sets tag on current transaction' do
         transaction = subject.start_transaction 'Test'
         subject.set_label :things, 'are all good!'
 
@@ -239,6 +239,20 @@ module ElasticAPM
           thi_ngs: 'are all good!',
           thin_gs: 'are all good!'
         )
+      end
+
+      it 'allows boolean values' do
+        transaction = subject.start_transaction 'Test'
+        subject.set_label :things, true
+
+        expect(transaction.context.labels).to match(things: true)
+      end
+
+      it 'allows numerical values' do
+        transaction = subject.start_transaction 'Test'
+        subject.set_label :things, 123
+
+        expect(transaction.context.labels).to match(things: 123)
       end
     end
 

--- a/spec/elastic_apm/instrumenter_spec.rb
+++ b/spec/elastic_apm/instrumenter_spec.rb
@@ -235,10 +235,10 @@ module ElasticAPM
         subject.set_label 'thin*gs', 'are all good!'
 
         expect(transaction.context.labels).to match(
-                                                th_ings: 'are all good!',
-                                                thi_ngs: 'are all good!',
-                                                thin_gs: 'are all good!'
-                                            )
+          th_ings: 'are all good!',
+          thi_ngs: 'are all good!',
+          thin_gs: 'are all good!'
+        )
       end
     end
 

--- a/spec/elastic_apm/instrumenter_spec.rb
+++ b/spec/elastic_apm/instrumenter_spec.rb
@@ -80,7 +80,16 @@ module ElasticAPM
 
         it 'adds them to transaction context' do
           transaction = subject.start_transaction 'Test', 't'
-          expect(transaction.context.tags).to match(more: 'yes!')
+          expect(transaction.context.labels).to match(more: 'yes!')
+        end
+      end
+
+      context 'with default labels' do
+        let(:config) { Config.new(default_labels: { more: 'yes!' }) }
+
+        it 'adds them to transaction context' do
+          transaction = subject.start_transaction 'Test', 't'
+          expect(transaction.context.labels).to match(more: 'yes!')
         end
       end
     end
@@ -211,25 +220,25 @@ module ElasticAPM
       end
     end
 
-    describe '#set_tag' do
+    describe '#set_label' do
       it 'sets tag on currenct transaction' do
         transaction = subject.start_transaction 'Test'
-        subject.set_tag :things, 'are all good!'
+        subject.set_label :things, 'are all good!'
 
-        expect(transaction.context.tags).to match(things: 'are all good!')
+        expect(transaction.context.labels).to match(things: 'are all good!')
       end
 
       it 'de-dots keys' do
         transaction = subject.start_transaction 'Test'
-        subject.set_tag 'th.ings', 'are all good!'
-        subject.set_tag 'thi"ngs', 'are all good!'
-        subject.set_tag 'thin*gs', 'are all good!'
+        subject.set_label 'th.ings', 'are all good!'
+        subject.set_label 'thi"ngs', 'are all good!'
+        subject.set_label 'thin*gs', 'are all good!'
 
-        expect(transaction.context.tags).to match(
-          th_ings: 'are all good!',
-          thi_ngs: 'are all good!',
-          thin_gs: 'are all good!'
-        )
+        expect(transaction.context.labels).to match(
+                                                th_ings: 'are all good!',
+                                                thi_ngs: 'are all good!',
+                                                thin_gs: 'are all good!'
+                                            )
       end
     end
 

--- a/spec/elastic_apm/transaction_spec.rb
+++ b/spec/elastic_apm/transaction_spec.rb
@@ -15,11 +15,11 @@ module ElasticAPM
       its(:notifications) { should be_empty }
       its(:trace_id) { should be subject.trace_context.trace_id }
 
-      context 'with tags from context and args' do
-        it 'merges tags' do
-          context = Context.new(tags: { context: 'yes' })
-          subject = described_class.new(tags: { args: 'yes' }, context: context)
-          expect(subject.context.tags).to match(args: 'yes', context: 'yes')
+      context 'with labels from context and args' do
+        it 'merges labels' do
+          context = Context.new(labels: { context: 'yes' })
+          subject = described_class.new(labels: { args: 'yes' }, context: context)
+          expect(subject.context.labels).to match(args: 'yes', context: 'yes')
         end
       end
     end

--- a/spec/elastic_apm/transport/serializers/metricset_serializer_spec.rb
+++ b/spec/elastic_apm/transport/serializers/metricset_serializer_spec.rb
@@ -15,7 +15,7 @@ module ElasticAPM
           it 'matches' do
             expect(result[:metricset]).to be_a Hash
             expect(result[:metricset][:timestamp]).to be_an Integer
-            expect(result[:metricset][:tags]).to be_nil
+            expect(result[:metricset][:labels]).to be_nil
             expect(result[:metricset][:samples]).to be_a Hash
             expect(result[:metricset][:samples][:thing][:value]).to eq 1.0
             expect(result[:metricset][:samples][:other][:value]).to eq 321

--- a/spec/elastic_apm/transport/serializers_spec.rb
+++ b/spec/elastic_apm/transport/serializers_spec.rb
@@ -57,6 +57,24 @@ module ElasticAPM
           expect(thing[:test]).to match(/X{1023}…/)
         end
       end
+
+      describe '#mixed_object' do
+        class TruncateSerializer < Serializers::Serializer
+          def serialize(obj)
+            mixed_object(obj)
+          end
+        end
+
+        it 'truncates string values to 1024 chars and leaves others unchanged' do
+          obj = { string: 'X' * 2000,
+                  bool: true,
+                  numerical: 123 }
+          thing = TruncateSerializer.new(Config.new).serialize(obj)
+          expect(thing[:string]).to match(/X{1023}…/)
+          expect(thing[:bool]).to match(true)
+          expect(thing[:numerical]).to match(123)
+        end
+      end
     end
   end
 end

--- a/spec/elastic_apm_spec.rb
+++ b/spec/elastic_apm_spec.rb
@@ -176,7 +176,7 @@ RSpec.describe ElasticAPM do
       should delegate :report_message,
         to: agent, args: ['NOT OK', { backtrace: Array, context: nil }]
     end
-    it { should delegate :set_tag, to: agent, args: [nil, nil] }
+    it { should delegate :set_label, to: agent, args: [nil, nil] }
     it { should delegate :set_custom_context, to: agent, args: [nil] }
     it { should delegate :set_user, to: agent, args: [nil] }
 

--- a/spec/elastic_apm_spec.rb
+++ b/spec/elastic_apm_spec.rb
@@ -266,5 +266,20 @@ RSpec.describe ElasticAPM do
         end
       end
     end
+
+    describe '.set_tag' do
+      it 'redirects to set_label with string value' do
+        expect(ElasticAPM).to receive(:warn).with(/DEPRECATED/).exactly(3).times
+
+        expect(ElasticAPM).to receive(:set_label).with(:a_string, 'a')
+        ElasticAPM.set_tag(:a_string, 'a')
+
+        expect(ElasticAPM).to receive(:set_label).with(:a_number, '1')
+        ElasticAPM.set_tag(:a_number, 1)
+
+        expect(ElasticAPM).to receive(:set_label).with(:a_boolean, 'true')
+        ElasticAPM.set_tag(:a_boolean, true)
+      end
+    end
   end
 end

--- a/spec/integration/opentracing_spec.rb
+++ b/spec/integration/opentracing_spec.rb
@@ -217,7 +217,7 @@ RSpec.describe 'OpenTracing bridge', :intercept do
         end
 
         describe 'set_label' do
-          it 'sets tag' do
+          it 'sets label' do
             subject.set_label :custom_key, 'custom_type'
             expect(subject.elastic_span.context.labels[:custom_key])
               .to eq 'custom_type'

--- a/spec/integration/opentracing_spec.rb
+++ b/spec/integration/opentracing_spec.rb
@@ -152,7 +152,7 @@ RSpec.describe 'OpenTracing bridge', :intercept do
     it 'traces nested spans' do
       OpenTracing.start_active_span(
         'operation_name',
-        tags: { test: '0' }
+        labels: { test: '0' }
       ) do |scope|
         expect(scope).to be_a(ElasticAPM::OpenTracing::Scope)
         expect(OpenTracing.active_span).to be scope.span
@@ -160,7 +160,7 @@ RSpec.describe 'OpenTracing bridge', :intercept do
 
         OpenTracing.start_active_span(
           'nested',
-          tags: { test: '1' }
+          labels: { test: '1' }
         ) do |nested_scope|
           expect(OpenTracing.active_span).to_not be_nil
           expect(nested_scope.span).to eq OpenTracing.active_span
@@ -175,10 +175,10 @@ RSpec.describe 'OpenTracing bridge', :intercept do
       expect(@intercepted.spans.length).to be 2
 
       transaction, = @intercepted.transactions
-      expect(transaction.context.tags).to match(test: '0')
+      expect(transaction.context.labels).to match(test: '0')
 
       span = @intercepted.spans.last
-      expect(span.context.tags).to match(test: '1')
+      expect(span.context.labels).to match(test: '1')
     end
   end
 
@@ -207,7 +207,7 @@ RSpec.describe 'OpenTracing bridge', :intercept do
       end
     end
 
-    describe 'set_tag' do
+    describe 'set_label' do
       subject { described_class.new(elastic_span, trace_context) }
 
       shared_examples :opengraph_span do
@@ -216,10 +216,10 @@ RSpec.describe 'OpenTracing bridge', :intercept do
           expect(elastic_span.name).to eq 'Test'
         end
 
-        describe 'set_tag' do
+        describe 'set_label' do
           it 'sets tag' do
-            subject.set_tag :custom_key, 'custom_type'
-            expect(subject.elastic_span.context.tags[:custom_key])
+            subject.set_label :custom_key, 'custom_type'
+            expect(subject.elastic_span.context.labels[:custom_key])
               .to eq 'custom_type'
           end
         end
@@ -232,10 +232,10 @@ RSpec.describe 'OpenTracing bridge', :intercept do
         it_behaves_like :opengraph_span
 
         it 'knows user fields' do
-          subject.set_tag 'user.id', 1
-          subject.set_tag 'user.username', 'someone'
-          subject.set_tag 'user.email', 'someone@example.com'
-          subject.set_tag 'user.other_field', 'someone@example.com'
+          subject.set_label 'user.id', 1
+          subject.set_label 'user.username', 'someone'
+          subject.set_label 'user.email', 'someone@example.com'
+          subject.set_label 'user.other_field', 'someone@example.com'
 
           user = subject.elastic_span.context.user
           expect(user.id).to eq 1
@@ -255,7 +255,7 @@ RSpec.describe 'OpenTracing bridge', :intercept do
         it_behaves_like :opengraph_span
 
         it "doesn't explode on user fields" do
-          expect { subject.set_tag 'user.id', 1 }
+          expect { subject.set_label 'user.id', 1 }
             .to_not raise_error
         end
       end


### PR DESCRIPTION
Changes included in this PR:

- Add method `set_label` on `ElasticAPM` and deprecate `set_tag` with a warning
- Add ENV option `ELASTIC_APM_DEFAULT_LABELS` and deprecate `ELASTIC_APM_DEFAULT_TAGS`
- Add config option `default_labels`
- Override `default_tags` method to set `default_labels` internally. 
- Rename all `set_tag` private methods to `set_label`
- Rename all object attributes `tags` to `labels`
- Continue to serialize a context with a `tags` key but the value is its `labels` attribute.
- Raise an exception if both `default_labels` and `default_tags` are set in the config.

Close #466

Update: 
Merged in PR #541 to this one. It allows non-String values to be passed to `set_label` but preserves the behavior of `set_tag`.