### PR TITLE
Use connection_config instead to avoid retrieving a connection

### DIFF
--- a/lib/elastic_apm/normalizers/rails/active_record.rb
+++ b/lib/elastic_apm/normalizers/rails/active_record.rb
@@ -33,8 +33,9 @@ module ElasticAPM
         private
 
         def subtype(payload)
-          connection_adapter(
-            payload[:connection] || ::ActiveRecord::Base.connection
+          cached_adapter_name(
+            payload[:connection] ? payload[:connection].adapter_name :
+              ::ActiveRecord::Base.connection_config[:adapter]
           )
         end
 
@@ -42,10 +43,10 @@ module ElasticAPM
           @summarizer.summarize(sql)
         end
 
-        def connection_adapter(conn)
-          return UNKNOWN unless conn.adapter_name
-          @adapters[conn.adapter_name] ||
-            (@adapters[conn.adapter_name] = conn.adapter_name.downcase)
+        def cached_adapter_name(adapter_name)
+          return UNKNOWN if adapter_name.nil? || adapter_name.empty?
+          @adapters[adapter_name] ||
+            (@adapters[adapter_name] = adapter_name.downcase)
         rescue StandardError
           nil
         end


### PR DESCRIPTION
Closes #https://github.com/elastic/apm-agent-ruby/issues/601

Calling `#connection` on `ActiveRecord::Base` [retrieves a connection](https://github.com/rails/rails/blob/master/activerecord/lib/active_record/base.rb#L219-L229) so we should instead consult the `connection_config`.