### PR TITLE
Lazy load ActiveRecord adapter in SQL normalizer

### DIFF
--- a/lib/elastic_apm/normalizers/rails/active_record.rb
+++ b/lib/elastic_apm/normalizers/rails/active_record.rb
@@ -15,7 +15,6 @@ module ElasticAPM
         def initialize(*args)
           super
 
-          @subtype = lookup_adapter || 'unknown'
           @summarizer = SqlSummarizer.new
         end
 
@@ -25,10 +24,14 @@ module ElasticAPM
           name = summarize(payload[:sql]) || payload[:name]
           context =
             Span::Context.new(db: { statement: payload[:sql], type: 'sql' })
-          [name, TYPE, @subtype, ACTION, context]
+          [name, TYPE, subtype, ACTION, context]
         end
 
         private
+
+        def subtype
+          @subtype ||= (lookup_adapter || 'unknown')
+        end
 
         def summarize(sql)
           @summarizer.summarize(sql)


### PR DESCRIPTION
Hello,

I've installed and configured the gem to test in our organization and we hit a strange issue with our configuration. We set the database settings during Rails' initialization process and due to a case how we run the background workers (using forking approach) the database credentials are available after Rails is fully booted. But the current code will force the AR adapter to initialize a collection and break. I know it's an edge case, but I think it's safer to lazy load the AR connection call when you actually try to track an SQL.