### PR TITLE
Use monotonic time to calculate durations

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -78,6 +78,9 @@ Layout/EmptyLineAfterGuardClause:
 Naming/MemoizedInstanceVariableName:
   Enabled: false
 
+Naming/UncommunicativeMethodParamName:
+  Enabled: false
+
 Style/SpecialGlobalVars:
   Enabled: false
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,9 +14,10 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 
 #### Changed
 
-The following changes are breaking, as they may change the way data is grouped in Kibana.
+The following changes are breaking, as they may change the way data is grouped or shown in Kibana.
 No changes are necessary to your app.
 
+- Durations are measured using monotonic time ([#550](https://github.com/elastic/apm-agent-ruby/pull/550))
 - Errors' `message` no longer include their `type` ([#323](https://github.com/elastic/apm-agent-ruby/pull/323/files))
 - External request spans now have type `external.http.{library}` ([#514](https://github.com/elastic/apm-agent-ruby/pull/514))
 

--- a/lib/elastic_apm/opentracing.rb
+++ b/lib/elastic_apm/opentracing.rb
@@ -65,10 +65,10 @@ module ElasticAPM
       end
       # rubocop:enable Lint/UnusedMethodArgument
 
-      def finish(end_time: Time.now)
+      def finish(end_clock: Util.monotonic_micros)
         return unless (instrumenter = ElasticAPM.agent&.instrumenter)
 
-        elastic_span.done end_time: Util.micros(end_time)
+        elastic_span.done end_clock: end_clock
 
         case elastic_span
         when ElasticAPM::Transaction

--- a/lib/elastic_apm/opentracing.rb
+++ b/lib/elastic_apm/opentracing.rb
@@ -65,10 +65,10 @@ module ElasticAPM
       end
       # rubocop:enable Lint/UnusedMethodArgument
 
-      def finish(end_clock: Util.monotonic_micros)
+      def finish(clock_end: Util.monotonic_micros)
         return unless (instrumenter = ElasticAPM.agent&.instrumenter)
 
-        elastic_span.done end_clock: end_clock
+        elastic_span.done clock_end: clock_end
 
         case elastic_span
         when ElasticAPM::Transaction

--- a/lib/elastic_apm/opentracing.rb
+++ b/lib/elastic_apm/opentracing.rb
@@ -65,8 +65,15 @@ module ElasticAPM
       end
       # rubocop:enable Lint/UnusedMethodArgument
 
-      def finish(clock_end: Util.monotonic_micros)
+      # rubocop:disable Metrics/MethodLength
+      def finish(clock_end: Util.monotonic_micros, end_time: nil)
         return unless (instrumenter = ElasticAPM.agent&.instrumenter)
+
+        if end_time
+          warn '[ElasticAPM] DEPRECATED: Setting a custom end time as a ' \
+            '`Time` is deprecated. Use `clock_end:` and monotonic time instead.'
+          clock_end = end_time
+        end
 
         elastic_span.done clock_end: clock_end
 
@@ -79,6 +86,7 @@ module ElasticAPM
 
         instrumenter.enqueue.call elastic_span
       end
+      # rubocop:enable Metrics/MethodLength
 
       private
 

--- a/lib/elastic_apm/span.rb
+++ b/lib/elastic_apm/span.rb
@@ -61,18 +61,19 @@ module ElasticAPM
 
     # life cycle
 
-    def start(timestamp = Util.micros)
-      @timestamp = timestamp
-
+    def start(start_clock = Util.monotonic_micros)
+      @timestamp = Util.micros
+      @clock = start_clock
       self
     end
 
-    def stop(end_timestamp = Util.micros)
-      @duration ||= (end_timestamp - timestamp)
+    def stop(end_clock = Util.monotonic_micros)
+      @duration ||= (end_clock - @clock)
+      self
     end
 
-    def done(end_time: Util.micros)
-      stop end_time
+    def done(end_clock: Util.monotonic_micros)
+      stop end_clock
 
       build_stacktrace! if should_build_stacktrace?
       self.original_backtrace = nil # release original

--- a/lib/elastic_apm/span.rb
+++ b/lib/elastic_apm/span.rb
@@ -61,19 +61,19 @@ module ElasticAPM
 
     # life cycle
 
-    def start(start_clock = Util.monotonic_micros)
+    def start(clock_start = Util.monotonic_micros)
       @timestamp = Util.micros
-      @clock = start_clock
+      @clock_start = clock_start
       self
     end
 
-    def stop(end_clock = Util.monotonic_micros)
-      @duration ||= (end_clock - @clock)
+    def stop(clock_end = Util.monotonic_micros)
+      @duration ||= (clock_end - @clock_start)
       self
     end
 
-    def done(end_clock: Util.monotonic_micros)
-      stop end_clock
+    def done(clock_end: Util.monotonic_micros)
+      stop clock_end
 
       build_stacktrace! if should_build_stacktrace?
       self.original_backtrace = nil # release original

--- a/lib/elastic_apm/transaction.rb
+++ b/lib/elastic_apm/transaction.rb
@@ -54,20 +54,20 @@ module ElasticAPM
 
     # life cycle
 
-    def start(start_clock = Util.monotonic_micros)
+    def start(clock_start = Util.monotonic_micros)
       @timestamp = Util.micros
-      @clock = start_clock
+      @clock_start = clock_start
       self
     end
 
-    def stop(end_clock = Util.monotonic_micros)
+    def stop(clock_end = Util.monotonic_micros)
       raise 'Transaction not yet start' unless timestamp
-      @duration = end_clock - @clock
+      @duration = clock_end - @clock_start
       self
     end
 
-    def done(result = nil, end_clock: Util.monotonic_micros)
-      stop end_clock
+    def done(result = nil, clock_end: Util.monotonic_micros)
+      stop clock_end
       self.result = result if result
       self
     end

--- a/lib/elastic_apm/transaction.rb
+++ b/lib/elastic_apm/transaction.rb
@@ -54,19 +54,20 @@ module ElasticAPM
 
     # life cycle
 
-    def start(timestamp = Util.micros)
-      @timestamp = timestamp
+    def start(start_clock = Util.monotonic_micros)
+      @timestamp = Util.micros
+      @clock = start_clock
       self
     end
 
-    def stop(end_timestamp = Util.micros)
+    def stop(end_clock = Util.monotonic_micros)
       raise 'Transaction not yet start' unless timestamp
-      @duration = end_timestamp - timestamp
+      @duration = end_clock - @clock
       self
     end
 
-    def done(result = nil, end_time: Util.micros)
-      stop end_time
+    def done(result = nil, end_clock: Util.monotonic_micros)
+      stop end_clock
       self.result = result if result
       self
     end

--- a/lib/elastic_apm/util.rb
+++ b/lib/elastic_apm/util.rb
@@ -3,13 +3,13 @@
 module ElasticAPM
   # @api private
   module Util
-    def self.nearest_minute(target = Time.now.utc)
-      target - target.to_i % 60
-    end
-
     def self.micros(target = Time.now)
       utc = target.utc
       utc.to_i * 1_000_000 + utc.usec
+    end
+
+    def self.monotonic_micros
+      Process.clock_gettime(Process::CLOCK_MONOTONIC, :microsecond)
     end
 
     def self.git_sha

--- a/spec/elastic_apm/span_spec.rb
+++ b/spec/elastic_apm/span_spec.rb
@@ -48,16 +48,18 @@ module ElasticAPM
       let(:transaction) { Transaction.new }
 
       subject do
-        described_class.new(name: 'Spannest name',
-                            transaction_id: transaction.id,
-                            trace_context: trace_context)
+        described_class.new(
+          name: 'Spannest name',
+          transaction_id: transaction.id,
+          trace_context: trace_context
+        )
       end
 
       it 'has a relative and absolute start time', :mock_time do
         transaction.start
         travel 100
         expect(subject.start).to be subject
-        expect(subject.timestamp - transaction.timestamp).to eq 100_000
+        expect(subject.timestamp - transaction.timestamp).to eq 100
       end
     end
 
@@ -65,9 +67,11 @@ module ElasticAPM
       let(:transaction) { Transaction.new }
 
       subject do
-        described_class.new(name: 'Spannest name',
-                            transaction_id: transaction.id,
-                            trace_context: trace_context)
+        described_class.new(
+          name: 'Spannest name',
+          transaction_id: transaction.id,
+          trace_context: trace_context
+        )
       end
 
       it 'sets duration' do
@@ -77,12 +81,12 @@ module ElasticAPM
         subject.stop
 
         expect(subject).to be_stopped
-        expect(subject.duration).to be 100_000
+        expect(subject.duration).to be 100
       end
     end
 
     describe '#done', :mock_time do
-      let(:duration) { 100 }
+      let(:duration_us) { 5_100 }
       let(:span_frames_min_duration) { '5ms' }
       let(:config) do
         Config.new(span_frames_min_duration: span_frames_min_duration)
@@ -100,12 +104,12 @@ module ElasticAPM
       before do
         subject.original_backtrace = caller
         subject.start
-        travel duration
+        travel duration_us
         subject.done
       end
 
       it { should be_stopped }
-      its(:duration) { should be 100_000 }
+      its(:duration) { should be duration_us }
       its(:stacktrace) { should be_a Stacktrace }
 
       context 'when shorter than min for stacktrace' do

--- a/spec/elastic_apm/transaction_spec.rb
+++ b/spec/elastic_apm/transaction_spec.rb
@@ -26,7 +26,7 @@ module ElasticAPM
 
     describe '#start', :mock_time do
       it 'sets timestamp' do
-        expect(subject.start.timestamp).to be Util.micros(@mocked_date)
+        expect(subject.start.timestamp).to be Util.micros
       end
     end
 

--- a/spec/elastic_apm/transaction_spec.rb
+++ b/spec/elastic_apm/transaction_spec.rb
@@ -34,7 +34,7 @@ module ElasticAPM
       it 'sets duration' do
         subject.start
         travel 100
-        expect(subject.stop.duration).to eq 100_000
+        expect(subject.stop.duration).to eq 100
         expect(subject).to be_stopped
       end
     end
@@ -46,7 +46,7 @@ module ElasticAPM
         subject.done('HTTP 200')
 
         expect(subject).to be_stopped
-        expect(subject.duration).to be 100_000
+        expect(subject.duration).to be 100
         expect(subject.result).to eq 'HTTP 200'
       end
     end

--- a/spec/elastic_apm/transport/serializers/span_serializer_spec.rb
+++ b/spec/elastic_apm/transport/serializers/span_serializer_spec.rb
@@ -22,7 +22,7 @@ module ElasticAPM
               trace_context: trace_context
             ).tap do |span|
               span.start
-              travel 100
+              travel 10_000
               span.stop
             end
           end
@@ -41,7 +41,7 @@ module ElasticAPM
                 context: { sync: true },
                 stacktrace: [],
                 timestamp: 694_224_000_000_000,
-                duration: 100
+                duration: 10
               }
             )
           end

--- a/spec/elastic_apm/transport/serializers/transaction_serializer_spec.rb
+++ b/spec/elastic_apm/transport/serializers/transaction_serializer_spec.rb
@@ -18,7 +18,7 @@ module ElasticAPM
             let(:transaction) do
               ElasticAPM.start
               ElasticAPM.with_transaction('GET /something', 'request') do |t|
-                travel 100
+                travel 10_000
                 t.result = '200'
               end
               ElasticAPM.stop
@@ -36,7 +36,7 @@ module ElasticAPM
                   "type": 'request',
                   "result": '200',
                   "context": nil,
-                  "duration": 100.0,
+                  "duration": 10,
                   "timestamp": 694_224_000_000_000,
                   "trace_id": transaction.trace_id,
                   "sampled": true,

--- a/spec/elastic_apm/util_spec.rb
+++ b/spec/elastic_apm/util_spec.rb
@@ -10,7 +10,7 @@ module ElasticAPM
 
     describe '.monotonic_micros' do
       it 'returns current processor microseconds' do
-        expect(Util.monotonic_micros.to_s).to match(/\d{12}/)
+        expect(Util.monotonic_micros.to_s).to match(/\d+/)
       end
     end
 

--- a/spec/elastic_apm/util_spec.rb
+++ b/spec/elastic_apm/util_spec.rb
@@ -2,16 +2,15 @@
 
 module ElasticAPM
   RSpec.describe Util do
-    describe '.nearest_minute', :mock_time do
-      it 'normalizes to nearest minute' do
-        travel 125_000 # two minutes five secs
-        expect(Util.nearest_minute).to eq Time.utc(1992, 1, 1, 0, 2)
+    describe '.micros', mock_time: true do
+      it 'returns current µs since unix epoch' do
+        expect(Util.micros).to eq 694_224_000_000_000
       end
     end
 
-    describe '.ms', mock_time: true do
-      it 'returns current µs since unix epoch' do
-        expect(Util.micros).to eq 694_224_000_000_000
+    describe '.monotonic_micros' do
+      it 'returns current processor microseconds' do
+        expect(Util.monotonic_micros.to_s).to match(/\d{12}/)
       end
     end
 

--- a/spec/integration/opentracing_spec.rb
+++ b/spec/integration/opentracing_spec.rb
@@ -274,7 +274,7 @@ RSpec.describe 'OpenTracing bridge', :intercept do
 
           expect(span).to receive(:warn).with(/DEPRECATED/)
 
-          span.finish end_time: Time.current
+          span.finish end_time: Time.now
 
           expect(elastic_span.duration).to_not be nil
         end

--- a/spec/integration/opentracing_spec.rb
+++ b/spec/integration/opentracing_spec.rb
@@ -260,5 +260,25 @@ RSpec.describe 'OpenTracing bridge', :intercept do
         end
       end
     end
+
+    describe 'deprecations' do
+      describe '#finish with Time' do
+        it 'warns and manages' do
+          elastic_span =
+            ElasticAPM::Span.new(
+              name: 'Span',
+              transaction_id: 'transaction_id',
+              trace_context: nil
+            ).start
+          span = described_class.new(elastic_span, nil)
+
+          expect(span).to receive(:warn).with(/DEPRECATED/)
+
+          span.finish end_time: Time.current
+
+          expect(elastic_span.duration).to_not be nil
+        end
+      end
+    end
   end
 end

--- a/spec/support/mock_time.rb
+++ b/spec/support/mock_time.rb
@@ -3,11 +3,11 @@
 RSpec.configure do |config|
   config.before :each, mock_time: true do
     @mocked_date = Time.utc(1992, 1, 1)
-    @mocked_clock = 123_456_000_000
+    @mocked_clock = 123_000
 
-    def travel(distance)
-      Timecop.freeze(@mocked_date += (distance / 1_000_000.0))
-      @mocked_clock += distance
+    def travel(us)
+      Timecop.freeze(@mocked_date += (us / 1_000_000.0))
+      @mocked_clock += us
     end
 
     allow(ElasticAPM::Util).to receive(:monotonic_micros) { @mocked_clock }

--- a/spec/support/mock_time.rb
+++ b/spec/support/mock_time.rb
@@ -1,15 +1,21 @@
 # frozen_string_literal: true
 
 RSpec.configure do |config|
-  config.around :each, mock_time: true do |example|
+  config.before :each, mock_time: true do
     @mocked_date = Time.utc(1992, 1, 1)
+    @mocked_clock = 123_456_000_000
 
     def travel(distance)
-      Timecop.freeze(@mocked_date += distance / 1_000.0)
+      Timecop.freeze(@mocked_date += (distance / 1_000_000.0))
+      @mocked_clock += distance
     end
 
+    allow(ElasticAPM::Util).to receive(:monotonic_micros) { @mocked_clock }
+
     travel 0
-    example.run
+  end
+
+  config.after :each, mock_time: true do
     Timecop.return
   end
 end

--- a/spec/support/mock_time.rb
+++ b/spec/support/mock_time.rb
@@ -2,11 +2,11 @@
 
 RSpec.configure do |config|
   config.before :each, mock_time: true do
-    @mocked_date = Time.utc(1992, 1, 1)
+    @mocked_time = Time.utc(1992, 1, 1)
     @mocked_clock = 123_000
 
     def travel(us)
-      Timecop.freeze(@mocked_date += (us / 1_000_000.0))
+      Timecop.freeze(@mocked_time += (us / 1_000_000.0))
       @mocked_clock += us
     end
 


### PR DESCRIPTION
This changes a public api method in OpenTracing (`end_time` -> `end_clock`) however we could perhaps add a workaround.

I think I'd like to add a bit of explicitness to the `travel` method too from `mock_time`. It's not clear what unit we are traveling by (microseconds, now) and that might confuse a bit.

Closes #208 