### PR TITLE
Fix configuration in Kibana requests

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -35,6 +35,11 @@ endif::[]
 
 - Add Grape support. {pull}562[#562]
 
+[float]
+===== Fixed
+
+- Fixed pulling config from Kibana {pull}594[#594]
+
 [[release-notes-3.x]]
 === Ruby Agent version 3.x
 

--- a/Gemfile
+++ b/Gemfile
@@ -32,10 +32,14 @@ else
 end
 
 ## Install Framework
-GITHUB_REPOS = { 'grape' => 'ruby-grape/grape'}
+GITHUB_REPOS = {
+  'grape' => 'ruby-grape/grape',
+  'rails' => 'rails/rails',
+  'sinatra' => 'sinatra/sinatra'
+}.freeze
 
-frameworks = ENV.fetch('FRAMEWORK', 'rails').split(',')
-frameworks_versions = frameworks.inject({}) do |frameworks, str|
+parsed_frameworks = ENV.fetch('FRAMEWORK', 'rails').split(',')
+frameworks_versions = parsed_frameworks.inject({}) do |frameworks, str|
   framework, *version = str.split('-')
   frameworks.merge(framework => version.join('-'))
 end
@@ -43,7 +47,7 @@ end
 frameworks_versions.each do |framework, version|
   case version
   when 'master'
-    gem framework, github: (GITHUB_REPOS[framework] || "#{framework}/#{framework}")
+    gem framework, github: GITHUB_REPOS.fetch[framework]
   when /.+/
     gem framework, "~> #{version}.0"
   else

--- a/lib/elastic_apm/central_config.rb
+++ b/lib/elastic_apm/central_config.rb
@@ -91,7 +91,7 @@ module ElasticAPM
       @config = config.dup.tap { |new_config| new_config.assign(new_options) }
     end
 
-    # rubocop:disable Metrics/MethodLength
+    # rubocop:disable Metrics/MethodLength, Metrics/AbcSize
     def handle_success(resp)
       if resp.status == 304
         info 'Received 304 Not Modified'
@@ -99,7 +99,10 @@ module ElasticAPM
         update = JSON.parse(resp.body.to_s)
         assign(update)
 
-        info 'Updated config from Kibana'
+        if @modified_options.any?
+          info 'Updated config from Kibana'
+          debug 'Modified: %s', @modified_options.inspect
+        end
       end
 
       schedule_next_fetch(resp)
@@ -109,7 +112,7 @@ module ElasticAPM
       error 'Failed to apply remote config, %s', e.inspect
       debug { e.backtrace.join('\n') }
     end
-    # rubocop:enable Metrics/MethodLength
+    # rubocop:enable Metrics/MethodLength, Metrics/AbcSize
 
     def handle_error(error)
       debug(

--- a/lib/elastic_apm/central_config.rb
+++ b/lib/elastic_apm/central_config.rb
@@ -23,6 +23,7 @@ module ElasticAPM
     def initialize(config)
       @config = config
       @modified_options = {}
+      @http = Transport::Connection::Http.new(config, headers: headers)
     end
 
     attr_reader :config
@@ -122,7 +123,7 @@ module ElasticAPM
     end
 
     def perform_request
-      HTTP.get(server_url, headers: headers)
+      @http.get(server_url)
     end
 
     def server_url
@@ -134,13 +135,8 @@ module ElasticAPM
 
     def headers
       @headers ||=
-        {
-          etag: 1,
-          content_type: 'application/json'
-        }.tap do |headers|
-          if (token = config.secret_token)
-            headers['Authorization'] = "Bearer #{token}"
-          end
+        Transport::Headers.new(config).tap do |headers|
+          headers['Etag'] = 1
         end
     end
 

--- a/lib/elastic_apm/config.rb
+++ b/lib/elastic_apm/config.rb
@@ -165,6 +165,29 @@ module ElasticAPM
       @span_frames_min_duration_us ||= span_frames_min_duration * 1_000_000
     end
 
+    # rubocop:disable Metrics/MethodLength
+    def ssl_context
+      return unless use_ssl?
+
+      @ssl_context ||=
+        OpenSSL::SSL::SSLContext.new.tap do |context|
+          if server_ca_cert
+            context.ca_file = server_ca_cert
+          else
+            context.cert_store =
+              OpenSSL::X509::Store.new.tap(&:set_default_paths)
+          end
+
+          context.verify_mode =
+            if verify_server_cert
+              OpenSSL::SSL::VERIFY_PEER
+            else
+              OpenSSL::SSL::VERIFY_NONE
+            end
+        end
+    end
+    # rubocop:enable Metrics/MethodLength
+
     def inspect
       super.split.first + '>'
     end

--- a/lib/elastic_apm/transport/base.rb
+++ b/lib/elastic_apm/transport/base.rb
@@ -1,10 +1,14 @@
 # frozen_string_literal: true
 
 require 'elastic_apm/metadata'
+require 'elastic_apm/transport/user_agent'
+require 'elastic_apm/transport/headers'
 require 'elastic_apm/transport/connection'
 require 'elastic_apm/transport/worker'
 require 'elastic_apm/transport/serializers'
 require 'elastic_apm/transport/filters'
+require 'elastic_apm/transport/connection/http'
+
 require 'elastic_apm/util/throttle'
 
 module ElasticAPM

--- a/lib/elastic_apm/transport/connection.rb
+++ b/lib/elastic_apm/transport/connection.rb
@@ -20,7 +20,6 @@ module ElasticAPM
 
       def initialize(config)
         @config = config
-        @headers = Headers.new(config).chunked!
         @metadata = JSON.fast_generate(
           Serializers::MetadataSerializer.new(config).build(
             Metadata.new(config)
@@ -82,10 +81,9 @@ module ElasticAPM
         schedule_closing if @config.api_request_time
 
         @http =
-          Http.open(
-            @config, @url,
-            headers: @headers.to_h
-          ).tap { |http| http.write(@metadata) }
+          Http.open(@config, @url).tap do |http|
+            http.write(@metadata)
+          end
       end
       # rubocop:enable
 

--- a/lib/elastic_apm/transport/connection.rb
+++ b/lib/elastic_apm/transport/connection.rb
@@ -1,10 +1,7 @@
 # frozen_string_literal: true
 
-require 'elastic_apm/transport/connection/http'
-
 module ElasticAPM
   module Transport
-    # rubocop:disable Metrics/ClassLength
     # @api private
     class Connection
       include Logging
@@ -21,20 +18,15 @@ module ElasticAPM
       # with ongoing write requests to `http`, write and close
       # requests have to be synchronized.
 
-      HEADERS = {
-        'Content-Type' => 'application/x-ndjson',
-        'Transfer-Encoding' => 'chunked'
-      }.freeze
-      GZIP_HEADERS = HEADERS.merge(
-        'Content-Encoding' => 'gzip'
-      ).freeze
-
-      def initialize(config, metadata)
+      def initialize(config)
         @config = config
-        @headers = build_headers(metadata)
-        @metadata = JSON.fast_generate(metadata)
+        @headers = Headers.new(config).chunked!
+        @metadata = JSON.fast_generate(
+          Serializers::MetadataSerializer.new(config).build(
+            Metadata.new(config)
+          )
+        )
         @url = config.server_url + '/intake/v2/events'
-        @ssl_context = build_ssl_context
         @mutex = Mutex.new
       end
 
@@ -92,8 +84,7 @@ module ElasticAPM
         @http =
           Http.open(
             @config, @url,
-            headers: @headers,
-            ssl_context: @ssl_context
+            headers: @headers.to_h
           ).tap { |http| http.write(@metadata) }
       end
       # rubocop:enable
@@ -105,49 +96,6 @@ module ElasticAPM
             flush(:timeout)
           end
       end
-
-      def build_headers(metadata)
-        (
-          @config.http_compression? ? GZIP_HEADERS : HEADERS
-        ).dup.tap do |headers|
-          headers['User-Agent'] = build_user_agent(metadata)
-
-          if (token = @config.secret_token)
-            headers['Authorization'] = "Bearer #{token}"
-          end
-        end
-      end
-
-      def build_user_agent(metadata)
-        runtime = metadata.dig(:metadata, :service, :runtime)
-
-        [
-          "elastic-apm-ruby/#{VERSION}",
-          HTTP::Request::USER_AGENT,
-          [runtime[:name], runtime[:version]].join('/')
-        ].join(' ')
-      end
-
-      def build_ssl_context # rubocop:disable Metrics/MethodLength
-        return unless @config.use_ssl?
-
-        OpenSSL::SSL::SSLContext.new.tap do |context|
-          if @config.server_ca_cert
-            context.ca_file = @config.server_ca_cert
-          else
-            context.cert_store =
-              OpenSSL::X509::Store.new.tap(&:set_default_paths)
-          end
-
-          context.verify_mode =
-            if @config.verify_server_cert
-              OpenSSL::SSL::VERIFY_PEER
-            else
-              OpenSSL::SSL::VERIFY_NONE
-            end
-        end
-      end
     end
-    # rubocop:enable Metrics/ClassLength
   end
 end

--- a/lib/elastic_apm/transport/connection/http.rb
+++ b/lib/elastic_apm/transport/connection/http.rb
@@ -9,21 +9,39 @@ module ElasticAPM
       class Http
         include Logging
 
-        def initialize(config)
+        def initialize(config, headers: {})
           @config = config
+          @headers = headers
+          @client = build_client
+        end
+
+        def open(url)
           @closed = Concurrent::AtomicBoolean.new
-
           @rd, @wr = ProxyPipe.pipe(compress: @config.http_compression?)
+          @request = open_request_in_thread(url)
         end
 
-        def open(url, headers: {}, ssl_context: nil)
-          @request = open_request_in_thread(url, headers, ssl_context)
-        end
-
-        def self.open(config, url, headers: {}, ssl_context: nil)
-          new(config).tap do |http|
-            http.open(url, headers: headers, ssl_context: ssl_context)
+        def self.open(config, url, headers: {})
+          new(config, headers: headers).tap do |http|
+            http.open(url)
           end
+        end
+
+        def post(url, body: nil)
+          request(:post, url, body: body)
+        end
+
+        def get(url)
+          request(:get, url)
+        end
+
+        def request(method, url, body: nil)
+          @client.send(
+            method,
+            url,
+            body: body,
+            ssl_context: @config.ssl_context
+          ).flush
         end
 
         def write(str)
@@ -65,23 +83,29 @@ module ElasticAPM
           format('[THREAD:%s]', Thread.current.object_id)
         end
 
-        # rubocop:disable Metrics/LineLength
-        def open_request_in_thread(url, headers, ssl_context)
-          client = build_client(headers)
-
+        # rubocop:disable Metrics/MethodLength
+        def open_request_in_thread(url)
           debug '%s: Opening new request', thread_str
           Thread.new do
             begin
-              post(client, url, ssl_context)
+              resp = post(url, body: @rd)
+
+              if resp&.status == 202
+                debug 'APM Server responded with status 202'
+              elsif resp
+                error "APM Server responded with an error:\n%p", resp.body.to_s
+              end
             rescue Exception => e
-              error "Couldn't establish connection to APM Server:\n%p", e.inspect
+              error(
+                "Couldn't establish connection to APM Server:\n%p", e.inspect
+              )
             end
           end
         end
-        # rubocop:enable Metrics/LineLength
+        # rubocop:enable Metrics/MethodLength
 
-        def build_client(headers)
-          client = HTTP.headers(headers)
+        def build_client
+          client = HTTP.headers(@headers)
           return client unless @config.proxy_address && @config.proxy_port
 
           client.via(
@@ -91,20 +115,6 @@ module ElasticAPM
             @config.proxy_password,
             @config.proxy_headers
           )
-        end
-
-        def post(client, url, ssl_context)
-          resp = client.post(
-            url,
-            body: @rd,
-            ssl_context: ssl_context
-          ).flush
-
-          if resp&.status == 202
-            debug 'APM Server responded with status 202'
-          elsif resp
-            error "APM Server responded with an error:\n%p", resp.body.to_s
-          end
         end
       end
     end

--- a/lib/elastic_apm/transport/headers.rb
+++ b/lib/elastic_apm/transport/headers.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+module ElasticAPM
+  module Transport
+    # @api private
+    class Headers
+      HEADERS = {
+        'Content-Type' => 'application/x-ndjson',
+        'Transfer-Encoding' => 'chunked'
+      }.freeze
+      GZIP_HEADERS = HEADERS.merge(
+        'Content-Encoding' => 'gzip'
+      ).freeze
+
+      def initialize(config, initial: {})
+        @config = config
+        @hash = build!(initial)
+      end
+
+      attr_accessor :hash
+
+      def [](key)
+        @hash[key]
+      end
+
+      def []=(key, value)
+        @hash[key] = value
+      end
+
+      def merge!(other)
+        @hash.merge!(other)
+        self
+      end
+
+      def to_h
+        @hash
+      end
+
+      def chunked!
+        self.class.new(@config, initial: hash.dup).merge!(
+          @config.http_compression? ? GZIP_HEADERS : HEADERS
+        )
+      end
+
+      private
+
+      def build!(headers)
+        headers[:'User-Agent'] = UserAgent.new(@config).to_s
+
+        if (token = @config.secret_token)
+          headers[:Authorization] = "Bearer #{token}"
+        end
+
+        headers
+      end
+    end
+  end
+end

--- a/lib/elastic_apm/transport/headers.rb
+++ b/lib/elastic_apm/transport/headers.rb
@@ -27,6 +27,10 @@ module ElasticAPM
         @hash[key] = value
       end
 
+      def merge(other)
+        self.class.new(@config, initial: @hash.merge(other))
+      end
+
       def merge!(other)
         @hash.merge!(other)
         self
@@ -36,8 +40,8 @@ module ElasticAPM
         @hash
       end
 
-      def chunked!
-        self.class.new(@config, initial: hash.dup).merge!(
+      def chunked
+        merge(
           @config.http_compression? ? GZIP_HEADERS : HEADERS
         )
       end

--- a/lib/elastic_apm/transport/user_agent.rb
+++ b/lib/elastic_apm/transport/user_agent.rb
@@ -15,14 +15,15 @@ module ElasticAPM
       private
 
       def build(config)
-        serializer = Serializers::MetadataSerializer.new(config)
-        metadata = serializer.build(Metadata.new(config))
-        runtime = metadata.dig(:metadata, :service, :runtime)
+        metadata = Metadata.new(config)
 
         [
           "elastic-apm-ruby/#{VERSION}",
           HTTP::Request::USER_AGENT,
-          [runtime[:name], runtime[:version]].join('/')
+          [
+            metadata.service.runtime.name,
+            metadata.service.runtime.version
+          ].join('/')
         ].join(' ')
       end
     end

--- a/lib/elastic_apm/transport/user_agent.rb
+++ b/lib/elastic_apm/transport/user_agent.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+module ElasticAPM
+  module Transport
+    # @api private
+    class UserAgent
+      def initialize(config)
+        @built = build(config)
+      end
+
+      def to_s
+        @built
+      end
+
+      private
+
+      def build(config)
+        serializer = Serializers::MetadataSerializer.new(config)
+        metadata = serializer.build(Metadata.new(config))
+        runtime = metadata.dig(:metadata, :service, :runtime)
+
+        [
+          "elastic-apm-ruby/#{VERSION}",
+          HTTP::Request::USER_AGENT,
+          [runtime[:name], runtime[:version]].join('/')
+        ].join(' ')
+      end
+    end
+  end
+end

--- a/lib/elastic_apm/transport/worker.rb
+++ b/lib/elastic_apm/transport/worker.rb
@@ -25,8 +25,7 @@ module ElasticAPM
         @serializers = serializers
         @filters = filters
 
-        metadata = serializers.serialize(Metadata.new(config))
-        @connection = conn_adapter.new(config, metadata)
+        @connection = conn_adapter.new(config)
       end
 
       attr_reader :queue, :filters, :name, :connection, :serializers

--- a/spec/elastic_apm/central_config_spec.rb
+++ b/spec/elastic_apm/central_config_spec.rb
@@ -46,7 +46,7 @@ module ElasticAPM
         subject.fetch_and_apply_config
         subject.promise.wait
 
-        stub_response('Not found', status: 404)
+        stub_response('Not found', response: { status: 404 })
 
         subject.fetch_and_apply_config
         subject.promise.wait
@@ -58,7 +58,9 @@ module ElasticAPM
         it 'schedules a new poll' do
           stub_response(
             {},
-            headers: { 'Cache-Control': 'must-revalidate, max-age=123' }
+            response: {
+              headers: { 'Cache-Control': 'must-revalidate, max-age=123' }
+            }
           )
 
           subject.fetch_and_apply_config
@@ -73,7 +75,9 @@ module ElasticAPM
         it 'doesn\'t restore config, schedules a new poll' do
           stub_response(
             { transaction_sample_rate: 0.5 },
-            headers: { 'Cache-Control': 'must-revalidate, max-age=0.1' }
+            response: {
+              headers: { 'Cache-Control': 'must-revalidate, max-age=0.1' }
+            }
           )
 
           subject.fetch_and_apply_config
@@ -81,8 +85,10 @@ module ElasticAPM
 
           stub_response(
             nil,
-            status: 304,
-            headers: { 'Cache-Control': 'must-revalidate, max-age=123' }
+            response: {
+              status: 304,
+              headers: { 'Cache-Control': 'must-revalidate, max-age=123' }
+            }
           )
 
           subject.fetch_and_apply_config
@@ -96,7 +102,7 @@ module ElasticAPM
 
       context 'when server responds 404' do
         it 'schedules a new poll' do
-          stub_response('Not found', status: 404)
+          stub_response('Not found', response: { status: 404 })
 
           subject.fetch_and_apply_config
           subject.promise.wait
@@ -118,7 +124,7 @@ module ElasticAPM
 
       context 'when not found' do
         before do
-          stub_response('Not found', status: 404)
+          stub_response('Not found', response: { status: 404 })
         end
 
         it 'raises an error' do
@@ -137,10 +143,23 @@ module ElasticAPM
 
       context 'when server error' do
         it 'raises an error' do
-          stub_response('Server error', status: 500)
+          stub_response('Server error', response: { status: 500 })
 
           expect { subject.fetch_config }
             .to raise_error(CentralConfig::ServerError)
+        end
+      end
+
+      context 'with a secret token' do
+        before { config.secret_token = 'zecret' }
+
+        it 'sets auth header' do
+          stub_response(
+            {},
+            request: { headers: { 'Authorization': 'Bearer zecret' } }
+          )
+
+          subject.fetch_config
         end
       end
     end
@@ -165,9 +184,13 @@ module ElasticAPM
       end
     end
 
-    def stub_response(body, **opts)
-      stub_request(:get, 'http://localhost:8200/config/v1/agents?service.name=MyApp')
-        .to_return(body: body && body.to_json, **opts)
+    def stub_response(body, request: {}, response: {})
+      url = 'http://localhost:8200/config/v1/agents?service.name=MyApp'
+
+      stub_request(:get, url).tap do |stub|
+        stub.with(request) if request.any?
+        stub.to_return(body: body && body.to_json, **response)
+      end
     end
   end
 end

--- a/spec/elastic_apm/central_config_spec.rb
+++ b/spec/elastic_apm/central_config_spec.rb
@@ -100,6 +100,26 @@ module ElasticAPM
         end
       end
 
+      context 'when server sends etag header' do
+        it 'includes etag in next request' do
+          stub_response(
+            nil,
+            response: { headers: { 'Etag': '___etag___' } }
+          )
+
+          subject.fetch_and_apply_config
+          subject.promise.wait
+
+          stub_response(
+            nil,
+            request: { headers: { 'Etag': '___etag___' } }
+          )
+
+          subject.fetch_and_apply_config
+          subject.promise.wait
+        end
+      end
+
       context 'when server responds 404' do
         it 'schedules a new poll' do
           stub_response('Not found', response: { status: 404 })

--- a/spec/elastic_apm/central_config_spec.rb
+++ b/spec/elastic_apm/central_config_spec.rb
@@ -2,7 +2,7 @@
 
 module ElasticAPM
   RSpec.describe CentralConfig do
-    let(:config) { Config.new }
+    let(:config) { Config.new service_name: 'MyApp' }
     subject { described_class.new(config) }
 
     describe '#start' do
@@ -166,7 +166,7 @@ module ElasticAPM
     end
 
     def stub_response(body, **opts)
-      stub_request(:post, 'http://localhost:8200/config/v1/agents')
+      stub_request(:get, 'http://localhost:8200/config/v1/agents?service.name=MyApp')
         .to_return(body: body && body.to_json, **opts)
     end
   end

--- a/spec/elastic_apm/transport/connection/http_spec.rb
+++ b/spec/elastic_apm/transport/connection/http_spec.rb
@@ -21,7 +21,7 @@ module ElasticAPM
       end
 
       describe '#initialize' do
-        subject { described_class.open(config, url, headers: headers) }
+        subject { described_class.open(config, url) }
 
         it 'is has no active connection' do
           expect(subject.closed?).to be false
@@ -29,7 +29,7 @@ module ElasticAPM
       end
 
       describe 'write and close' do
-        subject { described_class.open(config, url, headers: headers) }
+        subject { described_class.open(config, url) }
 
         it 'sends metadata' do
           stub = build_stub(body: /metadata/, headers: headers)
@@ -79,7 +79,7 @@ module ElasticAPM
       context 'http compression' do
         let(:config) { Config.new }
 
-        subject { described_class.open(config, url, headers: headers) }
+        subject { described_class.open(config, url) }
 
         it 'compresses the payload' do
           stub = build_stub(

--- a/spec/elastic_apm/transport/connection_spec.rb
+++ b/spec/elastic_apm/transport/connection_spec.rb
@@ -6,8 +6,7 @@ module ElasticAPM
   module Transport
     RSpec.describe Connection do
       let(:config) { Config.new(http_compression: false) }
-      let(:metadata) { Serializers.new(config).serialize(Metadata.new(config)) }
-      subject { described_class.new(config, metadata) }
+      subject { described_class.new(config) }
 
       describe '#initialize' do
         it 'is has no active connection' do
@@ -137,6 +136,11 @@ module ElasticAPM
 
         context 'and gzip off' do
           let(:config) { Config.new(http_compression: false) }
+          let(:metadata) do
+            Serializers::MetadataSerializer.new(config).build(
+              Metadata.new(config)
+            )
+          end
 
           before do
             config.api_request_size = "#{metadata.to_json.bytesize + 1}b"

--- a/spec/elastic_apm/transport/headers_spec.rb
+++ b/spec/elastic_apm/transport/headers_spec.rb
@@ -23,9 +23,9 @@ module ElasticAPM
         end
       end
 
-      describe 'chunked!' do
+      describe 'chunked' do
         it 'returns a modified copy' do
-          chunked = subject.chunked!
+          chunked = subject.chunked
           expect(chunked).to_not be subject
           expect(chunked.hash).to_not be subject.hash
           expect(subject['Transfer-Encoding']).to be nil
@@ -35,7 +35,7 @@ module ElasticAPM
 
         context 'with compression' do
           it 'sets gzip header' do
-            chunked = subject.chunked!
+            chunked = subject.chunked
             expect(chunked['Content-Encoding']).to eq 'gzip'
           end
         end

--- a/spec/elastic_apm/transport/headers_spec.rb
+++ b/spec/elastic_apm/transport/headers_spec.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+module ElasticAPM
+  module Transport
+    RSpec.describe Headers do
+      let(:config) { Config.new }
+      subject { described_class.new(config) }
+
+      describe 'to_h' do
+        it 'constructs the default headers from config' do
+          expect(subject.to_h).to match('User-Agent': String)
+        end
+
+        context 'with a secret token' do
+          let(:config) { Config.new secret_token: 'TOKEN' }
+
+          it 'includes auth bearer' do
+            expect(subject.to_h).to match(
+              'User-Agent': String,
+              'Authorization': 'Bearer TOKEN'
+            )
+          end
+        end
+      end
+
+      describe 'chunked!' do
+        it 'returns a modified copy' do
+          chunked = subject.chunked!
+          expect(chunked).to_not be subject
+          expect(chunked.hash).to_not be subject.hash
+          expect(subject['Transfer-Encoding']).to be nil
+          expect(chunked['Transfer-Encoding']).to eq 'chunked'
+          expect(chunked['Content-Type']).to eq 'application/x-ndjson'
+        end
+
+        context 'with compression' do
+          it 'sets gzip header' do
+            chunked = subject.chunked!
+            expect(chunked['Content-Encoding']).to eq 'gzip'
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/elastic_apm/transport/user_agent_spec.rb
+++ b/spec/elastic_apm/transport/user_agent_spec.rb
@@ -10,9 +10,9 @@ module ElasticAPM
         it 'builds a string' do
           expect(subject.to_s).to match(
             %r{
-              elastic-apm-ruby/\d+\.\d+\.\d+\s
-              http\.rb/\d+\.\d+\.\d+\s
-              ruby/\d+\.\d+\.\d+
+              \Aelastic-apm-ruby/(\d+\.)+\d+\s
+              http.rb/(\d+\.)+\d+\s
+              j?ruby/(\d+\.)+\d+\z
             }x
           )
         end

--- a/spec/elastic_apm/transport/user_agent_spec.rb
+++ b/spec/elastic_apm/transport/user_agent_spec.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+module ElasticAPM
+  module Transport
+    RSpec.describe UserAgent do
+      let(:config) { Config.new }
+      subject { described_class.new(config) }
+
+      describe 'to_s' do
+        it 'builds a string' do
+          expect(subject.to_s).to match(
+            %r{
+              elastic-apm-ruby/\d+\.\d+\.\d+\s
+              http\.rb/\d+\.\d+\.\d+\s
+              ruby/\d+\.\d+\.\d+
+            }x
+          )
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
We were constructing the requests with an outdated method. This uses the proper, documented approach instead.

This PR also makes the CentralConfig polling share functionality with the Intake API sending. Setting headers, SSLContext, proxy settings.