### PR TITLE
ci(jenkins): Reduce number of requested workers

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -47,7 +47,6 @@ pipeline {
     Checkout the code and stash it, to use it on other stages.
     */
     stage('Checkout') {
-      agent { label 'immutable' }
       options { skipDefaultCheckout() }
       steps {
         deleteDir()
@@ -56,7 +55,6 @@ pipeline {
       }
     }
     stage('Sanity checks') {
-      agent { label 'linux && immutable && docker' }
       when {
         beforeAgent true
         anyOf {
@@ -85,7 +83,6 @@ pipeline {
     Execute unit tests.
     */
     stage('Test') {
-      agent { label 'linux && immutable' }
       options { skipDefaultCheckout() }
       steps {
         withGithubNotify(context: 'Tests', tab: 'tests') {

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -55,6 +55,13 @@ pipeline {
       }
     }
     stage('Sanity checks') {
+      when {
+        beforeAgent true
+        anyOf {
+          not { changeRequest() }
+          expression { return params.Run_As_Master_Branch }
+        }
+      }
       options { skipDefaultCheckout() }
       environment {
         HOME = "${env.WORKSPACE}"
@@ -96,6 +103,19 @@ pipeline {
       }
       stage('Benchmarks') {
         options { skipDefaultCheckout() }
+        when {
+          beforeAgent true
+          allOf {
+            anyOf {
+              branch 'master'
+              branch "\\d+\\.\\d+"
+              branch "v\\d?"
+              tag "v\\d+\\.\\d+\\.\\d+*"
+              expression { return params.Run_As_Master_Branch }
+            }
+            expression { return params.bench_ci }
+          }
+        }
         stages {
           stage('Clean Workspace') {
             agent { label 'metal' }
@@ -160,6 +180,12 @@ pipeline {
         environment {
           RUBY_DOCKER_TAG = 'ruby:2.6'
         }
+        when {
+          beforeAgent true
+          anyOf {
+            tag pattern: 'v\\d+.*', comparator: 'REGEXP'
+          }
+        }
         steps {
           withGithubNotify(context: 'Release') {
             deleteDir()
@@ -172,8 +198,7 @@ pipeline {
                       sshagent(['f6c7695a-671e-4f4f-a331-acdce44ff9ba']) {
                         sh '.ci/prepare-git-context.sh'
                         sh 'gem install rake yard rspec'
-                        sh 'touch file'
-                        echo 'ignore'
+                        sh 'rake release'
                       }
                     }
                   }
@@ -211,13 +236,16 @@ def runBenchmark(version){
             dockerLogin(secret: "${DOCKER_SECRET}", registry: "${DOCKER_REGISTRY}")
           }
           try{
-            //sh "./spec/scripts/benchmarks.sh ${version}"
-            sh 'touch file'
-            echo 'ignore'
+            sh "./spec/scripts/benchmarks.sh ${version}"
           } catch(e){
             throw e
           } finally {
-            echo 'ignore'
+            archiveArtifacts(
+              allowEmptyArchive: true,
+              artifacts: "**/benchmark-${transformedVersion}.raw,**/benchmark-${transformedVersion}.error",
+              onlyIfSuccessful: false)
+            sendBenchmarks(file: "benchmark-${transformedVersion}.bulk",
+              index: "benchmark-ruby", archive: true)
           }
         }
       }

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -133,7 +133,6 @@ pipeline {
             The result JSON files are also archive into Jenkins.
           */
           stage('Run Benchmarks') {
-            agent { label 'linux && immutable' }
             steps {
               withGithubNotify(context: 'Run Benchmarks') {
                 deleteDir()

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -55,13 +55,6 @@ pipeline {
       }
     }
     stage('Sanity checks') {
-      when {
-        beforeAgent true
-        anyOf {
-          not { changeRequest() }
-          expression { return params.Run_As_Master_Branch }
-        }
-      }
       options { skipDefaultCheckout() }
       environment {
         HOME = "${env.WORKSPACE}"
@@ -103,19 +96,6 @@ pipeline {
       }
       stage('Benchmarks') {
         options { skipDefaultCheckout() }
-        when {
-          beforeAgent true
-          allOf {
-            anyOf {
-              branch 'master'
-              branch "\\d+\\.\\d+"
-              branch "v\\d?"
-              tag "v\\d+\\.\\d+\\.\\d+*"
-              expression { return params.Run_As_Master_Branch }
-            }
-            expression { return params.bench_ci }
-          }
-        }
         stages {
           stage('Clean Workspace') {
             agent { label 'metal' }
@@ -180,12 +160,6 @@ pipeline {
         environment {
           RUBY_DOCKER_TAG = 'ruby:2.6'
         }
-        when {
-          beforeAgent true
-          anyOf {
-            tag pattern: 'v\\d+.*', comparator: 'REGEXP'
-          }
-        }
         steps {
           withGithubNotify(context: 'Release') {
             deleteDir()
@@ -198,7 +172,8 @@ pipeline {
                       sshagent(['f6c7695a-671e-4f4f-a331-acdce44ff9ba']) {
                         sh '.ci/prepare-git-context.sh'
                         sh 'gem install rake yard rspec'
-                        sh 'rake release'
+                        sh 'touch file'
+                        echo 'ignore'
                       }
                     }
                   }
@@ -236,16 +211,13 @@ def runBenchmark(version){
             dockerLogin(secret: "${DOCKER_SECRET}", registry: "${DOCKER_REGISTRY}")
           }
           try{
-            sh "./spec/scripts/benchmarks.sh ${version}"
+            //sh "./spec/scripts/benchmarks.sh ${version}"
+            sh 'touch file'
+            echo 'ignore'
           } catch(e){
             throw e
           } finally {
-            archiveArtifacts(
-              allowEmptyArchive: true,
-              artifacts: "**/benchmark-${transformedVersion}.raw,**/benchmark-${transformedVersion}.error",
-              onlyIfSuccessful: false)
-            sendBenchmarks(file: "benchmark-${transformedVersion}.bulk",
-              index: "benchmark-ruby", archive: true)
+            echo 'ignore'
           }
         }
       }

--- a/.ci/downstreamTests.groovy
+++ b/.ci/downstreamTests.groovy
@@ -42,7 +42,6 @@ pipeline {
     Checkout the code and stash it, to use it on other stages.
     */
     stage('Checkout') {
-      agent { label 'immutable' }
       options { skipDefaultCheckout() }
       steps {
         deleteDir()
@@ -54,14 +53,12 @@ pipeline {
       }
     }
     stage('Test') {
-      agent { label 'linux && immutable' }
       options { skipDefaultCheckout() }
       steps {
         runTests('.ci/.jenkins_framework.yml')
       }
     }
     stage('Master Test') {
-      agent { label 'linux && immutable' }
       options { skipDefaultCheckout() }
       steps {
         catchError(buildResult: 'SUCCESS', stageResult: 'UNSTABLE', message: "The tests for the master framework have failed. Let's warn instead.") {

--- a/.ci/prepare-git-context.sh
+++ b/.ci/prepare-git-context.sh
@@ -20,4 +20,5 @@ git checkout "${BRANCH_NAME}"
 
 # Ensure the master branch points to the original commit to avoid commit injection
 # when running the release pipeline.
-git reset --hard "${GIT_COMMIT}"
+# used GIT_BASE_COMMIT instead GIT_COMMIT to support the MultiBranchPipelines.
+git reset --hard "${GIT_BASE_COMMIT}"


### PR DESCRIPTION
## Highlights
- Reuse the top-level worker as much as possible.
- Used to take 5 minutes to get to the `test` stage and now 2 minutes in the main pipeline.
- Used to take 3 minutes to get to the `test` stage and now 1.5 minutes in the downstream pipeline.
- Minor fix in the git reset --hard, as the GIT_BASE_COMMIT is the right env variable, created on the fly, with the commit sha either for the TAG/Branch/PR. GIT_COMMIT only works for branches.

## Test Cases
- Every single stage should run but the release stage.