### PR TITLE
Clone HTTP cookies when building context

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -40,6 +40,7 @@ endif::[]
 ===== Fixed
 
 - Fixed pulling config from Kibana {pull}594[#594]
+- Fixed a bug where the agent would alter the original cookies hash {pull}616[#616]
 
 [[release-notes-3.x]]
 === Ruby Agent version 3.x

--- a/lib/elastic_apm/context_builder.rb
+++ b/lib/elastic_apm/context_builder.rb
@@ -38,7 +38,7 @@ module ElasticAPM
       request.headers = headers if config.capture_headers?
       request.env = env if config.capture_env?
 
-      request.cookies = req.cookies
+      request.cookies = req.cookies.dup
 
       context
     end

--- a/spec/elastic_apm/context_builder_spec.rb
+++ b/spec/elastic_apm/context_builder_spec.rb
@@ -30,6 +30,8 @@ module ElasticAPM
         expect(request.url.full).to eq 'http://example.org/somewhere/in/there?q=yes'
 
         expect(request.cookies).to eq('things' => '1')
+        # Make sure we have a clone and not the original
+        expect(request.cookies).to_not be env['rack.request.cookie_hash']
 
         expect(request.headers).to eq(
           'Content-Type' => 'application/json',


### PR DESCRIPTION
Fixes elastic/apm-agent-ruby#614