### PR TITLE
Make sure to close spans after tests in OpenTracing spec

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,8 +4,6 @@ source 'https://rubygems.org'
 
 git_source(:github) { |repo_name| "https://github.com/#{repo_name}" }
 
-gemspec
-
 gem 'rack-test'
 gem 'rspec'
 gem 'rspec-its'
@@ -65,3 +63,5 @@ group :bench do
   gem 'ruby-prof', require: nil, platforms: %i[ruby]
   gem 'stackprof', require: nil, platforms: %i[ruby]
 end
+
+gemspec

--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,8 @@ source 'https://rubygems.org'
 
 git_source(:github) { |repo_name| "https://github.com/#{repo_name}" }
 
+gemspec
+
 gem 'rack-test'
 gem 'rspec'
 gem 'rspec-its'
@@ -63,5 +65,3 @@ group :bench do
   gem 'ruby-prof', require: nil, platforms: %i[ruby]
   gem 'stackprof', require: nil, platforms: %i[ruby]
 end
-
-gemspec

--- a/lib/elastic_apm.rb
+++ b/lib/elastic_apm.rb
@@ -1,5 +1,15 @@
 # frozen_string_literal: true
 
+require 'erb'
+require 'http'
+require 'json'
+require 'yaml'
+require 'zlib'
+require 'logger'
+require 'concurrent'
+require 'forwardable'
+require 'securerandom'
+
 require 'elastic_apm/version'
 require 'elastic_apm/internal_error'
 require 'elastic_apm/logging'

--- a/lib/elastic_apm/central_config.rb
+++ b/lib/elastic_apm/central_config.rb
@@ -122,7 +122,7 @@ module ElasticAPM
     end
 
     def perform_request
-      Http.post(
+      HTTP.post(
         config.server_url + '/config/v1/agents',
         body: @service_info,
         headers: { etag: 1, content_type: 'application/json' }

--- a/lib/elastic_apm/config.rb
+++ b/lib/elastic_apm/config.rb
@@ -1,9 +1,5 @@
 # frozen_string_literal: true
 
-require 'logger'
-require 'yaml'
-require 'erb'
-
 require 'elastic_apm/util/prefixed_logger'
 
 require 'elastic_apm/config/options'

--- a/lib/elastic_apm/logging.rb
+++ b/lib/elastic_apm/logging.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'logger'
-
 module ElasticAPM
   # @api private
   module Logging

--- a/lib/elastic_apm/span.rb
+++ b/lib/elastic_apm/span.rb
@@ -1,8 +1,5 @@
 # frozen_string_literal: true
 
-require 'securerandom'
-require 'forwardable'
-
 require 'elastic_apm/span/context'
 
 module ElasticAPM

--- a/lib/elastic_apm/spies.rb
+++ b/lib/elastic_apm/spies.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require 'forwardable'
 require 'elastic_apm/util/inflector'
 
 module ElasticAPM

--- a/lib/elastic_apm/transaction.rb
+++ b/lib/elastic_apm/transaction.rb
@@ -1,8 +1,5 @@
 # frozen_string_literal: true
 
-require 'securerandom'
-require 'forwardable'
-
 module ElasticAPM
   # @api private
   class Transaction

--- a/lib/elastic_apm/transport/connection.rb
+++ b/lib/elastic_apm/transport/connection.rb
@@ -1,8 +1,5 @@
 # frozen_string_literal: true
 
-require 'concurrent'
-require 'zlib'
-
 require 'elastic_apm/transport/connection/http'
 
 module ElasticAPM

--- a/lib/elastic_apm/transport/connection/http.rb
+++ b/lib/elastic_apm/transport/connection/http.rb
@@ -1,9 +1,5 @@
 # frozen_string_literal: true
 
-require 'http'
-require 'concurrent'
-require 'zlib'
-
 require 'elastic_apm/transport/connection/proxy_pipe'
 
 module ElasticAPM

--- a/lib/elastic_apm/transport/connection/proxy_pipe.rb
+++ b/lib/elastic_apm/transport/connection/proxy_pipe.rb
@@ -1,8 +1,5 @@
 # frozen_string_literal: true
 
-require 'concurrent'
-require 'zlib'
-
 module ElasticAPM
   module Transport
     class Connection

--- a/lib/elastic_apm/transport/serializers.rb
+++ b/lib/elastic_apm/transport/serializers.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'json'
-
 module ElasticAPM
   module Transport
     # @api private

--- a/spec/integration/opentracing_spec.rb
+++ b/spec/integration/opentracing_spec.rb
@@ -35,6 +35,7 @@ RSpec.describe 'OpenTracing bridge', :intercept do
     describe '#start_span' do
       context 'as root' do
         subject! { ::OpenTracing.start_span('namest') }
+        after { subject.finish }
 
         it { should be_an ElasticAPM::OpenTracing::Span }
         its(:elastic_span) { should be_an ElasticAPM::Transaction }
@@ -48,6 +49,10 @@ RSpec.describe 'OpenTracing bridge', :intercept do
       context 'as a child' do
         let(:parent) { ::OpenTracing.start_span('parent') }
         subject! { ::OpenTracing.start_span('namest', child_of: parent) }
+        after do
+          subject.finish
+          parent.finish
+        end
 
         its(:context) { should be parent.context }
         its(:elastic_span) { should be_a ElasticAPM::Span }
@@ -57,6 +62,7 @@ RSpec.describe 'OpenTracing bridge', :intercept do
     describe '#start_active_span' do
       context 'as root' do
         subject! { ::OpenTracing.start_active_span('namest') }
+        after { subject.close }
 
         it { should be_an ElasticAPM::OpenTracing::Scope }
         its(:elastic_span) { should be_a ElasticAPM::Transaction }
@@ -69,6 +75,10 @@ RSpec.describe 'OpenTracing bridge', :intercept do
       context 'as child_of' do
         let(:parent) { ::OpenTracing.start_span('parent') }
         subject! { ::OpenTracing.start_active_span('namest', child_of: parent) }
+        after do
+          subject.close
+          parent.finish
+        end
 
         it 'is the correct span' do
           expect(subject.span.elastic_span).to be_an ElasticAPM::Span

--- a/spec/integration/opentracing_spec.rb
+++ b/spec/integration/opentracing_spec.rb
@@ -93,8 +93,10 @@ RSpec.describe 'OpenTracing bridge', :intercept do
     describe 'activation' do
       it 'sets the span as active in scope' do
         span = OpenTracing.start_span('name')
-        OpenTracing.scope_manager.activate(span)
+        scope = OpenTracing.scope_manager.activate(span)
         expect(OpenTracing.active_span).to be span
+
+        scope.close
       end
     end
 


### PR DESCRIPTION
I think yesterdays CI failures were due to some OT spans bleeding into the following examples. This should fix.