### PR TITLE
Remove trailing slash from server_url Config option

### DIFF
--- a/lib/elastic_apm/config.rb
+++ b/lib/elastic_apm/config.rb
@@ -21,7 +21,7 @@ module ElasticAPM
 
     # rubocop:disable Metrics/LineLength, Layout/ExtraSpacing
     option :config_file,                       type: :string, default: 'config/elastic_apm.yml'
-    option :server_url,                        type: :string, default: 'http://localhost:8200'
+    option :server_url,                        type: :url,    default: 'http://localhost:8200'
     option :secret_token,                      type: :string
 
     option :active,                            type: :bool,   default: true

--- a/lib/elastic_apm/config/options.rb
+++ b/lib/elastic_apm/config/options.rb
@@ -48,7 +48,7 @@ module ElasticAPM
           when :bool then normalize_bool(val)
           when :list then normalize_list(val)
           when :dict then normalize_dict(val)
-          when :url then normalize_trailing_slash(val)
+          when :url then normalize_url(val)
           else
             # raise "Unknown options type '#{type.inspect}'"
             val
@@ -71,7 +71,7 @@ module ElasticAPM
           Hash[val.split(/[&,]/).map { |kv| kv.split('=') }]
         end
 
-        def normalize_trailing_slash(val)
+        def normalize_url(val)
           return val unless val.is_a?(String)
           val.end_with?('/') ? val.chomp('/') : val
         end

--- a/lib/elastic_apm/config/options.rb
+++ b/lib/elastic_apm/config/options.rb
@@ -48,6 +48,7 @@ module ElasticAPM
           when :bool then normalize_bool(val)
           when :list then normalize_list(val)
           when :dict then normalize_dict(val)
+          when :url then normalize_trailing_slash(val)
           else
             # raise "Unknown options type '#{type.inspect}'"
             val
@@ -68,6 +69,11 @@ module ElasticAPM
         def normalize_dict(val)
           return val unless val.is_a?(String)
           Hash[val.split(/[&,]/).map { |kv| kv.split('=') }]
+        end
+
+        def normalize_trailing_slash(val)
+          return val unless val.is_a?(String)
+          val.end_with?('/') ? val.chomp('/') : val
         end
       end
 

--- a/spec/elastic_apm/config_spec.rb
+++ b/spec/elastic_apm/config_spec.rb
@@ -77,6 +77,14 @@ module ElasticAPM
       end
     end
 
+    context 'server_url with a trailing slash' do
+      subject { Config.new(server_url: 'http://localhost:8200/') }
+
+      it 'strips the trailing slash' do
+        expect(subject.server_url).to eq('http://localhost:8200')
+      end
+    end
+
     context 'duration units' do
       subject do
         Config.new(


### PR DESCRIPTION
This PR adds a converter `url` type that removes a trailing slash from the `server_url` config option.

Closes #568