### PR TITLE
ci(jenkins): disable benchmarking for the jruby:9.2

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -141,7 +141,10 @@ pipeline {
                   script {
                     def versions = readYaml(file: ".ci/.jenkins_ruby.yml")
                     def benchmarkTask = [:]
-                    versions['RUBY_VERSION'].each{ v ->
+                    // TODO: benchmark for the jruby:9.2 and similar versions got some issues with
+                    //       NoMethodError: undefined method `[]' for nil:NilClass
+                    //      <main> at bench/report.rb:48
+                    versions['RUBY_VERSION'].findAll { !it.contains('9.2') }.each{ v ->
                       benchmarkTask[v] = runBenchmark(v)
                     }
                     parallel(benchmarkTask)


### PR DESCRIPTION
Caused by https://github.com/elastic/apm-agent-ruby/issues/521

## Highlights
- Current jruby:9.2 flavors are failing in the CI when running the benchmark with the below stack trace

```
NoMethodError: undefined method `[]' for nil:NilClass
```

For the time being let's disable them.