### PR TITLE
[2.x][docs] fix pull link (#596)

### DIFF
--- a/docs/release-notes.asciidoc
+++ b/docs/release-notes.asciidoc
@@ -1,4 +1,4 @@
-:pull: https://github.com/elastic/apm-server/pull/
+:pull: https://github.com/elastic/apm-agent-ruby/pull/
 
 [[release-notes]]
 == Release notes


### PR DESCRIPTION
Backports https://github.com/elastic/apm-agent-ruby/pull/596.