### PR TITLE
Shuffle spec order on each run

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -28,6 +28,8 @@ Concurrent.use_stdlib_logger(Logger::DEBUG)
 Thread.abort_on_exception = true
 
 RSpec.configure do |config|
+  config.order = :random
+
   config.include ExceptionHelpers
   config.include WithAgent
   config.include PlatformHelpers


### PR DESCRIPTION
It might help us dig out unwanted inconsistencies in the specs. Or it might be annoying or confusing. I'm for it, _wdyt_ @estolfo?