### PR TITLE
Add API on event context to set framework name and version

### DIFF
--- a/lib/elastic_apm/context.rb
+++ b/lib/elastic_apm/context.rb
@@ -9,25 +9,36 @@ require 'elastic_apm/context/user'
 module ElasticAPM
   # @api private
   class Context
-    def initialize(custom: {}, labels: {}, user: nil)
+    def initialize(custom: {}, labels: {}, user: nil, service: nil)
       @custom = custom
       @labels = labels
       @user = user || User.new
+      @service = service
     end
+
+    Service = Struct.new(:framework)
+    Framework = Struct.new(:name, :version)
 
     attr_accessor :request
     attr_accessor :response
     attr_accessor :user
     attr_reader :custom
     attr_reader :labels
+    attr_reader :service
 
     def empty?
       return false if labels.any?
       return false if custom.any?
       return false if user.any?
+      return false if service
       return false if request || response
 
       true
+    end
+
+    def set_service(framework_name: nil, framework_version: nil)
+      @service = Service.new(Framework.new(framework_name,
+                                           framework_version))
     end
   end
 end

--- a/lib/elastic_apm/transport/serializers/context_serializer.rb
+++ b/lib/elastic_apm/transport/serializers/context_serializer.rb
@@ -13,7 +13,8 @@ module ElasticAPM
             tags: mixed_object(context.labels),
             request: build_request(context.request),
             response: build_response(context.response),
-            user: build_user(context.user)
+            user: build_user(context.user),
+            service: build_service(context.service)
           }
         end
 
@@ -77,6 +78,17 @@ module ElasticAPM
             pathname: keyword_field(url.pathname),
             search: keyword_field(url.search),
             hash: keyword_field(url.hash)
+          }
+        end
+
+        def build_service(service)
+          return unless service
+
+          {
+            framework: {
+              name: keyword_field(service.framework.name),
+              version: keyword_field(service.framework.version)
+            }
           }
         end
       end

--- a/spec/elastic_apm/context_spec.rb
+++ b/spec/elastic_apm/context_spec.rb
@@ -20,5 +20,17 @@ module ElasticAPM
         expect(Context.new.tap { |c| c.response = 1 }).to_not be_empty
       end
     end
+
+    describe 'service' do
+      before do
+        subject.set_service(framework_name: 'Grape',
+                            framework_version: '1.2')
+      end
+
+      it 'sets the service' do
+        expect(subject.service.framework.name).to eq('Grape')
+        expect(subject.service.framework.version).to eq('1.2')
+      end
+    end
   end
 end

--- a/spec/elastic_apm/transport/serializers/context_serializer_spec.rb
+++ b/spec/elastic_apm/transport/serializers/context_serializer_spec.rb
@@ -13,6 +13,16 @@ module ElasticAPM
           result = subject.build(context)
           expect(result.dig(:response, :status_code)).to be 302
         end
+
+        context 'service' do
+          it 'includes the service' do
+            context = Context.new
+            context.set_service(framework_name: 'Grape', framework_version: '1.2')
+            result = subject.build(context)
+            expect(result[:service][:framework][:name]).to eq('Grape')
+            expect(result[:service][:framework][:version]).to eq('1.2')
+          end
+        end
       end
     end
   end


### PR DESCRIPTION
This change is motivated by [this comment](https://github.com/elastic/apm-agent-ruby/pull/562/files#r334814742)

This PR adds a variable on a `Context` that represents `service` data, previously only ever set on `Metadata`. It adds a method `context#set_service` that would allow the Grape support implementation to set the framework and framework version to its own attributes. This is important for when Grape is used alongside Rails and the events need to be tracked as coming from Grape, not Rails.