### PR TITLE
Log CentralConfig connection errors on debug level

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+#### Changed
+
+- Log 404s from CentralConfig on debug level ([#553](https://github.com/elastic/apm-agent-ruby/pull/553))
+
 ## 3.0.0 (2019-10-08)
 
 ### Breaking Changes
@@ -11,7 +17,16 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 The following changes are breaking, as they may change the way data is grouped or shown in Kibana or how your app
 defines agent settings.
 
-- Decrease stack_trace_limit to 50 ([#515](https://github.com/elastic/apm-agent-ruby/pull/515))
+- Removed all deprecated methods and config options
+
+#### Changed
+
+- Log 404s from CentralConfig on debug level ([#553](https://github.com/elastic/apm-agent-ruby/pull/553))
+
+The following changes are breaking, as they may change the way data is grouped or shown in Kibana.
+No changes are necessary to your app.
+
+- Durations are measured using monotonic time ([#550](https://github.com/elastic/apm-agent-ruby/pull/550))
 - Errors' `message` no longer include their `type` ([#323](https://github.com/elastic/apm-agent-ruby/pull/323/files))
 - External request spans now have type `external.http.{library}` ([#514](https://github.com/elastic/apm-agent-ruby/pull/514))
 - Durations are measured using monotonic time ([#550](https://github.com/elastic/apm-agent-ruby/pull/550))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,16 +17,7 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 The following changes are breaking, as they may change the way data is grouped or shown in Kibana or how your app
 defines agent settings.
 
-- Removed all deprecated methods and config options
-
-#### Changed
-
-- Log 404s from CentralConfig on debug level ([#553](https://github.com/elastic/apm-agent-ruby/pull/553))
-
-The following changes are breaking, as they may change the way data is grouped or shown in Kibana.
-No changes are necessary to your app.
-
-- Durations are measured using monotonic time ([#550](https://github.com/elastic/apm-agent-ruby/pull/550))
+- Decrease stack_trace_limit to 50 ([#515](https://github.com/elastic/apm-agent-ruby/pull/515))
 - Errors' `message` no longer include their `type` ([#323](https://github.com/elastic/apm-agent-ruby/pull/323/files))
 - External request spans now have type `external.http.{library}` ([#514](https://github.com/elastic/apm-agent-ruby/pull/514))
 - Durations are measured using monotonic time ([#550](https://github.com/elastic/apm-agent-ruby/pull/550))

--- a/lib/elastic_apm/central_config.rb
+++ b/lib/elastic_apm/central_config.rb
@@ -107,7 +107,7 @@ module ElasticAPM
     # rubocop:enable Metrics/MethodLength
 
     def handle_error(error)
-      error(
+      debug(
         'Failed fetching config: %s, trying again in %d seconds',
         error.response.body, DEFAULT_MAX_AGE
       )


### PR DESCRIPTION
As Central Config comes enabled yet needs special setup in APM Server/Kibana, logging 404s every 5mins on the `error` log level seems a bit more critical than it is.

The Python logs http errors from Central Config on the `debug` level which is more sensible.