### PR TITLE
[docs] Documentation restructure

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -1,0 +1,1 @@
+This is a placeholder file. Release notes are published in CHANGELOG.md

--- a/docs/advanced.asciidoc
+++ b/docs/advanced.asciidoc
@@ -9,8 +9,6 @@ endif::[]
 
 * <<context>>
 * <<custom-instrumentation>>
-* <<opentracing>>
 
 include::./context.asciidoc[]
 include::./custom-instrumentation.asciidoc[]
-include::./opentracing.asciidoc[]

--- a/docs/api.asciidoc
+++ b/docs/api.asciidoc
@@ -5,7 +5,7 @@ https://www.elastic.co/guide/en/apm/agent/ruby/current/introduction.html[elastic
 endif::[]
 
 [[api]]
-== Public API
+== API reference
 
 Although most usage is covered automatically, Elastic APM also has a public
 API that allows custom usage.

--- a/docs/configuration.asciidoc
+++ b/docs/configuration.asciidoc
@@ -325,13 +325,13 @@ Get an array of enabled instrumentations with `ElasticAPM.agent.config.enabled_i
 The name of the environment this service is deployed in,
 e.g. "production" or "staging".
 
-Environments allow you to easily filter data on a global level in the APM UI.
+Environments allow you to easily filter data on a global level in the APM app.
 It's important to be consistent when naming environments across agents.
-See {kibana-ref}/filters.html#environment-selector[environment selector] in the Kibana UI for more information.
+See {kibana-ref}/filters.html#environment-selector[environment selector] in the APM app for more information.
 
 Defaults to `ENV['RAILS_ENV'] || ENV['RACK_ENV']`.
 
-NOTE: This feature is fully supported in the APM UI in Kibana versions >= 7.2.
+NOTE: This feature is fully supported in the APM app in Kibana versions >= 7.2.
 You must use the query bar to filter for a specific environment in versions prior to 7.2.
 
 [float]

--- a/docs/configuration.asciidoc
+++ b/docs/configuration.asciidoc
@@ -221,7 +221,7 @@ Whether or not to attach `ENV` from Rack to transactions and errors.
 | `ELASTIC_APM_CENTRAL_CONFIG` | `central_config` | `true`
 |============
 
-Enable {kibana-ref}/agent-configuration.html[APM Agent Configuration via Kibana].
+Enable {apm-app-ref}/agent-configuration.html[APM Agent Configuration via Kibana].
 If set to `true`, the client will poll the APM Server regularly for new agent configuration.
 
 Usually APM Server determines how often to poll, but if not the default interval is 5 minutes.
@@ -327,7 +327,7 @@ e.g. "production" or "staging".
 
 Environments allow you to easily filter data on a global level in the APM app.
 It's important to be consistent when naming environments across agents.
-See {kibana-ref}/filters.html#environment-selector[environment selector] in the APM app for more information.
+See {apm-app-ref}/filters.html#environment-selector[environment selector] in the APM app for more information.
 
 Defaults to `ENV['RAILS_ENV'] || ENV['RACK_ENV']`.
 

--- a/docs/custom-instrumentation.asciidoc
+++ b/docs/custom-instrumentation.asciidoc
@@ -1,12 +1,12 @@
 [[custom-instrumentation]]
 === Custom instrumentation
 
-When <<introduction,installed>> and <<configuration,properly configured>>
+When installed and properly configured,
 ElasticAPM will automatically wrap your app's request/responses in transactions
 and report its errors.
 It also wraps each background job if you use Sidekiq or DelayedJob.
 
-But it is possible to create your own transactions as well as provide spans for
+But it is also possible to create your own transactions as well as provide spans for
 any automatic or custom transaction.
 
 See <<api-agent-start_transaction,`ElasticAPM.start_transaction`>> and

--- a/docs/debugging.asciidoc
+++ b/docs/debugging.asciidoc
@@ -1,5 +1,5 @@
 [[debugging]]
-== Debugging the agent itself
+== Troubleshooting
 
 Hopefully the agent Just Works™, but depending on your situation the agent might need some tuning.
 

--- a/docs/getting-started-rack.asciidoc
+++ b/docs/getting-started-rack.asciidoc
@@ -5,7 +5,7 @@ https://www.elastic.co/guide/en/apm/agent/ruby/current/introduction.html[elastic
 endif::[]
 
 [[getting-started-rack]]
-== Getting started with Rack
+=== Getting started with Rack
 
 Add the gem to your `Gemfile`:
 

--- a/docs/getting-started-rails.asciidoc
+++ b/docs/getting-started-rails.asciidoc
@@ -5,10 +5,10 @@ https://www.elastic.co/guide/en/apm/agent/ruby/current/introduction.html[elastic
 endif::[]
 
 [[getting-started-rails]]
-== Getting started with Rails
+=== Getting started with Rails
 
 [float]
-=== Setup
+==== Setup
 
 Add the gem to your `Gemfile`:
 

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -12,21 +12,21 @@ endif::[]
 
 include::./introduction.asciidoc[]
 
-include::./getting-started-rails.asciidoc[]
-
-include::./getting-started-rack.asciidoc[]
-
-include::./configuration.asciidoc[]
-
-include::./log-correlation.asciidoc[]
-
-include::./metrics.asciidoc[]
-
-include::./advanced.asciidoc[]
+include::./set-up.asciidoc[]
 
 include::./supported-technologies.asciidoc[]
 
+include::./configuration.asciidoc[]
+
+include::./advanced.asciidoc[]
+
 include::./api.asciidoc[]
+
+include::./metrics.asciidoc[]
+
+include::./opentracing.asciidoc[]
+
+include::./log-correlation.asciidoc[]
 
 include::./debugging.asciidoc[]
 

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -1,5 +1,4 @@
-:branch: current
-:server-branch: 6.5
+include::{asciidoc-dir}/../../shared/versions/stack/current.asciidoc[]
 include::{asciidoc-dir}/../../shared/attributes.asciidoc[]
 
 ifdef::env-github[]

--- a/docs/introduction.asciidoc
+++ b/docs/introduction.asciidoc
@@ -17,10 +17,10 @@ It also offers an API which allows you to instrument any application.
 === How does the Agent work?
 
 The agent auto-instruments <<supported-technologies,supported technologies>> and records interesting events,
-like HTTP requests and database queries. To do this, it {NEED CONTENT HERE}.
+like HTTP requests and database queries. To do this, it uses relevant public APIs when they are provided by the libraries. Otherwise, it carefully wraps the necessary internal methods.
 This means that for the supported technologies, there are no code changes required.
 
-The Agent automatically {NEED CONTENT HERE} to measure their duration and metadata (like the DB statement),
+The Agent automatically keeps track of queries to your data stores to measure their duration and metadata (like the DB statement),
 as well as HTTP related information (like the URL, parameters, and headers).
 
 These events, called Transactions and Spans, are sent to the APM Server.

--- a/docs/introduction.asciidoc
+++ b/docs/introduction.asciidoc
@@ -5,15 +5,27 @@ https://www.elastic.co/guide/en/apm/agent/ruby/current/introduction.html[elastic
 endif::[]
 
 [[introduction]]
-
 == Introduction
 
-Welcome to the APM Ruby Agent documentation.
-
-The Elastic APM Ruby Agent sends performance metrics and error logs to an
-Elastic APM Server.
+The Elastic APM Ruby Agent sends performance metrics and error logs to the APM Server.
 It has built-in support for <<getting-started-rails,Ruby on Rails>> and other
 <<getting-started-rack,Rack-compatible>> applications.
+It also offers an API which allows you to instrument any application.
+
+[float]
+[[how-it-works]]
+=== How does the Agent work?
+
+The agent auto-instruments <<supported-technologies,supported technologies>> and records interesting events,
+like HTTP requests and database queries. To do this, it {NEED CONTENT HERE}.
+This means that for the supported technologies, there are no code changes required.
+
+The Agent automatically {NEED CONTENT HERE} to measure their duration and metadata (like the DB statement),
+as well as HTTP related information (like the URL, parameters, and headers).
+
+These events, called Transactions and Spans, are sent to the APM Server.
+The APM Server converts them to a format suitable for Elasticsearch, and sends them to an Elasticsearch cluster.
+You can then use the APM app in Kibana to gain insight into latency issues and error culprits within your application.
 
 [float]
 [[additional-components]]
@@ -21,13 +33,3 @@ It has built-in support for <<getting-started-rails,Ruby on Rails>> and other
 
 APM Agents work in conjunction with the {apm-server-ref-v}/index.html[APM Server], {ref}/index.html[Elasticsearch], and {kibana-ref}/index.html[Kibana].
 Please view the {apm-overview-ref-v}/index.html[APM Overview] for details on how these components work together. 
-
-[float]
-[[framework-support]]
-=== Framework Support
-
-The Elastic APM Ruby Agent officially supports Ruby on Rails versions 4.x on
-onwards, see <<getting-started-rails,Getting started with Ruby on Rails>>.
-
-For Sinatra and other Rack compatible frameworks, see
-<<getting-started-rack,Getting started with Rack>>.

--- a/docs/opentracing.asciidoc
+++ b/docs/opentracing.asciidoc
@@ -55,11 +55,11 @@ Elastic APM defines some tags which are not included in the OpenTracing API but 
 - `type` - sets the type of the transaction,
   for example `request`, `ext` or `db`
 - `user.id` - sets the user id,
-  appears in the "User" tab in the transaction details in the Elastic APM UI
+  appears in the "User" tab in the transaction details in the Elastic APM app
 - `user.email` - sets the user email,
-  appears in the "User" tab in the transaction details in the Elastic APM UI
+  appears in the "User" tab in the transaction details in the Elastic APM app
 - `user.username` - sets the user name,
-  appears in the "User" tab in the transaction details in the Elastic APM UI
+  appears in the "User" tab in the transaction details in the Elastic APM app
 - `result` - sets the result of the transaction. Overrides the default value of `success`.
   If the `error` tag is set to `true`, the default value is `error`.
 

--- a/docs/opentracing.asciidoc
+++ b/docs/opentracing.asciidoc
@@ -4,7 +4,7 @@ please view this documentation at https://www.elastic.co/guide/en/apm/agent/ruby
 endif::[]
 
 [[opentracing]]
-=== OpenTracing bridge
+== OpenTracing API
 
 The Elastic APM OpenTracing bridge allows to create Elastic APM `Transactions` and `Spans`,
 using the OpenTracing API.
@@ -16,7 +16,7 @@ subsequent spans are mapped to Elastic APM `Span`.
 
 [float]
 [[operation-modes]]
-=== Operation Modes
+== Operation Modes
 
 This bridge allows for different operation modes in combination with the Elastic APM Agent.
 
@@ -34,12 +34,12 @@ This bridge allows for different operation modes in combination with the Elastic
 
 [float]
 [[getting-started]]
-=== Getting started
+== Getting started
 Either `require 'elastic_apm/opentracing'` during the boot of your app or specify the `require:` argument to your `Gemfile`, eg. `gem 'elastic_apm', require: 'elastic_apm/opentracing'`.
 
 [float]
 [[init-tracer]]
-=== Set Elastic APM as the global tracer
+== Set Elastic APM as the global tracer
 
 [source,ruby]
 ----
@@ -48,7 +48,7 @@ Either `require 'elastic_apm/opentracing'` during the boot of your app or specif
 
 [float]
 [[elastic-apm-tags]]
-=== Elastic APM specific tags
+== Elastic APM specific tags
 
 Elastic APM defines some tags which are not included in the OpenTracing API but are relevant in the context of Elastic APM.
 
@@ -65,30 +65,30 @@ Elastic APM defines some tags which are not included in the OpenTracing API but 
 
 [float]
 [[unsupported]]
-=== Caveats
+== Caveats
 Not all features of the OpenTracing API are supported.
 
 [float]
 [[propagation]]
-==== Context propagation
+=== Context propagation
 This bridge only supports the format `OpenTracing::FORMAT_RACK`, using HTTP headers with capitalized names, prefixed with `HTTP_` as Rack does it.
 
 `OpenTracing::FORMAT_BINARY` is currently not supported.
 
 [float]
 [[references]]
-==== Span References
+=== Span References
 Currently, this bridge only supports `child_of` references.
 Other references,
 like `follows_from` are not supported yet.
 
 [float]
 [[baggage]]
-==== Baggage
+=== Baggage
 The `Span.set_baggage` method is not supported.
 Baggage items are dropped with a warning log message.
 
 [float]
 [[logs]]
-==== Logs
+=== Logs
 Logs are currently not supported.

--- a/docs/set-up.asciidoc
+++ b/docs/set-up.asciidoc
@@ -1,0 +1,16 @@
+ifdef::env-github[]
+NOTE: For the best reading experience,
+please view this documentation at
+https://www.elastic.co/guide/en/apm/agent/ruby/current/set-up.html[elastic.co]
+endif::[]
+
+[[set-up]]
+== Set up the Agent
+
+To get you off the ground, we’ve prepared guides for setting up the Agent with different frameworks:
+
+include::./getting-started-rails.asciidoc[]
+
+include::./getting-started-rack.asciidoc[]
+
+For custom instrumentation, see the <<api>>.

--- a/docs/supported-technologies.asciidoc
+++ b/docs/supported-technologies.asciidoc
@@ -7,10 +7,8 @@ endif::[]
 == Supported technologies
 
 The Elastic APM Ruby Agent has built-in support for many frameworks and
-libraries.
-
-Generally we want to support all the most popular libraries, so if your favorite
-is missing feel free so request it in an issue or better yet supply a pull
+libraries. Generally, we want to support all of the most popular libraries. If your favorite
+is missing, feel free to request it in an issue, or better yet, create a pull
 request.
 
 [float]


### PR DESCRIPTION
**This PR must be merged in the order outlined in https://github.com/elastic/apm-agent-ruby/issues/556.**

This PR accomplishes the following:
* Use shared version attributes
* Rename the APM UI to "APM app"
* Updates `{kibana-ref}` links to `{apm-app-ref}` links.
* Updates to the new documentation structure
* Adds a top level heading for log correlation
* Adds a section on how the Agent does instrumentation
* Adds a placeholder `CHANGELOG.asciidoc` file

New layout:
![Screen Shot 2019-10-09 at 11 37 51 AM](https://user-images.githubusercontent.com/5618806/66510884-c6034400-ea8a-11e9-9799-42721efe82b0.png)
