### PR TITLE
Replace invalid bytes in SqlSummarizer

### DIFF
--- a/lib/elastic_apm/sql_summarizer.rb
+++ b/lib/elastic_apm/sql_summarizer.rb
@@ -9,21 +9,23 @@ module ElasticAPM
     TABLE_REGEX = %{["'`]?([A-Za-z0-9_]+)["'`]?}
 
     REGEXES = {
-      /^BEGIN/i => 'BEGIN',
-      /^COMMIT/i => 'COMMIT',
-      /^SELECT .* FROM #{TABLE_REGEX}/i => 'SELECT FROM ',
-      /^INSERT INTO #{TABLE_REGEX}/i => 'INSERT INTO ',
-      /^UPDATE #{TABLE_REGEX}/i => 'UPDATE ',
-      /^DELETE FROM #{TABLE_REGEX}/i => 'DELETE FROM '
+      /^BEGIN/iu => 'BEGIN',
+      /^COMMIT/iu => 'COMMIT',
+      /^SELECT .* FROM #{TABLE_REGEX}/iu => 'SELECT FROM ',
+      /^INSERT INTO #{TABLE_REGEX}/iu => 'INSERT INTO ',
+      /^UPDATE #{TABLE_REGEX}/iu => 'UPDATE ',
+      /^DELETE FROM #{TABLE_REGEX}/iu => 'DELETE FROM '
     }.freeze
 
     FORMAT = '%s%s'
+    UTF8 = 'UTF-8'
 
     def self.cache
       @cache ||= Util::LruCache.new
     end
 
     def summarize(sql)
+      sql = sql.encode(UTF8, invalid: :replace, replace: nil)
       self.class.cache[sql] ||=
         REGEXES.find do |regex, sig|
           if (match = sql[0...1000].match(regex))

--- a/spec/elastic_apm/sql_summarizer_spec.rb
+++ b/spec/elastic_apm/sql_summarizer_spec.rb
@@ -53,5 +53,13 @@ module ElasticAPM
       result = subject.summarize(sql)
       expect(result).to eq 'SQL'
     end
+
+    context 'invalid bytes' do
+      it 'replaces invalid bytes' do
+        sql = "INSERT INTO table (a, b) VALUES ('\255','\255')"
+        result = subject.summarize(sql)
+        expect(result).to eq('INSERT INTO table')
+      end
+    end
   end
 end


### PR DESCRIPTION
These changes replace the invalid bytes in the sql string when matching the regexes and makes the regex encodings all UTF-8.

Closes elastic/apm-agent-ruby#595