### PR TITLE
Config objects are not mutated and transactions have a local config

### DIFF
--- a/lib/elastic_apm/agent.rb
+++ b/lib/elastic_apm/agent.rb
@@ -231,6 +231,12 @@ module ElasticAPM
     def add_filter(key, callback)
       transport.add_filter(key, callback)
     end
+
+    def update_config(new_options)
+      @config = config.dup.tap do |_config|
+        new_options.each { |key, value| _config.send(:"#{key}=", value) }
+      end
+    end
   end
   # rubocop:enable Metrics/ClassLength
 end

--- a/lib/elastic_apm/agent.rb
+++ b/lib/elastic_apm/agent.rb
@@ -69,7 +69,7 @@ module ElasticAPM
       @context_builder = ContextBuilder.new(config)
       @error_builder = ErrorBuilder.new(self)
 
-      @central_config = CentralConfig.new(config)
+      @central_config = CentralConfig.new(config, self)
       @transport = Transport::Base.new(config)
       @instrumenter = Instrumenter.new(
         config,

--- a/lib/elastic_apm/agent.rb
+++ b/lib/elastic_apm/agent.rb
@@ -71,6 +71,7 @@ module ElasticAPM
       @central_config = CentralConfig.new(config)
       @transport = Transport::Base.new(config)
       @instrumenter = Instrumenter.new(
+        config,
         stacktrace_builder: stacktrace_builder
       ) { |event| enqueue event }
       @metrics = Metrics.new(config) { |event| enqueue event }

--- a/lib/elastic_apm/central_config.rb
+++ b/lib/elastic_apm/central_config.rb
@@ -81,7 +81,7 @@ module ElasticAPM
         update[key] = @modified_options.delete(key)
       end
 
-      config.assign(update)
+      ElasticAPM.agent&.update_config(update)
     end
 
     private

--- a/lib/elastic_apm/central_config.rb
+++ b/lib/elastic_apm/central_config.rb
@@ -20,8 +20,9 @@ module ElasticAPM
 
     DEFAULT_MAX_AGE = 300
 
-    def initialize(config)
+    def initialize(config, agent)
       @config = config
+      @agent = agent
       @modified_options = {}
       @service_info = {
         'service.name': config.service_name,
@@ -81,7 +82,7 @@ module ElasticAPM
         update[key] = @modified_options.delete(key)
       end
 
-      ElasticAPM.agent&.update_config(update)
+      @agent.update_config(update)
     end
 
     private

--- a/lib/elastic_apm/central_config.rb
+++ b/lib/elastic_apm/central_config.rb
@@ -87,9 +87,7 @@ module ElasticAPM
     private
 
     def update_config(new_options)
-      @config = config.dup.tap do |_config|
-        new_options.each { |key, value| _config.send(:"#{key}=", value) }
-      end
+      @config = config.dup.tap { |new_config| new_config.assign(new_options) }
     end
 
     # rubocop:disable Metrics/MethodLength

--- a/lib/elastic_apm/central_config.rb
+++ b/lib/elastic_apm/central_config.rb
@@ -20,9 +20,8 @@ module ElasticAPM
 
     DEFAULT_MAX_AGE = 300
 
-    def initialize(config, agent)
+    def initialize(config)
       @config = config
-      @agent = agent
       @modified_options = {}
       @service_info = {
         'service.name': config.service_name,
@@ -82,10 +81,16 @@ module ElasticAPM
         update[key] = @modified_options.delete(key)
       end
 
-      @agent.update_config(update)
+      update_config(update)
     end
 
     private
+
+    def update_config(new_options)
+      @config = config.dup.tap do |_config|
+        new_options.each { |key, value| _config.send(:"#{key}=", value) }
+      end
+    end
 
     # rubocop:disable Metrics/MethodLength
     def handle_success(resp)

--- a/lib/elastic_apm/config.rb
+++ b/lib/elastic_apm/config.rb
@@ -107,11 +107,6 @@ module ElasticAPM
 
     attr_reader :options
 
-    def assign(update)
-      return unless update
-      update.each { |key, value| send(:"#{key}=", value) }
-    end
-
     # rubocop:disable Metrics/MethodLength
     def available_instrumentations
       %w[
@@ -178,6 +173,11 @@ module ElasticAPM
     end
 
     private
+
+    def assign(update)
+      return unless update
+      update.each { |key, value| send(:"#{key}=", value) }
+    end
 
     def load_config_file
       return unless File.exist?(config_file)

--- a/lib/elastic_apm/config.rb
+++ b/lib/elastic_apm/config.rb
@@ -107,6 +107,11 @@ module ElasticAPM
 
     attr_reader :options
 
+    def assign(update)
+      return unless update
+      update.each { |key, value| send(:"#{key}=", value) }
+    end
+
     # rubocop:disable Metrics/MethodLength
     def available_instrumentations
       %w[
@@ -173,11 +178,6 @@ module ElasticAPM
     end
 
     private
-
-    def assign(update)
-      return unless update
-      update.each { |key, value| send(:"#{key}=", value) }
-    end
 
     def load_config_file
       return unless File.exist?(config_file)

--- a/lib/elastic_apm/instrumenter.rb
+++ b/lib/elastic_apm/instrumenter.rb
@@ -39,15 +39,14 @@ module ElasticAPM
       end
     end
 
-    def initialize(config, stacktrace_builder:, &enqueue)
-      @config = config
+    def initialize(stacktrace_builder:, &enqueue)
       @stacktrace_builder = stacktrace_builder
       @enqueue = enqueue
 
       @current = Current.new
     end
 
-    attr_reader :config, :stacktrace_builder, :enqueue
+    attr_reader :stacktrace_builder, :enqueue
 
     def start
       debug 'Starting instrumenter'
@@ -82,6 +81,7 @@ module ElasticAPM
     def start_transaction(
       name = nil,
       type = nil,
+      config:,
       context: nil,
       trace_context: nil
     )
@@ -92,7 +92,7 @@ module ElasticAPM
           "Transactions may not be nested.\nAlready inside #{transaction}"
       end
 
-      sampled = trace_context ? trace_context.recorded? : random_sample?
+      sampled = trace_context ? trace_context.recorded? : random_sample?(config)
 
       transaction =
         Transaction.new(
@@ -101,7 +101,7 @@ module ElasticAPM
           context: context,
           trace_context: trace_context,
           sampled: sampled,
-          labels: config.default_labels
+          config: config
         )
 
       transaction.start
@@ -149,7 +149,7 @@ module ElasticAPM
 
       transaction.inc_started_spans!
 
-      if transaction.max_spans_reached?(config)
+      if transaction.max_spans_reached?
         transaction.inc_dropped_spans!
         return
       end
@@ -167,7 +167,7 @@ module ElasticAPM
         stacktrace_builder: stacktrace_builder
       )
 
-      if backtrace && config.span_frames_min_duration?
+      if backtrace && transaction.config.span_frames_min_duration?
         span.original_backtrace = backtrace
       end
 
@@ -205,7 +205,7 @@ module ElasticAPM
 
     def set_user(user)
       return unless current_transaction
-      current_transaction.context.user = Context::User.infer(config, user)
+      current_transaction.context.user = Context::User.infer(current_transaction.config, user)
     end
 
     def inspect
@@ -216,7 +216,7 @@ module ElasticAPM
 
     private
 
-    def random_sample?
+    def random_sample?(config)
       rand <= config.transaction_sample_rate
     end
   end

--- a/lib/elastic_apm/instrumenter.rb
+++ b/lib/elastic_apm/instrumenter.rb
@@ -39,7 +39,8 @@ module ElasticAPM
       end
     end
 
-    def initialize(stacktrace_builder:, &enqueue)
+    def initialize(config, stacktrace_builder:, &enqueue)
+      @config = config
       @stacktrace_builder = stacktrace_builder
       @enqueue = enqueue
 

--- a/lib/elastic_apm/instrumenter.rb
+++ b/lib/elastic_apm/instrumenter.rb
@@ -206,7 +206,7 @@ module ElasticAPM
 
     def set_user(user)
       return unless current_transaction
-      current_transaction.context.user = Context::User.infer(current_transaction.config, user)
+      current_transaction.set_user(user)
     end
 
     def inspect

--- a/lib/elastic_apm/transaction.rb
+++ b/lib/elastic_apm/transaction.rb
@@ -19,16 +19,17 @@ module ElasticAPM
       type = nil,
       sampled: true,
       context: nil,
-      labels: nil,
+      config:,
       trace_context: nil
     )
       @name = name
       @type = type || DEFAULT_TYPE
+      @config = config
 
       @sampled = sampled
 
       @context = context || Context.new # TODO: Lazy generate this?
-      Util.reverse_merge!(@context.labels, labels) if labels
+      Util.reverse_merge!(@context.labels, config.default_labels) if config.default_labels
 
       @trace_context = trace_context || TraceContext.new(recorded: sampled)
 
@@ -42,7 +43,7 @@ module ElasticAPM
     attr_accessor :name, :type, :result
 
     attr_reader :context, :duration, :started_spans, :dropped_spans,
-      :timestamp, :trace_context, :notifications
+      :timestamp, :trace_context, :notifications, :config
 
     def sampled?
       @sampled
@@ -82,7 +83,7 @@ module ElasticAPM
       @dropped_spans += 1
     end
 
-    def max_spans_reached?(config)
+    def max_spans_reached?
       started_spans > config.transaction_max_spans
     end
 

--- a/lib/elastic_apm/transaction.rb
+++ b/lib/elastic_apm/transaction.rb
@@ -93,6 +93,10 @@ module ElasticAPM
       context.response = Context::Response.new(*args)
     end
 
+    def set_user(user)
+      context.user = Context::User.infer(config, user)
+    end
+
     def inspect
       "<ElasticAPM::Transaction id:#{id}" \
         " name:#{name.inspect} type:#{type.inspect}>"

--- a/spec/elastic_apm/agent_spec.rb
+++ b/spec/elastic_apm/agent_spec.rb
@@ -68,7 +68,6 @@ module ElasticAPM
         {
           current_transaction: nil,
           current_span: nil,
-          start_transaction: [nil, nil, { context: nil, trace_context: nil }],
           end_transaction: [nil],
           start_span: [
             nil,
@@ -88,6 +87,12 @@ module ElasticAPM
         }.each do |name, args|
           expect(subject).to delegate(name, to: instrumenter, args: args)
         end
+      end
+
+      it 'passes the config when starting a transaction' do
+        expect(instrumenter).to receive(:start_transaction).with(
+            nil, nil, { context: nil, trace_context: nil, config: subject.config })
+        subject.start_transaction
       end
     end
 
@@ -155,21 +160,6 @@ module ElasticAPM
         expect do
           subject.add_filter :key, -> {}
         end.to change(subject.transport.filters, :length).by 1
-      end
-    end
-
-    describe '#update_config' do
-      let(:config) { Config.new transaction_sample_rate: 0.5 }
-      before { subject.update_config(transaction_sample_rate: 1.5,
-                                     transaction_max_spans: 100) }
-
-      it 'updates the config' do
-        expect(subject.config.transaction_sample_rate).to eq(1.5)
-        expect(subject.config.transaction_max_spans).to be(100)
-      end
-
-      it 'creates a new config object' do
-        expect(config).not_to be(subject.config)
       end
     end
   end

--- a/spec/elastic_apm/agent_spec.rb
+++ b/spec/elastic_apm/agent_spec.rb
@@ -91,7 +91,7 @@ module ElasticAPM
 
       it 'passes the config when starting a transaction' do
         expect(instrumenter).to receive(:start_transaction).with(
-            nil, nil, { context: nil, trace_context: nil, config: subject.config })
+          nil, nil, { context: nil, trace_context: nil, config: subject.config })
         subject.start_transaction
       end
     end

--- a/spec/elastic_apm/agent_spec.rb
+++ b/spec/elastic_apm/agent_spec.rb
@@ -157,5 +157,20 @@ module ElasticAPM
         end.to change(subject.transport.filters, :length).by 1
       end
     end
+
+    describe '#update_config' do
+      let(:config) { Config.new transaction_sample_rate: 0.5 }
+      before { subject.update_config(transaction_sample_rate: 1.5,
+                                     transaction_max_spans: 100) }
+
+      it 'updates the config' do
+        expect(subject.config.transaction_sample_rate).to eq(1.5)
+        expect(subject.config.transaction_max_spans).to be(100)
+      end
+
+      it 'creates a new config object' do
+        expect(config).not_to be(subject.config)
+      end
+    end
   end
 end

--- a/spec/elastic_apm/central_config_spec.rb
+++ b/spec/elastic_apm/central_config_spec.rb
@@ -3,7 +3,6 @@
 module ElasticAPM
   RSpec.describe CentralConfig do
     let(:config) { Config.new }
-    let(:agent) { double('agent', update_config: {}) }
     subject { described_class.new(config) }
 
     describe '#start' do

--- a/spec/elastic_apm/central_config_spec.rb
+++ b/spec/elastic_apm/central_config_spec.rb
@@ -4,7 +4,7 @@ module ElasticAPM
   RSpec.describe CentralConfig do
     let(:config) { Config.new }
     let(:agent) { double('agent', update_config: {}) }
-    subject { described_class.new(config, agent) }
+    subject { described_class.new(config) }
 
     describe '#start' do
       it 'polls for config' do
@@ -37,9 +37,7 @@ module ElasticAPM
         subject.promise.wait
 
         expect(req_stub).to have_been_requested
-        expect(agent).to have_received(:update_config).with(
-          'transaction_sample_rate' => '0.5'
-        )
+        expect(subject.config.transaction_sample_rate).to eq(0.5)
       end
 
       it 'reverts config if later 404' do
@@ -53,12 +51,7 @@ module ElasticAPM
         subject.fetch_and_apply_config
         subject.promise.wait
 
-        expect(agent).to have_received(:update_config).with(
-          'transaction_sample_rate' => '0.5'
-        )
-        expect(agent).to have_received(:update_config).with(
-          'transaction_sample_rate' => 1.0
-        )
+        expect(subject.config.transaction_sample_rate).to eq(1.0)
       end
 
       context 'when server responds 200 and cache-control' do
@@ -97,8 +90,7 @@ module ElasticAPM
 
           expect(subject.scheduled_task).to be_pending
           expect(subject.scheduled_task.initial_delay).to eq 123
-          expect(agent).to have_received(:update_config).
-            with('transaction_sample_rate' => 0.5).twice
+          expect(subject.config.transaction_sample_rate).to eq(0.5)
         end
       end
 
@@ -156,36 +148,20 @@ module ElasticAPM
     describe '#assign' do
       it 'updates config' do
         subject.assign(transaction_sample_rate: 0.5)
-        expect(agent).to have_received(:update_config).with(
-          transaction_sample_rate: 0.5
-        )
+        expect(subject.config.transaction_sample_rate).to eq(0.5)
       end
 
       it 'reverts to previous when missing' do
         subject.assign(transaction_sample_rate: 0.5)
         subject.assign({})
-
-        expect(agent).to have_received(:update_config).
-          with(transaction_sample_rate: 0.5)
-        expect(agent).to have_received(:update_config).
-          with(transaction_sample_rate: 1.0)
+        expect(subject.config.transaction_sample_rate).to eq(1.0)
       end
 
       it 'goes back and forth' do
-        expect(agent).to receive(:update_config).with(
-            transaction_sample_rate: 0.5
-        ).ordered
-        expect(agent).to receive(:update_config).with(
-            transaction_sample_rate: 1.0
-        ).ordered
-        expect(agent).to receive(:update_config).with(
-            transaction_sample_rate: 0.5
-        ).ordered
         subject.assign(transaction_sample_rate: 0.5)
         subject.assign({})
         subject.assign(transaction_sample_rate: 0.5)
-
-
+        expect(subject.config.transaction_sample_rate).to eq(0.5)
       end
     end
 

--- a/spec/elastic_apm/central_config_spec.rb
+++ b/spec/elastic_apm/central_config_spec.rb
@@ -4,11 +4,7 @@ module ElasticAPM
   RSpec.describe CentralConfig do
     let(:config) { Config.new }
     let(:agent) { double('agent', update_config: {}) }
-    subject { described_class.new(config) }
-
-    before do
-      allow(ElasticAPM).to receive(:agent) { agent }
-    end
+    subject { described_class.new(config, agent) }
 
     describe '#start' do
       it 'polls for config' do

--- a/spec/elastic_apm/instrumenter_spec.rb
+++ b/spec/elastic_apm/instrumenter_spec.rb
@@ -9,6 +9,7 @@ module ElasticAPM
 
     subject do
       Instrumenter.new(
+        config,
         stacktrace_builder: stacktrace_builder,
         &callback
       )

--- a/spec/elastic_apm/instrumenter_spec.rb
+++ b/spec/elastic_apm/instrumenter_spec.rb
@@ -9,7 +9,6 @@ module ElasticAPM
 
     subject do
       Instrumenter.new(
-        config,
         stacktrace_builder: stacktrace_builder,
         &callback
       )
@@ -22,7 +21,7 @@ module ElasticAPM
         before do
           subject.subscriber = subscriber
 
-          subject.start_transaction
+          subject.start_transaction(config: config)
           subject.stop
         end
 
@@ -50,7 +49,7 @@ module ElasticAPM
     describe '#start_transaction' do
       it 'returns a new transaction and sets it as current' do
         context = Context.new
-        transaction = subject.start_transaction 'Test', 't', context: context
+        transaction = subject.start_transaction 'Test', 't', config: config, context: context
         expect(transaction.name).to eq 'Test'
         expect(transaction.type).to eq 't'
         expect(transaction.id).to be subject.current_transaction.id
@@ -60,9 +59,9 @@ module ElasticAPM
       end
 
       it 'explodes if called inside other transaction' do
-        subject.start_transaction 'Test'
+        subject.start_transaction 'Test', config: config
 
-        expect { subject.start_transaction 'Test' }
+        expect { subject.start_transaction 'Test', config: config }
           .to raise_error(ExistingTransactionError)
       end
 
@@ -70,7 +69,7 @@ module ElasticAPM
         let(:config) { Config.new(instrument: false) }
 
         it 'is nil' do
-          expect(subject.start_transaction).to be nil
+          expect(subject.start_transaction(config: config)).to be nil
           expect(subject.current_transaction).to be nil
         end
       end
@@ -79,7 +78,7 @@ module ElasticAPM
         let(:config) { Config.new(default_labels: { more: 'yes!' }) }
 
         it 'adds them to transaction context' do
-          transaction = subject.start_transaction 'Test', 't'
+          transaction = subject.start_transaction 'Test', 't', config: config
           expect(transaction.context.labels).to match(more: 'yes!')
         end
       end
@@ -88,7 +87,7 @@ module ElasticAPM
         let(:config) { Config.new(default_labels: { more: 'yes!' }) }
 
         it 'adds them to transaction context' do
-          transaction = subject.start_transaction 'Test', 't'
+          transaction = subject.start_transaction 'Test', 't', config: config
           expect(transaction.context.labels).to match(more: 'yes!')
         end
       end
@@ -100,7 +99,7 @@ module ElasticAPM
       end
 
       it 'ends and enqueues current transaction' do
-        transaction = subject.start_transaction
+        transaction = subject.start_transaction(config: config)
 
         return_value = subject.end_transaction('result')
 
@@ -121,7 +120,7 @@ module ElasticAPM
         let(:config) { Config.new(transaction_sample_rate: 0.0) }
 
         it 'skips spans' do
-          transaction = subject.start_transaction
+          transaction = subject.start_transaction(config: config)
           expect(transaction).to_not be_sampled
 
           span = subject.start_span 'Span'
@@ -130,7 +129,7 @@ module ElasticAPM
       end
 
       context 'inside a sampled transaction' do
-        let(:transaction) { subject.start_transaction }
+        let(:transaction) { subject.start_transaction(config: config) }
         before { transaction }
 
         it "increments transaction's span count" do
@@ -185,12 +184,12 @@ module ElasticAPM
 
     describe '#end_span' do
       context 'when missing span' do
-        before { subject.start_transaction }
+        before { subject.start_transaction(config: config) }
         it { expect(subject.end_span).to be nil }
       end
 
       context 'inside transaction and span' do
-        let(:transaction) { subject.start_transaction }
+        let(:transaction) { subject.start_transaction(config: config) }
         let(:span) { subject.start_span 'Span' }
 
         before do
@@ -222,14 +221,14 @@ module ElasticAPM
 
     describe '#set_label' do
       it 'sets tag on current transaction' do
-        transaction = subject.start_transaction 'Test'
+        transaction = subject.start_transaction 'Test', config: config
         subject.set_label :things, 'are all good!'
 
         expect(transaction.context.labels).to match(things: 'are all good!')
       end
 
       it 'de-dots keys' do
-        transaction = subject.start_transaction 'Test'
+        transaction = subject.start_transaction 'Test', config: config
         subject.set_label 'th.ings', 'are all good!'
         subject.set_label 'thi"ngs', 'are all good!'
         subject.set_label 'thin*gs', 'are all good!'
@@ -242,14 +241,14 @@ module ElasticAPM
       end
 
       it 'allows boolean values' do
-        transaction = subject.start_transaction 'Test'
+        transaction = subject.start_transaction 'Test', config: config
         subject.set_label :things, true
 
         expect(transaction.context.labels).to match(things: true)
       end
 
       it 'allows numerical values' do
-        transaction = subject.start_transaction 'Test'
+        transaction = subject.start_transaction 'Test', config: config
         subject.set_label :things, 123
 
         expect(transaction.context.labels).to match(things: 123)
@@ -258,7 +257,7 @@ module ElasticAPM
 
     describe '#set_custom_context' do
       it 'sets custom context on transaction' do
-        transaction = subject.start_transaction 'Test'
+        transaction = subject.start_transaction 'Test', config: config
         subject.set_custom_context(one: 'is in', two: 2, three: false)
 
         expect(transaction.context.custom).to match(
@@ -273,7 +272,7 @@ module ElasticAPM
       User = Struct.new(:id, :email, :username)
 
       it 'sets user in context' do
-        transaction = subject.start_transaction 'Test'
+        transaction = subject.start_transaction 'Test', config: config
         subject.set_user(User.new(1, 'a@a', 'abe'))
         subject.end_transaction
 

--- a/spec/elastic_apm/normalizers/action_controller_spec.rb
+++ b/spec/elastic_apm/normalizers/action_controller_spec.rb
@@ -15,9 +15,9 @@ module ElasticAPM
 
         describe '#normalize' do
           it 'sets transaction name from payload' do
-            instrumenter = double(Instrumenter, config: Config.new)
+            instrumenter = double(Instrumenter)
             subject = ProcessActionNormalizer.new nil
-            transaction = Transaction.new instrumenter, 'Rack'
+            transaction = Transaction.new instrumenter, 'Rack', config: Config.new
 
             result = subject.normalize(
               transaction,

--- a/spec/elastic_apm/span_spec.rb
+++ b/spec/elastic_apm/span_spec.rb
@@ -45,7 +45,7 @@ module ElasticAPM
     end
 
     describe '#start', :mock_time do
-      let(:transaction) { Transaction.new }
+      let(:transaction) { Transaction.new config: Config.new }
 
       subject do
         described_class.new(
@@ -64,7 +64,7 @@ module ElasticAPM
     end
 
     describe '#stopped', :mock_time do
-      let(:transaction) { Transaction.new }
+      let(:transaction) { Transaction.new config: Config.new }
 
       subject do
         described_class.new(

--- a/spec/elastic_apm/transaction_spec.rb
+++ b/spec/elastic_apm/transaction_spec.rb
@@ -4,21 +4,26 @@ require 'spec_helper'
 
 module ElasticAPM
   RSpec.describe Transaction do
+    subject { described_class.new config: config }
+    let(:config) { Config.new }
+
     describe '#initialize', :mock_time do
       its(:id) { should_not be_nil }
       its(:type) { should eq 'custom' }
       it { should be_sampled }
       its(:trace_context) { should be_a TraceContext }
       its(:context) { should be_a Context }
+      its(:config) { should be_a Config }
       its(:started_spans) { should be 0 }
       its(:dropped_spans) { should be 0 }
       its(:notifications) { should be_empty }
       its(:trace_id) { should be subject.trace_context.trace_id }
 
-      context 'with labels from context and args' do
+      context 'with labels from context and config' do
+        let(:config) { Config.new(default_labels: { args: 'yes' }) }
         it 'merges labels' do
           context = Context.new(labels: { context: 'yes' })
-          subject = described_class.new(labels: { args: 'yes' }, context: context)
+          subject = described_class.new(config: config, context: context)
           expect(subject.context.labels).to match(args: 'yes', context: 'yes')
         end
       end
@@ -62,7 +67,7 @@ module ElasticAPM
       it 'keeps and returns current parent id if set' do
         trace_context = TraceContext.new
         trace_context.parent_id = 'things'
-        subject = Transaction.new trace_context: trace_context
+        subject = Transaction.new config: config, trace_context: trace_context
 
         parent_id = subject.ensure_parent_id
 
@@ -88,9 +93,9 @@ module ElasticAPM
     describe '#max_spans_reached?' do
       let(:config) { Config.new(transaction_max_spans: 3) }
 
-      subject { described_class.new }
+      subject { described_class.new(config: config) }
 
-      let(:result) { subject.max_spans_reached? config }
+      let(:result) { subject.max_spans_reached? }
 
       context 'when below max' do
         it { expect(result).to be false }

--- a/spec/elastic_apm/transaction_spec.rb
+++ b/spec/elastic_apm/transaction_spec.rb
@@ -92,9 +92,6 @@ module ElasticAPM
 
     describe '#max_spans_reached?' do
       let(:config) { Config.new(transaction_max_spans: 3) }
-
-      subject { described_class.new(config: config) }
-
       let(:result) { subject.max_spans_reached? }
 
       context 'when below max' do

--- a/spec/elastic_apm/transport/base_spec.rb
+++ b/spec/elastic_apm/transport/base_spec.rb
@@ -22,12 +22,12 @@ module ElasticAPM
         it 'stops all workers', :mock_intake do
           subject.start
 
-          subject.submit Transaction.new
-          subject.submit Transaction.new
-          subject.submit Transaction.new
-          subject.submit Transaction.new
-          subject.submit Transaction.new
-          subject.submit Transaction.new
+          subject.submit Transaction.new config: config
+          subject.submit Transaction.new config: config
+          subject.submit Transaction.new config: config
+          subject.submit Transaction.new config: config
+          subject.submit Transaction.new config: config
+          subject.submit Transaction.new config: config
           subject.stop
 
           wait_for transactions: 6
@@ -43,7 +43,7 @@ module ElasticAPM
         end
 
         it 'adds stuff to the queue' do
-          subject.submit Transaction.new
+          subject.submit Transaction.new config: config
           expect(subject.queue.length).to be 1
         end
 
@@ -51,11 +51,11 @@ module ElasticAPM
           let(:config) { Config.new(api_buffer_size: 5) }
 
           it 'skips if queue is full' do
-            5.times { subject.submit Transaction.new }
+            5.times { subject.submit Transaction.new config: config }
 
             expect(config.logger).to receive(:warn)
 
-            expect { subject.submit Transaction.new }
+            expect { subject.submit Transaction.new config: config }
               .to_not raise_error
 
             expect(subject.queue.length).to be 5

--- a/spec/elastic_apm/transport/serializers/span_serializer_spec.rb
+++ b/spec/elastic_apm/transport/serializers/span_serializer_spec.rb
@@ -6,10 +6,11 @@ module ElasticAPM
   module Transport
     module Serializers
       RSpec.describe SpanSerializer do
-        subject { described_class.new Config.new }
+        let(:config) { Config.new }
+        subject { described_class.new config }
 
         describe '#build', :mock_time do
-          let(:transaction) { Transaction.new.start }
+          let(:transaction) { Transaction.new(config: config).start }
 
           let(:trace_context) do
             TraceContext.parse("00-#{'1' * 32}-#{'2' * 16}-01")

--- a/spec/elastic_apm/transport/serializers_spec.rb
+++ b/spec/elastic_apm/transport/serializers_spec.rb
@@ -3,7 +3,8 @@
 module ElasticAPM
   module Transport
     RSpec.describe Serializers do
-      subject { described_class.new(Config.new) }
+      let(:config) { Config.new }
+      subject { described_class.new(config) }
 
       it 'initializes with config' do
         expect(subject).to be_a Serializers::Container
@@ -16,7 +17,7 @@ module ElasticAPM
 
       describe '#serialize' do
         it 'serializes known objects' do
-          expect(subject.serialize(Transaction.new)).to be_a Hash
+          expect(subject.serialize(Transaction.new config: config)).to be_a Hash
           expect(subject.serialize(Span.new(name: 'Name',
                                             transaction_id: '',
                                             trace_context: TraceContext.new)))

--- a/spec/elastic_apm/transport/worker_spec.rb
+++ b/spec/elastic_apm/transport/worker_spec.rb
@@ -52,7 +52,7 @@ module ElasticAPM
         it 'applies filters, writes resources to the connection' do
           expect(subject.filters).to receive(:apply!)
 
-          queue.push Transaction.new
+          queue.push Transaction.new config: config
           Thread.new { subject.work_forever }.join 0.1
 
           expect(subject.connection.calls.length).to be 1
@@ -73,7 +73,7 @@ module ElasticAPM
           end
 
           it 'applies filters, writes resources to the connection' do
-            queue.push Transaction.new
+            queue.push Transaction.new config: config
 
             Thread.new { subject.work_forever }.join 0.1
 
@@ -86,7 +86,8 @@ module ElasticAPM
         it 'rescues exceptions' do
           event = Transaction.new(
             "What's in a name ⁉️",
-            (+'👏').force_encoding('ascii-8bit')
+            (+'👏').force_encoding('ascii-8bit'),
+            config: config
           )
 
           expect(config.logger).to receive(:error).twice.and_call_original

--- a/spec/integration/opentracing_spec.rb
+++ b/spec/integration/opentracing_spec.rb
@@ -186,7 +186,7 @@ RSpec.describe 'OpenTracing bridge', :intercept do
     before { ElasticAPM.start }
     after { ElasticAPM.stop }
 
-    let(:elastic_span) { ElasticAPM::Transaction.new }
+    let(:elastic_span) { ElasticAPM::Transaction.new config: ElasticAPM::Config.new  }
 
     describe 'log_kv' do
       subject { described_class.new(elastic_span, nil) }
@@ -226,7 +226,7 @@ RSpec.describe 'OpenTracing bridge', :intercept do
       end
 
       context 'when transaction' do
-        let(:elastic_span) { ElasticAPM::Transaction.new }
+        let(:elastic_span) { ElasticAPM::Transaction.new config: ElasticAPM::Config.new }
         let(:trace_context) { nil }
 
         it_behaves_like :opengraph_span


### PR DESCRIPTION
This is the first in a series of 3 PRs involving how the config for an agent is set, updated, and accessed. 

The changes will be in three parts:
1) **→[This PR]** `CentralConfig` wraps a `Config` object and swaps it out for a new one when updates are received. A transaction gets a local `config` object that it refers to for the entirety of its lifetime. This achieves the functionality of "snapshotting" the config at transaction start.
2) All objects refer to `ElasticAPM.config` (forwarded to `ElasticAPM.agent.config`) when they need to reference a config. That way, all references to `config` will be the latest one, as managed by the `CentralConfig`.
3) The `Logging` module will reference `ElasticAPM.config` but allow the `#config` method to be overridden, in case an object needs to define a local one.


Closes #536 