### PR TITLE
Add ElasticAPM::Sinatra.start API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 
 ## Unreleased
 
+### Added
+
+- Add `ElasticAPM::Sinatra.start` API. ([#566](https://github.com/elastic/apm-agent-ruby/pull/566))
+
 #### Changed
 
 - Log 404s from CentralConfig on debug level ([#553](https://github.com/elastic/apm-agent-ruby/pull/553))

--- a/docs/api.asciidoc
+++ b/docs/api.asciidoc
@@ -204,6 +204,17 @@ ElasticAPM::Rails.start(server_url: 'http://localhost:8200')
 ----
 
 [float]
+[[sinatra-start]]
+=== Sinatra
+
+Start the agent and hook into Sinatra.
+
+[source,ruby]
+----
+ElasticAPM::Sinatra.start(MySinatraApp, server_url: 'http://localhost:8200')
+----
+
+[float]
 === Errors
 
 [float]

--- a/docs/configuration.asciidoc
+++ b/docs/configuration.asciidoc
@@ -53,6 +53,17 @@ ElasticAPM.start(
 )
 ----
 
+Alternatively, you can use the `ElasticAPM::Sinatra.start` API.
+
+[source,ruby]
+----
+# config.ru or similar
+ElasticAPM::Sinatra.start(
+  MyApp,
+  service_name: 'SomeOtherName'
+)
+----
+
 See <<getting-started-rack>>.
 
 [float]

--- a/docs/getting-started-rack.asciidoc
+++ b/docs/getting-started-rack.asciidoc
@@ -64,6 +64,9 @@ end
 # Takes optional ElasticAPM::Config values
 ElasticAPM.start(app: MySinatraApp, ...)
 
+# You can also do the following, which is equivalent to the above:
+# ElasticAPM::Sinatra.start(MySinatraApp, ...)
+
 run MySinatraApp
 
 at_exit { ElasticAPM.stop }

--- a/lib/elastic_apm.rb
+++ b/lib/elastic_apm.rb
@@ -14,6 +14,7 @@ require 'elastic_apm/util'
 require 'elastic_apm/middleware'
 
 require 'elastic_apm/railtie' if defined?(::Rails::Railtie)
+require 'elastic_apm/sinatra' if defined?(::Sinatra)
 
 # ElasticAPM
 module ElasticAPM # rubocop:disable Metrics/ModuleLength

--- a/lib/elastic_apm/config.rb
+++ b/lib/elastic_apm/config.rb
@@ -215,7 +215,7 @@ module ElasticAPM
     def set_sinatra(app)
       self.service_name = format_name(service_name || app.to_s)
       self.framework_name = framework_name || 'Sinatra'
-      self.framework_version = framework_version || Sinatra::VERSION
+      self.framework_version = framework_version || ::Sinatra::VERSION
       self.__root_path = Dir.pwd
     end
 

--- a/lib/elastic_apm/sinatra.rb
+++ b/lib/elastic_apm/sinatra.rb
@@ -11,7 +11,7 @@ module ElasticAPM
     # @return [true, nil] true if the agent was started, nil otherwise.
     def start(app, config)
       config = Config.new(config) unless config.is_a?(Config)
-      set_config(app, config)
+      configure_app(app, config)
 
       ElasticAPM.start(config)
       ElasticAPM.running?
@@ -22,7 +22,7 @@ module ElasticAPM
 
     private
 
-    def set_config(app, config)
+    def configure_app(app, config)
       config.service_name ||= format_name(app.to_s)
       config.framework_name ||= 'Sinatra'
       config.framework_version ||= ::Sinatra::VERSION

--- a/lib/elastic_apm/sinatra.rb
+++ b/lib/elastic_apm/sinatra.rb
@@ -4,7 +4,6 @@ module ElasticAPM
   # Module for starting the ElasticAPM agent and hooking into Sinatra.
   module Sinatra
     extend self
-    # rubocop:disable Metrics/MethodLength, Metrics/AbcSize
     # Start the ElasticAPM agent and hook into Sinatra.
     #
     # @param app [Sinatra::Base] A Sinatra app.
@@ -20,7 +19,6 @@ module ElasticAPM
       config.logger.error format('Failed to start: %s', e.message)
       config.logger.debug "Backtrace:\n" + e.backtrace.join("\n")
     end
-    # rubocop:enable Metrics/MethodLength, Metrics/AbcSize
 
     private
 

--- a/lib/elastic_apm/sinatra.rb
+++ b/lib/elastic_apm/sinatra.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+module ElasticAPM
+  # Module for starting the ElasticAPM agent and hooking into Sinatra.
+  module Sinatra
+    extend self
+    # rubocop:disable Metrics/MethodLength, Metrics/AbcSize
+    # Start the ElasticAPM agent and hook into Sinatra.
+    #
+    # @param app [Sinatra::Base] A Sinatra app.
+    # @param config [Config, Hash] An instance of Config or a Hash config.
+    # @return [true, nil] true if the agent was started, nil otherwise.
+    def start(app, config)
+      config = Config.new(config) unless config.is_a?(Config)
+      set_config(app, config)
+
+      ElasticAPM.start(config)
+      ElasticAPM.running?
+    rescue StandardError => e
+      config.logger.error format('Failed to start: %s', e.message)
+      config.logger.debug "Backtrace:\n" + e.backtrace.join("\n")
+    end
+    # rubocop:enable Metrics/MethodLength, Metrics/AbcSize
+
+    private
+
+    def set_config(app, config)
+      config.service_name ||= format_name(app.to_s)
+      config.framework_name ||= 'Sinatra'
+      config.framework_version ||= ::Sinatra::VERSION
+      config.__root_path ||= Dir.pwd
+    end
+
+    def format_name(str)
+      str && str.gsub('::', '_')
+    end
+  end
+end

--- a/spec/elastic_apm/sinatra_spec.rb
+++ b/spec/elastic_apm/sinatra_spec.rb
@@ -27,7 +27,7 @@ if defined?(Sinatra)
 
         it 'sets the options' do
           expect(ElasticAPM.agent.config.options[:service_name].value)
-              .to eq('Other Name')
+            .to eq('Other Name')
         end
       end
     end

--- a/spec/elastic_apm/sinatra_spec.rb
+++ b/spec/elastic_apm/sinatra_spec.rb
@@ -33,4 +33,6 @@ if defined?(Sinatra)
       end
     end
   end
+else
+  puts '[INFO] Skipping Sinatra.start spec'
 end

--- a/spec/elastic_apm/sinatra_spec.rb
+++ b/spec/elastic_apm/sinatra_spec.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+if defined?(Sinatra)
+  RSpec.describe Sinatra do
+    describe '.start' do
+      before do
+        class SinatraTestApp < ::Sinatra::Base
+          use ElasticAPM::Middleware
+        end
+        ElasticAPM::Sinatra.start(SinatraTestApp, config)
+      end
+
+      after do
+        ElasticAPM.stop
+        Object.send(:remove_const, :SinatraTestApp)
+      end
+
+      context 'with no overridden config settings' do
+        let(:config) { {} }
+        it 'starts the agent' do
+          expect(ElasticAPM::Agent).to be_running
+        end
+      end
+
+      context 'a config with settings' do
+        let(:config) { { service_name: 'Other Name' } }
+
+        it 'sets the options' do
+          expect(ElasticAPM.agent.config.options[:service_name].value)
+              .to eq('Other Name')
+        end
+      end
+    end
+  end
+end

--- a/spec/elastic_apm/sinatra_spec.rb
+++ b/spec/elastic_apm/sinatra_spec.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 if defined?(Sinatra)
+  require 'elastic_apm/sinatra'
   RSpec.describe Sinatra do
     describe '.start' do
       before do

--- a/spec/integration/sinatra_spec.rb
+++ b/spec/integration/sinatra_spec.rb
@@ -6,49 +6,47 @@ if defined?(Sinatra)
   RSpec.describe 'Sinatra integration', :mock_intake do
     include Rack::Test::Methods
 
-    class FancyError < StandardError; end
-    class BackwardsCompatibleLogger < Logger
-      def write(*args)
-        self.<<(*args)
-      end
-    end
-
-    class SinatraTestApp < ::Sinatra::Base
-      enable :logging
-      disable :protection
-      disable :show_exceptions
-
-      use ElasticAPM::Middleware
-      use Rack::CommonLogger, BackwardsCompatibleLogger.new(nil)
-      # use Rack::CommonLogger, BackwardsCompatibleLogger.new(STDOUT)
-
-      get '/' do
-        'Yes!'
-      end
-
-      get '/inline' do
-        erb 'Inline <%= "t" * 3 %>emplate'
-      end
-
-      template :index do
-        '<%= (1..3).to_a.join(" ") %> hello <%= @name %>'
-      end
-
-      get '/tmpl' do
-        @name = 'you'
-        erb :index
-      end
-
-      get '/error' do
-        raise FancyError, 'Halp!'
-      end
-    end
-
-    def app
-      SinatraTestApp
-    end
+    let(:app) { SinatraTestApp }
 
     before(:all) do
+      class FancyError < StandardError; end
+      class BackwardsCompatibleLogger < Logger
+        def write(*args)
+          self.<<(*args)
+        end
+      end
+
+      class SinatraTestApp < ::Sinatra::Base
+        enable :logging
+        disable :protection
+        disable :show_exceptions
+
+        use ElasticAPM::Middleware
+        use Rack::CommonLogger, BackwardsCompatibleLogger.new(nil)
+        # use Rack::CommonLogger, BackwardsCompatibleLogger.new(STDOUT)
+
+        get '/' do
+          'Yes!'
+        end
+
+        get '/inline' do
+          erb 'Inline <%= "t" * 3 %>emplate'
+        end
+
+        template :index do
+          '<%= (1..3).to_a.join(" ") %> hello <%= @name %>'
+        end
+
+        get '/tmpl' do
+          @name = 'you'
+          erb :index
+        end
+
+        get '/error' do
+          raise FancyError, 'Halp!'
+        end
+      end
+
       ElasticAPM.start(app: SinatraTestApp, api_request_time: '250ms')
     end
 


### PR DESCRIPTION
This allows users to explicitly start the agent + hook in their Sinatra app.

`ElasticAPM::Sinatra.start(MyApp, config)`