### PR TITLE
Support starting more than one span on a transaction

### DIFF
--- a/docs/api.asciidoc
+++ b/docs/api.asciidoc
@@ -155,7 +155,7 @@ Arguments:
 Returns the created span.
 
 If you'd like to create an asynchronous span, you have to pass the parent `Span` or `Transaction` to the `start_span` method.
-You can also set the `sync` flag to `false`, if you'd like the span to be marked as asynchronous.
+You can also set the `sync` flag to `false`, if you'd like the span to be marked as asynchronous. This has no effect other than being queryable in Elasticsearch.
 
 [source,ruby]
 ----

--- a/docs/api.asciidoc
+++ b/docs/api.asciidoc
@@ -159,7 +159,7 @@ You can also set the `sync` flag to `false`, if you'd like the span to be marked
 
 [source,ruby]
 ----
-transaction = ElasticAPM.start_transaction
+transaction = ElasticAPM.current_transaction # or start one with `.start_transaction`
 Thread.new do
   ElasticAPM.start_span(
     'job 1',

--- a/docs/api.asciidoc
+++ b/docs/api.asciidoc
@@ -147,10 +147,28 @@ Arguments:
   * `context`: An instance of `Span::Context`.
   * `include_stacktrace`: Whether or not to collect a Stacktrace.
   * `trace_context:`: An optional `TraceContext` object for Distributed Tracing.
+  * `parent:`: An optional parent transaction or span. Relevant when the span is created in another thread.
+  * `sync:`: An boolean to indicate whether the span is created synchronously or not.
   * `&block`: An optional block to wrap with the span.
   The block is passed the span as an optional argument.
 
 Returns the created span.
+
+If you'd like to create an asynchronous span, you have to pass the parent `Span` or `Transaction` to the `start_span` method.
+You can also set the `sync` flag to `false`, if you'd like the span to be marked as asynchronous.
+
+[source,ruby]
+----
+transaction = ElasticAPM.start_transaction
+Thread.new do
+  ElasticAPM.start_span(
+    'job 1',
+    parent: transaction,
+    sync: false
+  ) { Worker.perform }
+  ElasticAPM.end_span
+end
+----
 
 [float]
 [[api-agent-end_span]]
@@ -173,10 +191,27 @@ Arguments:
   * `context`: An instance of `Span::Context`.
   * `include_stacktrace`: Whether or not to collect a Stacktrace.
   * `trace_context:`: An optional `TraceContext` object for Distributed Tracing.
+  * `parent:`: An optional parent transaction or span. Relevant when the span is created in another thread.
+  * `sync:`: An boolean to indicate whether the span is created synchronously or not.
   * `&block`: An optional block to wrap with the span.
   The block is passed the span as an optional argument.
 
 Returns the return value of the given block.
+
+If you'd like to create an asynchronous span, you have to pass the parent `Span` or `Transaction` to the method.
+You can also set the `sync` flag to `false`, if you'd like the span to be marked as asynchronous.
+
+[source,ruby]
+----
+transaction = ElasticAPM.start_transaction
+Thread.new do
+  ElasticAPM.with_span(
+    'job 1',
+    parent: transaction,
+    sync: false
+  ) { Worker.perform }
+end
+----
 
 [float]
 [[api-agent-build-context]]

--- a/docs/api.asciidoc
+++ b/docs/api.asciidoc
@@ -203,7 +203,7 @@ You can also set the `sync` flag to `false`, if you'd like the span to be marked
 
 [source,ruby]
 ----
-transaction = ElasticAPM.start_transaction
+transaction = ElasticAPM.current_transaction # or start one with `.start_transaction`
 Thread.new do
   ElasticAPM.with_span(
     'job 1',

--- a/docs/api.asciidoc
+++ b/docs/api.asciidoc
@@ -198,7 +198,7 @@ Arguments:
 
 Returns the return value of the given block.
 
-If you'd like to create an asynchronous span, you have to pass the parent `Span` or `Transaction` to the method.
+If you'd like to create an asynchronous span, you have to pass the parent `Span` or `Transaction` to the `with_span` method.
 You can also set the `sync` flag to `false`, if you'd like the span to be marked as asynchronous.
 
 [source,ruby]

--- a/lib/elastic_apm.rb
+++ b/lib/elastic_apm.rb
@@ -226,7 +226,8 @@ module ElasticAPM
       action: nil,
       context: nil,
       include_stacktrace: true,
-      trace_context: nil
+      trace_context: nil,
+      parent: nil
     )
       unless block_given?
         raise ArgumentError,
@@ -244,7 +245,8 @@ module ElasticAPM
             action: action,
             context: context,
             include_stacktrace: include_stacktrace,
-            trace_context: trace_context
+            trace_context: trace_context,
+            parent: parent
           )
         yield span
       ensure

--- a/lib/elastic_apm.rb
+++ b/lib/elastic_apm.rb
@@ -180,7 +180,8 @@ module ElasticAPM
       context: nil,
       include_stacktrace: true,
       trace_context: nil,
-      parent: nil
+      parent: nil,
+      sync: nil
     )
       agent&.start_span(
         name,
@@ -189,7 +190,8 @@ module ElasticAPM
         action: action,
         context: context,
         trace_context: trace_context,
-        parent: parent
+        parent: parent,
+        sync: sync
       ).tap do |span|
         break unless span && include_stacktrace
         break unless agent.config.span_frames_min_duration?
@@ -227,7 +229,8 @@ module ElasticAPM
       context: nil,
       include_stacktrace: true,
       trace_context: nil,
-      parent: nil
+      parent: nil,
+      sync: nil
     )
       unless block_given?
         raise ArgumentError,
@@ -246,7 +249,8 @@ module ElasticAPM
             context: context,
             include_stacktrace: include_stacktrace,
             trace_context: trace_context,
-            parent: parent
+            parent: parent,
+            sync: sync
           )
         yield span
       ensure

--- a/lib/elastic_apm.rb
+++ b/lib/elastic_apm.rb
@@ -180,7 +180,7 @@ module ElasticAPM
       context: nil,
       include_stacktrace: true,
       trace_context: nil,
-      transaction: nil
+      parent: nil
     )
       agent&.start_span(
         name,
@@ -189,7 +189,7 @@ module ElasticAPM
         action: action,
         context: context,
         trace_context: trace_context,
-        transaction: transaction
+        parent: parent
       ).tap do |span|
         break unless span && include_stacktrace
         break unless agent.config.span_frames_min_duration?

--- a/lib/elastic_apm.rb
+++ b/lib/elastic_apm.rb
@@ -215,7 +215,7 @@ module ElasticAPM
     # Wrap a block in a Span, ending it after the block
     #
     # @param name [String] A description of the span, eq `SELECT FROM "users"`
-     # @param type [String] The kind of span, eq `db`
+    # @param type [String] The kind of span, eq `db`
     # @param subtype [String] The subtype of span eg. `postgresql`.
     # @param action [String] The action type of span eg. `connect` or `query`.
     # @param context [Span::Context] Context information about the span

--- a/lib/elastic_apm.rb
+++ b/lib/elastic_apm.rb
@@ -171,6 +171,9 @@ module ElasticAPM
     # @param include_stacktrace [Boolean] Whether or not to capture a stacktrace
     # @param trace_context [TraceContext] An optional [TraceContext] object for
     #   Distributed Tracing.
+    # @param parent [Transaction,Span] The parent transaction or span.
+    #   Relevant when the span is created in another thread.
+    # @param sync [Boolean] Whether the span is created synchronously or not.
     # @return [Span]
     def start_span(
       name,
@@ -219,6 +222,9 @@ module ElasticAPM
     # @param include_stacktrace [Boolean] Whether or not to capture a stacktrace
     # @param trace_context [TraceContext] An optional [TraceContext] object for
     #   Distributed Tracing.
+    # @param parent [Transaction,Span] The parent transaction or span.
+    #   Relevant when the span is created in another thread.
+    # @param sync [Boolean] Whether the span is created synchronously or not.
     # @yield [Span]
     # @return Result of block
     def with_span(

--- a/lib/elastic_apm.rb
+++ b/lib/elastic_apm.rb
@@ -179,7 +179,8 @@ module ElasticAPM
       action: nil,
       context: nil,
       include_stacktrace: true,
-      trace_context: nil
+      trace_context: nil,
+      parent_transaction: nil
     )
       agent&.start_span(
         name,
@@ -187,7 +188,8 @@ module ElasticAPM
         subtype: subtype,
         action: action,
         context: context,
-        trace_context: trace_context
+        trace_context: trace_context,
+        parent_transaction: parent_transaction
       ).tap do |span|
         break unless span && include_stacktrace
         break unless agent.config.span_frames_min_duration?

--- a/lib/elastic_apm.rb
+++ b/lib/elastic_apm.rb
@@ -180,7 +180,7 @@ module ElasticAPM
       context: nil,
       include_stacktrace: true,
       trace_context: nil,
-      parent_transaction: nil
+      transaction: nil
     )
       agent&.start_span(
         name,
@@ -189,7 +189,7 @@ module ElasticAPM
         action: action,
         context: context,
         trace_context: trace_context,
-        parent_transaction: parent_transaction
+        transaction: transaction
       ).tap do |span|
         break unless span && include_stacktrace
         break unless agent.config.span_frames_min_duration?

--- a/lib/elastic_apm/agent.rb
+++ b/lib/elastic_apm/agent.rb
@@ -166,7 +166,7 @@ module ElasticAPM
       backtrace: nil,
       context: nil,
       trace_context: nil,
-      parent_transaction: nil
+      transaction: nil
     )
       instrumenter.start_span(
         name,
@@ -176,7 +176,7 @@ module ElasticAPM
         backtrace: backtrace,
         context: context,
         trace_context: trace_context,
-        parent_transaction: parent_transaction
+        transaction: transaction
       )
     end
     # rubocop:enable Metrics/ParameterLists

--- a/lib/elastic_apm/agent.rb
+++ b/lib/elastic_apm/agent.rb
@@ -165,7 +165,8 @@ module ElasticAPM
       action: nil,
       backtrace: nil,
       context: nil,
-      trace_context: nil
+      trace_context: nil,
+      parent_transaction: nil
     )
       instrumenter.start_span(
         name,
@@ -174,7 +175,8 @@ module ElasticAPM
         action: action,
         backtrace: backtrace,
         context: context,
-        trace_context: trace_context
+        trace_context: trace_context,
+        parent_transaction: parent_transaction
       )
     end
     # rubocop:enable Metrics/ParameterLists

--- a/lib/elastic_apm/agent.rb
+++ b/lib/elastic_apm/agent.rb
@@ -166,7 +166,7 @@ module ElasticAPM
       backtrace: nil,
       context: nil,
       trace_context: nil,
-      transaction: nil
+      parent: nil
     )
       instrumenter.start_span(
         name,
@@ -176,7 +176,7 @@ module ElasticAPM
         backtrace: backtrace,
         context: context,
         trace_context: trace_context,
-        transaction: transaction
+        parent: parent
       )
     end
     # rubocop:enable Metrics/ParameterLists

--- a/lib/elastic_apm/agent.rb
+++ b/lib/elastic_apm/agent.rb
@@ -166,7 +166,8 @@ module ElasticAPM
       backtrace: nil,
       context: nil,
       trace_context: nil,
-      parent: nil
+      parent: nil,
+      sync: nil
     )
       instrumenter.start_span(
         name,
@@ -176,7 +177,8 @@ module ElasticAPM
         backtrace: backtrace,
         context: context,
         trace_context: trace_context,
-        parent: parent
+        parent: parent,
+        sync: sync
       )
     end
     # rubocop:enable Metrics/ParameterLists

--- a/lib/elastic_apm/child_durations.rb
+++ b/lib/elastic_apm/child_durations.rb
@@ -24,18 +24,23 @@ module ElasticAPM
         @nesting_level = 0
         @start = nil
         @duration = 0
+        @mutex = Mutex.new
       end
 
       attr_reader :duration
 
       def start
-        @nesting_level += 1
-        @start = Util.micros if @nesting_level == 1
+        @mutex.synchronize do
+          @nesting_level += 1
+          @start = Util.micros if @nesting_level == 1
+        end
       end
 
       def stop
-        @nesting_level -= 1
-        @duration = (Util.micros - @start) if @nesting_level == 0
+        @mutex.synchronize do
+          @nesting_level -= 1
+          @duration = (Util.micros - @start) if @nesting_level == 0
+        end
       end
     end
   end

--- a/lib/elastic_apm/instrumenter.rb
+++ b/lib/elastic_apm/instrumenter.rb
@@ -160,7 +160,7 @@ module ElasticAPM
       return unless transaction.sampled?
       return unless transaction.inc_started_spans!
 
-      parent ||= current_span || current_transaction
+      parent ||= (current_span || current_transaction)
 
       span = Span.new(
         name: name,

--- a/lib/elastic_apm/instrumenter.rb
+++ b/lib/elastic_apm/instrumenter.rb
@@ -146,7 +146,8 @@ module ElasticAPM
       backtrace: nil,
       context: nil,
       trace_context: nil,
-      parent: nil
+      parent: nil,
+      sync: nil
     )
 
       transaction =
@@ -173,7 +174,8 @@ module ElasticAPM
         trace_context: trace_context,
         type: type,
         context: context,
-        stacktrace_builder: stacktrace_builder
+        stacktrace_builder: stacktrace_builder,
+        sync: sync
       )
 
       if backtrace && transaction.config.span_frames_min_duration?

--- a/lib/elastic_apm/instrumenter.rb
+++ b/lib/elastic_apm/instrumenter.rb
@@ -153,12 +153,7 @@ module ElasticAPM
 
       parent = parent_transaction || current_span || current_transaction
 
-      transaction.inc_started_spans!
-
-      if transaction.max_spans_reached?
-        transaction.inc_dropped_spans!
-        return
-      end
+      return unless transaction.inc_started_spans!
 
       span = Span.new(
         name: name,

--- a/lib/elastic_apm/instrumenter.rb
+++ b/lib/elastic_apm/instrumenter.rb
@@ -144,10 +144,14 @@ module ElasticAPM
       action: nil,
       backtrace: nil,
       context: nil,
-      trace_context: nil
+      trace_context: nil,
+      parent_transaction: nil
     )
-      return unless (transaction = current_transaction)
+      transaction = parent_transaction || current_transaction
+      return unless transaction
       return unless transaction.sampled?
+
+      parent = parent_transaction || current_span || current_transaction
 
       transaction.inc_started_spans!
 
@@ -155,8 +159,6 @@ module ElasticAPM
         transaction.inc_dropped_spans!
         return
       end
-
-      parent = current_span || transaction
 
       span = Span.new(
         name: name,

--- a/lib/elastic_apm/instrumenter.rb
+++ b/lib/elastic_apm/instrumenter.rb
@@ -136,6 +136,7 @@ module ElasticAPM
     end
 
     # rubocop:disable Metrics/CyclomaticComplexity
+    # rubocop:disable Metrics/PerceivedComplexity
     # rubocop:disable Metrics/ParameterLists
     def start_span(
       name,
@@ -148,14 +149,15 @@ module ElasticAPM
       parent: nil
     )
 
-      transaction = case parent
+      transaction =
+        case parent
         when Span
           parent.transaction
         when Transaction
           parent
         else
           current_transaction
-      end
+        end
       return unless transaction
       return unless transaction.sampled?
       return unless transaction.inc_started_spans!
@@ -184,6 +186,7 @@ module ElasticAPM
     end
     # rubocop:enable Metrics/ParameterLists
     # rubocop:enable Metrics/CyclomaticComplexity
+    # rubocop:enable Metrics/PerceivedComplexity
 
     def end_span
       return unless (span = current_spans.pop)

--- a/lib/elastic_apm/instrumenter.rb
+++ b/lib/elastic_apm/instrumenter.rb
@@ -145,15 +145,15 @@ module ElasticAPM
       backtrace: nil,
       context: nil,
       trace_context: nil,
-      parent_transaction: nil
+      transaction: nil
     )
-      transaction = parent_transaction || current_transaction
-      return unless transaction
-      return unless transaction.sampled?
+      parent_transaction = transaction || current_transaction
+      return unless parent_transaction
+      return unless parent_transaction.sampled?
 
-      parent = parent_transaction || current_span || current_transaction
+      parent = transaction || current_span || current_transaction
 
-      return unless transaction.inc_started_spans!
+      return unless parent_transaction.inc_started_spans!
 
       span = Span.new(
         name: name,
@@ -167,7 +167,7 @@ module ElasticAPM
         stacktrace_builder: stacktrace_builder
       )
 
-      if backtrace && transaction.config.span_frames_min_duration?
+      if backtrace && parent_transaction.config.span_frames_min_duration?
         span.original_backtrace = backtrace
       end
 

--- a/lib/elastic_apm/instrumenter.rb
+++ b/lib/elastic_apm/instrumenter.rb
@@ -160,7 +160,7 @@ module ElasticAPM
       return unless transaction.sampled?
       return unless transaction.inc_started_spans!
 
-      parent = parent || current_span || current_transaction
+      parent ||= current_span || current_transaction
 
       span = Span.new(
         name: name,

--- a/lib/elastic_apm/span.rb
+++ b/lib/elastic_apm/span.rb
@@ -20,7 +20,8 @@ module ElasticAPM
       subtype: nil,
       action: nil,
       context: nil,
-      stacktrace_builder: nil
+      stacktrace_builder: nil,
+      sync: nil
     )
       @name = name
 
@@ -36,7 +37,7 @@ module ElasticAPM
       @parent = parent
       @trace_context = trace_context || parent.trace_context.child
 
-      @context = context || Span::Context.new
+      @context = context || Span::Context.new(sync: sync)
       @stacktrace_builder = stacktrace_builder
     end
     # rubocop:enable Metrics/ParameterLists

--- a/lib/elastic_apm/span/context.rb
+++ b/lib/elastic_apm/span/context.rb
@@ -4,8 +4,8 @@ module ElasticAPM
   class Span
     # @api private
     class Context
-      def initialize(db: nil, http: nil, labels: {})
-        @sync = true
+      def initialize(db: nil, http: nil, labels: {}, sync: nil)
+        @sync = sync
         @db = db && Db.new(db)
         @http = http && Http.new(http)
         @labels = labels

--- a/lib/elastic_apm/transaction.rb
+++ b/lib/elastic_apm/transaction.rb
@@ -78,6 +78,25 @@ module ElasticAPM
 
     # spans
 
+    def start_span(
+        name,
+        type = nil,
+        subtype: nil,
+        action: nil,
+        context: nil,
+        include_stacktrace: true,
+        trace_context: nil
+    )
+      ElasticAPM.start_span(name,
+                            type,
+                            subtype: subtype,
+                            action: action,
+                            context: context,
+                            include_stacktrace: include_stacktrace,
+                            trace_context: trace_context,
+                            transaction: self)
+    end
+
     def inc_started_spans!
       MUTEX.synchronize do
         @started_spans += 1

--- a/lib/elastic_apm/transaction.rb
+++ b/lib/elastic_apm/transaction.rb
@@ -78,25 +78,6 @@ module ElasticAPM
 
     # spans
 
-    def start_span(
-        name,
-        type = nil,
-        subtype: nil,
-        action: nil,
-        context: nil,
-        include_stacktrace: true,
-        trace_context: nil
-    )
-      ElasticAPM.start_span(name,
-                            type,
-                            subtype: subtype,
-                            action: action,
-                            context: context,
-                            include_stacktrace: include_stacktrace,
-                            trace_context: trace_context,
-                            transaction: self)
-    end
-
     def inc_started_spans!
       MUTEX.synchronize do
         @started_spans += 1
@@ -104,8 +85,8 @@ module ElasticAPM
           @dropped_spans += 1
           return false
         end
-        true
       end
+      true
     end
 
     # context

--- a/lib/elastic_apm/transaction.rb
+++ b/lib/elastic_apm/transaction.rb
@@ -10,6 +10,7 @@ module ElasticAPM
       :trace_id, :parent_id, :id, :ensure_parent_id
 
     DEFAULT_TYPE = 'custom'
+    MUTEX = Mutex.new
 
     # rubocop:disable Metrics/ParameterLists
     def initialize(
@@ -78,15 +79,15 @@ module ElasticAPM
     # spans
 
     def inc_started_spans!
-      @started_spans += 1
+      MUTEX.synchronize { @started_spans += 1 }
     end
 
     def inc_dropped_spans!
-      @dropped_spans += 1
+      MUTEX.synchronize { @dropped_spans += 1 }
     end
 
     def max_spans_reached?
-      started_spans > config.transaction_max_spans
+      MUTEX.synchronize { @started_spans > config.transaction_max_spans }
     end
 
     # context

--- a/lib/elastic_apm/transaction.rb
+++ b/lib/elastic_apm/transaction.rb
@@ -10,7 +10,8 @@ module ElasticAPM
       :trace_id, :parent_id, :id, :ensure_parent_id
 
     DEFAULT_TYPE = 'custom'
-    MUTEX = Mutex.new
+    STARTED_MUTEX = Mutex.new
+    DROPPED_MUTEX = Mutex.new
 
     # rubocop:disable Metrics/ParameterLists
     def initialize(
@@ -79,15 +80,15 @@ module ElasticAPM
     # spans
 
     def inc_started_spans!
-      MUTEX.synchronize { @started_spans += 1 }
-    end
-
-    def inc_dropped_spans!
-      MUTEX.synchronize { @dropped_spans += 1 }
+      STARTED_MUTEX.synchronize { @started_spans += 1 }
     end
 
     def max_spans_reached?
-      MUTEX.synchronize { @started_spans > config.transaction_max_spans }
+      STARTED_MUTEX.synchronize { @started_spans > config.transaction_max_spans }
+    end
+
+    def inc_dropped_spans!
+      DROPPED_MUTEX.synchronize { @dropped_spans += 1 }
     end
 
     # context

--- a/lib/elastic_apm/transport/serializers/span_serializer.rb
+++ b/lib/elastic_apm/transport/serializers/span_serializer.rb
@@ -34,7 +34,8 @@ module ElasticAPM
           def build(context)
             return unless context
 
-            { sync: context.sync }.tap do |base|
+            {}.tap do |base|
+              base[:sync] = context.sync unless context.sync.nil?
               base[:db] = build_db(context.db) if context.db
               base[:http] = build_http(context.http) if context.http
             end

--- a/spec/elastic_apm/agent_spec.rb
+++ b/spec/elastic_apm/agent_spec.rb
@@ -78,7 +78,7 @@ module ElasticAPM
               backtrace: nil,
               context: nil,
               trace_context: nil,
-              transaction: nil
+              parent: nil
             }
           ],
           end_span: nil,

--- a/spec/elastic_apm/agent_spec.rb
+++ b/spec/elastic_apm/agent_spec.rb
@@ -78,7 +78,8 @@ module ElasticAPM
               backtrace: nil,
               context: nil,
               trace_context: nil,
-              parent: nil
+              parent: nil,
+              sync: nil
             }
           ],
           end_span: nil,

--- a/spec/elastic_apm/agent_spec.rb
+++ b/spec/elastic_apm/agent_spec.rb
@@ -77,7 +77,8 @@ module ElasticAPM
               action: nil,
               backtrace: nil,
               context: nil,
-              trace_context: nil
+              trace_context: nil,
+              parent_transaction: nil
             }
           ],
           end_span: nil,

--- a/spec/elastic_apm/agent_spec.rb
+++ b/spec/elastic_apm/agent_spec.rb
@@ -78,7 +78,7 @@ module ElasticAPM
               backtrace: nil,
               context: nil,
               trace_context: nil,
-              parent_transaction: nil
+              transaction: nil
             }
           ],
           end_span: nil,

--- a/spec/elastic_apm/transaction_spec.rb
+++ b/spec/elastic_apm/transaction_spec.rb
@@ -103,30 +103,28 @@ module ElasticAPM
     end
 
     describe '#inc_started_spans!' do
-      it 'increments count' do
-        expect { subject.inc_started_spans! }
-          .to change(subject, :started_spans).by 1
-      end
-    end
-
-    describe '#inc_dropped_spans!' do
-      it 'increments count' do
-        expect { subject.inc_dropped_spans! }
-          .to change(subject, :dropped_spans).by 1
-      end
-    end
-
-    describe '#max_spans_reached?' do
-      let(:config) { Config.new(transaction_max_spans: 3) }
-      let(:result) { subject.max_spans_reached? }
-
-      context 'when below max' do
-        it { expect(result).to be false }
+      let!(:result) { subject.inc_started_spans! }
+      it 'increments started count' do
+        expect(subject.started_spans).to be(1)
       end
 
-      context 'when maximum reached' do
-        before { 4.times { subject.inc_started_spans! } }
-        it { expect(result).to be true }
+      it 'returns true' do
+        expect(result).to be true
+      end
+
+      context 'when max spans is reached' do
+        let(:config) { Config.new(transaction_max_spans: 3) }
+        let!(:result) do
+          3.times { subject.inc_started_spans! }
+          subject.inc_started_spans!
+        end
+        it 'increments dropped spans' do
+          expect(subject.dropped_spans).to be(1)
+        end
+
+        it 'returns false' do
+          expect(result).to be false
+        end
       end
     end
 

--- a/spec/elastic_apm/transaction_spec.rb
+++ b/spec/elastic_apm/transaction_spec.rb
@@ -135,30 +135,5 @@ module ElasticAPM
         expect(subject.context.response.headers).to match('Ok' => 'yes')
       end
     end
-
-    describe '#start_span' do
-      before { ElasticAPM.start }
-      after { ElasticAPM.stop }
-      context 'async spans' do
-        it 'can attach a span to a specific transaction' do
-          transaction = ElasticAPM.start_transaction
-          span1 = ElasticAPM.start_span 'Thread1'
-
-          span2 = Thread.new do
-            transaction.start_span 'Thread2'
-          end.value
-
-          span3 = Thread.new do
-            transaction.start_span 'Thread3'
-          end.value
-
-          expect(ElasticAPM.current_transaction.started_spans).to eq(3)
-          expect(span1.parent_id).to eq(span2.parent_id)
-          expect(span1.parent_id).to eq(span3.parent_id)
-          expect(span2.parent_id).to eq(transaction.trace_context.child.parent_id)
-          expect(span3.parent_id).to eq(transaction.trace_context.child.parent_id)
-        end
-      end
-    end
   end
 end

--- a/spec/elastic_apm/transaction_spec.rb
+++ b/spec/elastic_apm/transaction_spec.rb
@@ -135,5 +135,30 @@ module ElasticAPM
         expect(subject.context.response.headers).to match('Ok' => 'yes')
       end
     end
+
+    describe '#start_span' do
+      before { ElasticAPM.start }
+      after { ElasticAPM.stop }
+      context 'async spans' do
+        it 'can attach a span to a specific transaction' do
+          transaction = ElasticAPM.start_transaction
+          span1 = ElasticAPM.start_span 'Thread1'
+
+          span2 = Thread.new do
+            transaction.start_span 'Thread2'
+          end.value
+
+          span3 = Thread.new do
+            transaction.start_span 'Thread3'
+          end.value
+
+          expect(ElasticAPM.current_transaction.started_spans).to eq(3)
+          expect(span1.parent_id).to eq(span2.parent_id)
+          expect(span1.parent_id).to eq(span3.parent_id)
+          expect(span2.parent_id).to eq(transaction.trace_context.child.parent_id)
+          expect(span3.parent_id).to eq(transaction.trace_context.child.parent_id)
+        end
+      end
+    end
   end
 end

--- a/spec/elastic_apm/transport/serializers/span_serializer_spec.rb
+++ b/spec/elastic_apm/transport/serializers/span_serializer_spec.rb
@@ -89,7 +89,7 @@ module ElasticAPM
                 expect(result.dig(:span, :context, :db, :statement))
                   .to eq 'asd'
                 expect(result.dig(:span, :context, :http, :url)).to eq 'dsa'
-                expect(result.dig(:span, :context, :sync)).to be nil
+                expect(result[:span][:context].has_key?(:sync)).to be false
               end
             end
           end

--- a/spec/elastic_apm/transport/serializers/span_serializer_spec.rb
+++ b/spec/elastic_apm/transport/serializers/span_serializer_spec.rb
@@ -21,7 +21,8 @@ module ElasticAPM
               name: 'Span',
               transaction: transaction,
               parent: transaction,
-              trace_context: trace_context
+              trace_context: trace_context,
+              sync: true
             ).tap do |span|
               span.start
               travel 10_000
@@ -57,7 +58,8 @@ module ElasticAPM
                 trace_context: trace_context,
                 context: Span::Context.new(
                   db: { statement: 'asd' },
-                  http: { url: 'dsa' }
+                  http: { url: 'dsa' },
+                  sync: false
                 )
               )
             end
@@ -66,6 +68,29 @@ module ElasticAPM
               expect(result.dig(:span, :context, :db, :statement))
                 .to eq 'asd'
               expect(result.dig(:span, :context, :http, :url)).to eq 'dsa'
+              expect(result.dig(:span, :context, :sync)).to eq false
+            end
+
+            context 'when sync is nil' do
+              let(:span) do
+                Span.new(
+                  name: 'Span',
+                  transaction: transaction,
+                  parent: transaction,
+                  trace_context: trace_context,
+                  context: Span::Context.new(
+                    db: { statement: 'asd' },
+                    http: { url: 'dsa' }
+                  )
+                )
+              end
+
+              it 'adds context object' do
+                expect(result.dig(:span, :context, :db, :statement))
+                  .to eq 'asd'
+                expect(result.dig(:span, :context, :http, :url)).to eq 'dsa'
+                expect(result.dig(:span, :context, :sync)).to be nil
+              end
             end
           end
 

--- a/spec/elastic_apm/transport/serializers/span_serializer_spec.rb
+++ b/spec/elastic_apm/transport/serializers/span_serializer_spec.rb
@@ -89,7 +89,7 @@ module ElasticAPM
                 expect(result.dig(:span, :context, :db, :statement))
                   .to eq 'asd'
                 expect(result.dig(:span, :context, :http, :url)).to eq 'dsa'
-                expect(result[:span][:context].has_key?(:sync)).to be false
+                expect(result[:span][:context].key?(:sync)).to be false
               end
             end
           end

--- a/spec/elastic_apm_spec.rb
+++ b/spec/elastic_apm_spec.rb
@@ -258,7 +258,6 @@ RSpec.describe ElasticAPM do
         with_agent do
           transaction = ElasticAPM.start_transaction
           span1 = ElasticAPM.with_span 'run all the jobs' do |span|
-
             span2 = Thread.new do
               ElasticAPM.with_span('job 1', parent: span) { |s| s }
             end.value

--- a/spec/elastic_apm_spec.rb
+++ b/spec/elastic_apm_spec.rb
@@ -190,6 +190,24 @@ RSpec.describe ElasticAPM do
           expect(span2.parent_id).to eq(transaction.trace_context.child.parent_id)
         end
       end
+
+      context '#with_span' do
+        it 'allows async spans' do
+          transaction = ElasticAPM.start_transaction
+          span1 = Thread.new do
+            ElasticAPM.with_span('job 1', parent: transaction) { |span| span }
+          end.value
+
+          span2 = Thread.new do
+            ElasticAPM.with_span('job 2', parent: transaction) { |span| span }
+          end.value
+
+          expect(ElasticAPM.current_transaction.started_spans).to eq(2)
+          expect(span1.parent_id).to eq(span2.parent_id)
+          expect(span1.parent_id).to eq(transaction.trace_context.child.parent_id)
+          expect(span2.parent_id).to eq(transaction.trace_context.child.parent_id)
+        end
+      end
     end
 
     context 'span parent' do

--- a/spec/elastic_apm_spec.rb
+++ b/spec/elastic_apm_spec.rb
@@ -248,6 +248,7 @@ RSpec.describe ElasticAPM do
             span
           end
           transaction.done
+
           expect(transaction.started_spans).to eq(3)
           expect(span1.parent_id).to eq(
             transaction.trace_context.child.parent_id

--- a/spec/elastic_apm_spec.rb
+++ b/spec/elastic_apm_spec.rb
@@ -204,8 +204,9 @@ RSpec.describe ElasticAPM do
             span2 = Thread.new do
               ElasticAPM.with_span('job 2', parent: transaction) { |span| span }
             end.value
+            transaction.done
 
-            expect(ElasticAPM.current_transaction.started_spans).to eq(2)
+            expect(transaction.started_spans).to eq(2)
             expect(span1.parent_id).to eq(span2.parent_id)
             expect(span1.parent_id).to eq(transaction.trace_context.child.parent_id)
             expect(span2.parent_id).to eq(transaction.trace_context.child.parent_id)
@@ -232,7 +233,8 @@ RSpec.describe ElasticAPM do
             expect(span3.parent_id).to eq(span.trace_context.child.parent_id)
             span
           end
-          expect(ElasticAPM.current_transaction.started_spans).to eq(3)
+          transaction.done
+          expect(transaction.started_spans).to eq(3)
           expect(span1.parent_id).to eq(transaction.trace_context.child.parent_id)
         end
       end

--- a/spec/elastic_apm_spec.rb
+++ b/spec/elastic_apm_spec.rb
@@ -98,21 +98,6 @@ RSpec.describe ElasticAPM do
         expect(ElasticAPM.agent).to receive(:start_span)
         ElasticAPM.start_span 'Test'
       end
-
-      context 'async spans' do
-        it 'can attach a span to a specific transaction' do
-          transaction = ElasticAPM.start_transaction
-          span1 = ElasticAPM.start_span 'Thread1'
-
-          span2 = Thread.new do
-            ElasticAPM.start_span 'Thread2', transaction: transaction
-          end.value
-
-          expect(ElasticAPM.current_transaction.started_spans).to eq(2)
-          expect(span1.parent_id).to eq(span2.parent_id)
-          expect(span2.parent_id).to eq(transaction.trace_context.child.parent_id)
-        end
-      end
     end
 
     describe '.end_span' do

--- a/spec/elastic_apm_spec.rb
+++ b/spec/elastic_apm_spec.rb
@@ -105,7 +105,7 @@ RSpec.describe ElasticAPM do
           span1 = ElasticAPM.start_span 'Thread1'
 
           span2 = Thread.new do
-            ElasticAPM.start_span 'Thread2', parent_transaction: transaction
+            ElasticAPM.start_span 'Thread2', transaction: transaction
           end.value
 
           expect(ElasticAPM.current_transaction.started_spans).to eq(2)

--- a/spec/elastic_apm_spec.rb
+++ b/spec/elastic_apm_spec.rb
@@ -158,11 +158,11 @@ RSpec.describe ElasticAPM do
         with_agent do
           transaction = ElasticAPM.start_transaction
           span1 = Thread.new do
-            ElasticAPM.start_span('job 1', parent: transaction)
+            ElasticAPM.with_span('job 1', parent: transaction) { |span| span }
           end.value
 
           span2 = Thread.new do
-            ElasticAPM.start_span('job 2', parent: transaction)
+            ElasticAPM.with_span('job 2', parent: transaction) { |span| span }
           end.value
           transaction.done
 
@@ -183,11 +183,11 @@ RSpec.describe ElasticAPM do
             transaction = ElasticAPM.start_transaction
             transaction.done
             span1 = Thread.new do
-              ElasticAPM.start_span('job 1', parent: transaction)
+              ElasticAPM.with_span('job 1', parent: transaction) { |span| span }
             end.value
 
             span2 = Thread.new do
-              ElasticAPM.start_span('job 2', parent: transaction)
+              ElasticAPM.with_span('job 2', parent: transaction) { |span| span }
             end.value
             transaction.done
 
@@ -237,12 +237,12 @@ RSpec.describe ElasticAPM do
             allow(span).to receive(:transaction).and_return(transaction)
 
             span2 = Thread.new do
-              ElasticAPM.start_span('job 1', parent: span)
+              ElasticAPM.with_span('job 1', parent: span) { |s| s }
             end.value
             expect(span2.parent_id).to eq(span.trace_context.child.parent_id)
 
             span3 = Thread.new do
-              ElasticAPM.start_span('job 2', parent: span)
+              ElasticAPM.with_span('job 2', parent: span) { |s| s }
             end.value
             expect(span3.parent_id).to eq(span.trace_context.child.parent_id)
             span

--- a/spec/elastic_apm_spec.rb
+++ b/spec/elastic_apm_spec.rb
@@ -164,8 +164,9 @@ RSpec.describe ElasticAPM do
           span2 = Thread.new do
             ElasticAPM.start_span('job 2', parent: transaction)
           end.value
+          transaction.done
 
-          expect(ElasticAPM.current_transaction.started_spans).to eq(2)
+          expect(transaction.started_spans).to eq(2)
           expect(span1.parent_id).to eq(span2.parent_id)
           expect(span1.parent_id).to eq(transaction.trace_context.child.parent_id)
           expect(span2.parent_id).to eq(transaction.trace_context.child.parent_id)
@@ -184,8 +185,9 @@ RSpec.describe ElasticAPM do
             span2 = Thread.new do
               ElasticAPM.start_span('job 2', parent: transaction)
             end.value
+            transaction.done
 
-            expect(ElasticAPM.current_transaction.started_spans).to eq(2)
+            expect(transaction.started_spans).to eq(2)
             expect(span1.parent_id).to eq(span2.parent_id)
             expect(span1.parent_id).to eq(transaction.trace_context.child.parent_id)
             expect(span2.parent_id).to eq(transaction.trace_context.child.parent_id)

--- a/spec/elastic_apm_spec.rb
+++ b/spec/elastic_apm_spec.rb
@@ -152,30 +152,11 @@ RSpec.describe ElasticAPM do
     after { ElasticAPM.stop }
   end
 
-  context 'async spans' do
-    before { ElasticAPM.start }
-    after { ElasticAPM.stop }
+  context 'async spans', :intercept do
     context 'transaction parent' do
       it 'allows async spans' do
-        transaction = ElasticAPM.start_transaction
-        span1 = Thread.new do
-          ElasticAPM.start_span('job 1', parent: transaction)
-        end.value
-
-        span2 = Thread.new do
-          ElasticAPM.start_span('job 2', parent: transaction)
-        end.value
-
-        expect(ElasticAPM.current_transaction.started_spans).to eq(2)
-        expect(span1.parent_id).to eq(span2.parent_id)
-        expect(span1.parent_id).to eq(transaction.trace_context.child.parent_id)
-        expect(span2.parent_id).to eq(transaction.trace_context.child.parent_id)
-      end
-
-      context 'span created after transaction is ended' do
-        it 'allows async spans' do
+        with_agent do
           transaction = ElasticAPM.start_transaction
-          transaction.done
           span1 = Thread.new do
             ElasticAPM.start_span('job 1', parent: transaction)
           end.value
@@ -191,44 +172,69 @@ RSpec.describe ElasticAPM do
         end
       end
 
+      context 'span created after transaction is ended' do
+        it 'allows async spans' do
+          with_agent do
+            transaction = ElasticAPM.start_transaction
+            transaction.done
+            span1 = Thread.new do
+              ElasticAPM.start_span('job 1', parent: transaction)
+            end.value
+
+            span2 = Thread.new do
+              ElasticAPM.start_span('job 2', parent: transaction)
+            end.value
+
+            expect(ElasticAPM.current_transaction.started_spans).to eq(2)
+            expect(span1.parent_id).to eq(span2.parent_id)
+            expect(span1.parent_id).to eq(transaction.trace_context.child.parent_id)
+            expect(span2.parent_id).to eq(transaction.trace_context.child.parent_id)
+          end
+        end
+      end
+
       context '#with_span' do
         it 'allows async spans' do
-          transaction = ElasticAPM.start_transaction
-          span1 = Thread.new do
-            ElasticAPM.with_span('job 1', parent: transaction) { |span| span }
-          end.value
+          with_agent do
+            transaction = ElasticAPM.start_transaction
+            span1 = Thread.new do
+              ElasticAPM.with_span('job 1', parent: transaction) { |span| span }
+            end.value
 
-          span2 = Thread.new do
-            ElasticAPM.with_span('job 2', parent: transaction) { |span| span }
-          end.value
+            span2 = Thread.new do
+              ElasticAPM.with_span('job 2', parent: transaction) { |span| span }
+            end.value
 
-          expect(ElasticAPM.current_transaction.started_spans).to eq(2)
-          expect(span1.parent_id).to eq(span2.parent_id)
-          expect(span1.parent_id).to eq(transaction.trace_context.child.parent_id)
-          expect(span2.parent_id).to eq(transaction.trace_context.child.parent_id)
+            expect(ElasticAPM.current_transaction.started_spans).to eq(2)
+            expect(span1.parent_id).to eq(span2.parent_id)
+            expect(span1.parent_id).to eq(transaction.trace_context.child.parent_id)
+            expect(span2.parent_id).to eq(transaction.trace_context.child.parent_id)
+          end
         end
       end
     end
 
     context 'span parent' do
       it 'allows async spans' do
-        transaction = ElasticAPM.start_transaction
-        span1 = ElasticAPM.with_span 'run all the jobs' do |span|
-          allow(span).to receive(:transaction).and_return(transaction)
+        with_agent do
+          transaction = ElasticAPM.start_transaction
+          span1 = ElasticAPM.with_span 'run all the jobs' do |span|
+            allow(span).to receive(:transaction).and_return(transaction)
 
-          span2 = Thread.new do
-            ElasticAPM.start_span('job 1', parent: span)
-          end.value
-          expect(span2.parent_id).to eq(span.trace_context.child.parent_id)
+            span2 = Thread.new do
+              ElasticAPM.start_span('job 1', parent: span)
+            end.value
+            expect(span2.parent_id).to eq(span.trace_context.child.parent_id)
 
-          span3 = Thread.new do
-            ElasticAPM.start_span('job 2', parent: span)
-          end.value
-          expect(span3.parent_id).to eq(span.trace_context.child.parent_id)
-          span
+            span3 = Thread.new do
+              ElasticAPM.start_span('job 2', parent: span)
+            end.value
+            expect(span3.parent_id).to eq(span.trace_context.child.parent_id)
+            span
+          end
+          expect(ElasticAPM.current_transaction.started_spans).to eq(3)
+          expect(span1.parent_id).to eq(transaction.trace_context.child.parent_id)
         end
-        expect(ElasticAPM.current_transaction.started_spans).to eq(3)
-        expect(span1.parent_id).to eq(transaction.trace_context.child.parent_id)
       end
     end
   end

--- a/spec/elastic_apm_spec.rb
+++ b/spec/elastic_apm_spec.rb
@@ -168,8 +168,12 @@ RSpec.describe ElasticAPM do
 
           expect(transaction.started_spans).to eq(2)
           expect(span1.parent_id).to eq(span2.parent_id)
-          expect(span1.parent_id).to eq(transaction.trace_context.child.parent_id)
-          expect(span2.parent_id).to eq(transaction.trace_context.child.parent_id)
+          expect(span1.parent_id).to eq(
+            transaction.trace_context.child.parent_id
+          )
+          expect(span2.parent_id).to eq(
+            transaction.trace_context.child.parent_id
+          )
         end
       end
 
@@ -189,8 +193,12 @@ RSpec.describe ElasticAPM do
 
             expect(transaction.started_spans).to eq(2)
             expect(span1.parent_id).to eq(span2.parent_id)
-            expect(span1.parent_id).to eq(transaction.trace_context.child.parent_id)
-            expect(span2.parent_id).to eq(transaction.trace_context.child.parent_id)
+            expect(span1.parent_id).to eq(
+              transaction.trace_context.child.parent_id
+            )
+            expect(span2.parent_id).to eq(
+              transaction.trace_context.child.parent_id
+            )
           end
         end
       end
@@ -210,8 +218,12 @@ RSpec.describe ElasticAPM do
 
             expect(transaction.started_spans).to eq(2)
             expect(span1.parent_id).to eq(span2.parent_id)
-            expect(span1.parent_id).to eq(transaction.trace_context.child.parent_id)
-            expect(span2.parent_id).to eq(transaction.trace_context.child.parent_id)
+            expect(span1.parent_id).to eq(
+              transaction.trace_context.child.parent_id
+            )
+            expect(span2.parent_id).to eq(
+              transaction.trace_context.child.parent_id
+            )
           end
         end
       end
@@ -237,7 +249,9 @@ RSpec.describe ElasticAPM do
           end
           transaction.done
           expect(transaction.started_spans).to eq(3)
-          expect(span1.parent_id).to eq(transaction.trace_context.child.parent_id)
+          expect(span1.parent_id).to eq(
+            transaction.trace_context.child.parent_id
+          )
         end
       end
     end


### PR DESCRIPTION
The allows a span to be started in a thread with a parent from another thread.
It introduces a parm `parent` to `start_span` to achieve this.

It also exposes an attribute `sync` to be set when a span is created. The value for this field was previously *always* `true` but now the default is `nil` and it can be set by the user.

Closes elastic/apm-agent-ruby#369 