### PR TITLE
Use the connection from payload to get adapter, when available

### DIFF
--- a/lib/elastic_apm/normalizers/rails/active_record.rb
+++ b/lib/elastic_apm/normalizers/rails/active_record.rb
@@ -32,9 +32,9 @@ module ElasticAPM
         private
 
         def subtype(payload)
-          return connection_adapter(payload[:connection]) if payload.key?(:connection)
-
-          @default_adapter ||= connection_adapter(::ActiveRecord::Base.connection)
+          connection_adapter(
+            payload[:connection] ||::ActiveRecord::Base.connection
+          )
         end
 
         def summarize(sql)
@@ -42,7 +42,10 @@ module ElasticAPM
         end
 
         def connection_adapter(connection)
-          connection.adapter_name.downcase || UNKNOWN
+          @adapters ||= {}
+          return UNKNOWN unless connection.adapter_name
+          @adapters[connection.adapter_name] ||
+            (@adapters[connection.adapter_name] = connection.adapter_name.downcase)
         rescue StandardError
           nil
         end

--- a/lib/elastic_apm/normalizers/rails/active_record.rb
+++ b/lib/elastic_apm/normalizers/rails/active_record.rb
@@ -33,7 +33,7 @@ module ElasticAPM
 
         def subtype(payload)
           connection_adapter(
-            payload[:connection] ||::ActiveRecord::Base.connection
+            payload[:connection] || ::ActiveRecord::Base.connection
           )
         end
 
@@ -41,11 +41,11 @@ module ElasticAPM
           @summarizer.summarize(sql)
         end
 
-        def connection_adapter(connection)
+        def connection_adapter(conn)
           @adapters ||= {}
-          return UNKNOWN unless connection.adapter_name
-          @adapters[connection.adapter_name] ||
-            (@adapters[connection.adapter_name] = connection.adapter_name.downcase)
+          return UNKNOWN unless conn.adapter_name
+          @adapters[conn.adapter_name] ||
+            (@adapters[conn.adapter_name] = conn.adapter_name.downcase)
         rescue StandardError
           nil
         end

--- a/lib/elastic_apm/normalizers/rails/active_record.rb
+++ b/lib/elastic_apm/normalizers/rails/active_record.rb
@@ -12,7 +12,7 @@ module ElasticAPM
         TYPE = 'db'
         ACTION = 'sql'
         SKIP_NAMES = %w[SCHEMA CACHE].freeze
-        UNKNOWN = 'unknown'.freeze
+        UNKNOWN = 'unknown'
 
         def initialize(*args)
           super

--- a/lib/elastic_apm/normalizers/rails/active_record.rb
+++ b/lib/elastic_apm/normalizers/rails/active_record.rb
@@ -18,6 +18,7 @@ module ElasticAPM
           super
 
           @summarizer = SqlSummarizer.new
+          @adapters = {}
         end
 
         def normalize(_transaction, _name, payload)
@@ -42,7 +43,6 @@ module ElasticAPM
         end
 
         def connection_adapter(conn)
-          @adapters ||= {}
           return UNKNOWN unless conn.adapter_name
           @adapters[conn.adapter_name] ||
             (@adapters[conn.adapter_name] = conn.adapter_name.downcase)

--- a/spec/elastic_apm/normalizers/active_record_spec.rb
+++ b/spec/elastic_apm/normalizers/active_record_spec.rb
@@ -42,6 +42,8 @@ module ElasticAPM
           end
 
           it 'normalizes queries' do
+            allow(::ActiveRecord::Base)
+                .to receive(:connection) { double(adapter_name: nil) }
             sql = 'SELECT  "hotdogs".* FROM "hotdogs" ' \
               'WHERE "hotdogs"."topping" = $1 LIMIT 1'
 
@@ -54,6 +56,8 @@ module ElasticAPM
           end
 
           it 'uses the connection from payload, when available' do
+            allow(::ActiveRecord::Base)
+              .to receive(:connection) { double(adapter_name: nil) }
             sql = 'SELECT  "burgers".* FROM "burgers" ' \
               'WHERE "burgers"."cheese" = $1 LIMIT 1'
 
@@ -79,15 +83,15 @@ module ElasticAPM
             expect(action).to eq 'sql'
             expect(context_.db.statement).to eq sql
 
-            sql = 'SELECT  "burgers".* FROM "burgers" ' \
-              'WHERE "burgers"."cheese" = $1 LIMIT 1'
+            sql = 'SELECT  "pizza".* FROM "pizza" ' \
+              'WHERE "pizza"."topping" = $1 LIMIT 1'
 
             name, type, subtype, action, context_ = normalize_payload(
               sql: sql,
               connection: double(adapter_name: nil)
             )
 
-            expect(name).to eq 'SELECT FROM burgers'
+            expect(name).to eq 'SELECT FROM pizza'
             expect(type).to eq 'db'
             expect(subtype).to eq 'unknown'
             expect(action).to eq 'sql'

--- a/spec/elastic_apm/normalizers/active_record_spec.rb
+++ b/spec/elastic_apm/normalizers/active_record_spec.rb
@@ -56,46 +56,28 @@ module ElasticAPM
           end
 
           it 'uses the connection from payload, when available' do
-            allow(::ActiveRecord::Base)
-              .to receive(:connection) { double(adapter_name: nil) }
             sql = 'SELECT  "burgers".* FROM "burgers" ' \
               'WHERE "burgers"."cheese" = $1 LIMIT 1'
 
-            name, type, subtype, action, context_ = normalize_payload(
+            _name, _type, subtype, = normalize_payload(
               sql: sql,
               connection: double(adapter_name: 'MySQL')
             )
-
-            expect(name).to eq 'SELECT FROM burgers'
-            expect(type).to eq 'db'
             expect(subtype).to eq 'mysql'
-            expect(action).to eq 'sql'
-            expect(context_.db.statement).to eq sql
 
-            name, type, subtype, action, context_ = normalize_payload(
+            _name, _type, subtype, = normalize_payload(
               sql: sql,
               connection: double(adapter_name: 'Postgres')
             )
-
-            expect(name).to eq 'SELECT FROM burgers'
-            expect(type).to eq 'db'
             expect(subtype).to eq 'postgres'
-            expect(action).to eq 'sql'
-            expect(context_.db.statement).to eq sql
 
-            sql = 'SELECT  "pizza".* FROM "pizza" ' \
-              'WHERE "pizza"."topping" = $1 LIMIT 1'
-
-            name, type, subtype, action, context_ = normalize_payload(
+            allow(::ActiveRecord::Base)
+              .to receive(:connection) { double(adapter_name: nil) }
+            _name, _type, subtype, = normalize_payload(
               sql: sql,
               connection: double(adapter_name: nil)
             )
-
-            expect(name).to eq 'SELECT FROM pizza'
-            expect(type).to eq 'db'
             expect(subtype).to eq 'unknown'
-            expect(action).to eq 'sql'
-            expect(context_.db.statement).to eq sql
           end
 
           it 'skips cache queries' do

--- a/spec/elastic_apm/normalizers/active_record_spec.rb
+++ b/spec/elastic_apm/normalizers/active_record_spec.rb
@@ -43,7 +43,7 @@ module ElasticAPM
 
           it 'normalizes queries' do
             allow(::ActiveRecord::Base)
-                .to receive(:connection) { double(adapter_name: nil) }
+              .to receive(:connection) { double(adapter_name: nil) }
             sql = 'SELECT  "hotdogs".* FROM "hotdogs" ' \
               'WHERE "hotdogs"."topping" = $1 LIMIT 1'
 

--- a/spec/elastic_apm/normalizers/active_record_spec.rb
+++ b/spec/elastic_apm/normalizers/active_record_spec.rb
@@ -61,9 +61,35 @@ module ElasticAPM
               sql: sql,
               connection: double(adapter_name: 'MySQL')
             )
+
             expect(name).to eq 'SELECT FROM burgers'
             expect(type).to eq 'db'
             expect(subtype).to eq 'mysql'
+            expect(action).to eq 'sql'
+            expect(context_.db.statement).to eq sql
+
+            name, type, subtype, action, context_ = normalize_payload(
+              sql: sql,
+              connection: double(adapter_name: 'Postgres')
+            )
+
+            expect(name).to eq 'SELECT FROM burgers'
+            expect(type).to eq 'db'
+            expect(subtype).to eq 'postgres'
+            expect(action).to eq 'sql'
+            expect(context_.db.statement).to eq sql
+
+            sql = 'SELECT  "burgers".* FROM "burgers" ' \
+              'WHERE "burgers"."cheese" = $1 LIMIT 1'
+
+            name, type, subtype, action, context_ = normalize_payload(
+              sql: sql,
+              connection: double(adapter_name: nil)
+            )
+
+            expect(name).to eq 'SELECT FROM burgers'
+            expect(type).to eq 'db'
+            expect(subtype).to eq 'unknown'
             expect(action).to eq 'sql'
             expect(context_.db.statement).to eq sql
           end

--- a/spec/elastic_apm/normalizers/active_record_spec.rb
+++ b/spec/elastic_apm/normalizers/active_record_spec.rb
@@ -53,6 +53,21 @@ module ElasticAPM
             expect(context_.db.statement).to eq sql
           end
 
+          it 'uses the connection from payload, when available' do
+            sql = 'SELECT  "burgers".* FROM "burgers" ' \
+              'WHERE "burgers"."cheese" = $1 LIMIT 1'
+
+            name, type, subtype, action, context_ = normalize_payload(
+              sql: sql,
+              connection: double(adapter_name: 'MySQL')
+            )
+            expect(name).to eq 'SELECT FROM burgers'
+            expect(type).to eq 'db'
+            expect(subtype).to eq 'mysql'
+            expect(action).to eq 'sql'
+            expect(context_.db.statement).to eq sql
+          end
+
           it 'skips cache queries' do
             result =
               normalize_payload(name: 'CACHE', sql: 'DROP * FROM users')


### PR DESCRIPTION
Pass the payload object to the `lookup_adapter` method so that when it contains the `connection` object, it can be used get the adapter name. Fall back to `::ActiveRecord::Base.connection`, which is the previous behavior.

Made the names to skip a constant so that a new array isn't created everytime the `normalize` method is called.

Closes elastic/apm-agent-ruby#592 