### PR TITLE
Add example grok for trace IDs to log correlation docs

### DIFF
--- a/docs/log-correlation.asciidoc
+++ b/docs/log-correlation.asciidoc
@@ -94,3 +94,27 @@ end
 # [2019-09-16 11:54:59 +0200][RailsTestApp][INFO][transaction.id=3b92edcccc0a6d1e span.id=f3d7e32f176d4c93 trace.id=1275686e35de91f776557637e799651e]   Rendered text template (Duration: 0.1ms | Allocations: 17)
 # [2019-09-16 11:54:59 +0200][RailsTestApp][INFO][transaction.id=3b92edcccc0a6d1e span.id=3bde4e9c85ab359c trace.id=1275686e35de91f776557637e799651e] Completed 200 OK in 1ms (Views: 0.3ms | Allocations: 187)
 ----
+
+==== Extracting trace IDs from the logs
+
+For log correlation to work, the trace IDs must be extracted from the log message and stored in separate fields in the Elasticsearch document. There are many ways to achieve this, for example by using ingest node and defining a pipeline with a grok processor.
+For example, you can extract the trace id from the Lograge output generated above like this:
+
+[source,json]
+----
+PUT _ingest/pipeline/extract_trace_id
+{
+  "description": "Extract trace id from Lograge logs",
+  "processors": [
+    {
+      "grok": {
+        "field": "message",
+        "patterns": ["%{TIME}.*\\| [A-Z]\\, \\[%{TIMESTAMP_ISO8601}.*\\]  %{LOGLEVEL:log.level} [-]{2} \\: \\[[0-9A-Fa-f\\-]{36}\\] \\{.*\\\"trace\\.id\\\"\\:\\\"%{TRACE_ID:trace.id}.*\\}"],
+        "pattern_definitions": { "TRACE_ID": "[0-9A-Fa-f]{32}" }
+      }
+    }
+  ]
+}
+----
+
+Please see this documentation for more information.

--- a/docs/log-correlation.asciidoc
+++ b/docs/log-correlation.asciidoc
@@ -117,4 +117,4 @@ PUT _ingest/pipeline/extract_trace_id
 }
 ----
 
-Please see this documentation for more information.
+Please see {apm-overview-ref-v}/observability-integrations.html[Observability integrations] for more information.

--- a/docs/log-correlation.asciidoc
+++ b/docs/log-correlation.asciidoc
@@ -98,7 +98,7 @@ end
 ==== Extracting trace IDs from the logs
 
 For log correlation to work, the trace IDs must be extracted from the log message and stored in separate fields in the Elasticsearch document. There are many ways to achieve this, for example by using ingest node and defining a pipeline with a grok processor.
-For example, you can extract the trace id from the Lograge output generated above like this:
+You can extract the trace id from the Lograge output generated above like this:
 
 [source,json]
 ----

--- a/docs/log-correlation.asciidoc
+++ b/docs/log-correlation.asciidoc
@@ -95,6 +95,7 @@ end
 # [2019-09-16 11:54:59 +0200][RailsTestApp][INFO][transaction.id=3b92edcccc0a6d1e span.id=3bde4e9c85ab359c trace.id=1275686e35de91f776557637e799651e] Completed 200 OK in 1ms (Views: 0.3ms | Allocations: 187)
 ----
 
+[float]
 ==== Extracting trace IDs from the logs
 
 For log correlation to work, the trace IDs must be extracted from the log message and stored in separate fields in the Elasticsearch document. There are many ways to achieve this, for example by using ingest node and defining a pipeline with a grok processor.


### PR DESCRIPTION
This PR adds a section about extracting trace IDs from the logs so that log correlation can work. It provides an example grok pipeline processor.

@bmorelli25 Would you mind looking at this? 
Can you also tell me if the documentation added [here](https://github.com/elastic/apm-server/pull/2672/files) is live yet and how I can link to it? I want to add a link to the last sentence (`Please see this documentation for more information.`)