### PR TITLE
Refactor worker so that it manages its own threads and can be mocked easily

### DIFF
--- a/spec/elastic_apm/transport/worker_spec.rb
+++ b/spec/elastic_apm/transport/worker_spec.rb
@@ -24,7 +24,7 @@ module ElasticAPM
         its(:connection) { should be_a Connection }
       end
 
-      describe '#work_forever' do
+      describe '#ensure_running!' do
         class MockConnection
           def initialize(*_args)
             @calls = []
@@ -49,54 +49,133 @@ module ElasticAPM
           )
         end
 
-        it 'applies filters, writes resources to the connection' do
-          expect(subject.filters).to receive(:apply!)
+        context 'when there are filters' do
+          before do
+            expect(subject.filters).to receive(:apply!)
+            queue.push Transaction.new config: config
+            subject.ensure_running!
+            subject.stop!(0.1)
+          end
 
-          queue.push Transaction.new config: config
-          Thread.new { subject.work_forever }.join 0.1
-
-          expect(subject.connection.calls.length).to be 1
+          it 'applies filters, writes resources to the connection' do
+            expect(subject.connection.calls.length).to be 1
+          end
         end
 
-        it 'can be stopped with a message' do
-          expect(subject.connection).to receive(:flush)
-
-          thread = Thread.new { subject.work_forever }
-          queue.push Worker::StopMessage.new
-
-          thread.join 1
+        context 'when a stop message is enqueued' do
+          it 'the work is stopped' do
+            expect(subject.connection).to receive(:flush)
+            subject.ensure_running!
+            queue.push Worker::StopMessage.new
+            subject.stop!(1)
+          end
         end
 
         context 'when a filter wants to skip the event' do
           before do
             filters.add(:always_nil, ->(_payload) { nil })
+            queue.push Transaction.new config: config
+            subject.ensure_running!
+            subject.stop!(0.1)
           end
 
           it 'applies filters, writes resources to the connection' do
-            queue.push Transaction.new config: config
-
-            Thread.new { subject.work_forever }.join 0.1
-
             expect(subject.connection.calls.length).to be 0
           end
         end
       end
 
-      describe '#process' do
-        it 'rescues exceptions' do
-          event = Transaction.new(
-            "What's in a name ⁉️",
-            (+'👏').force_encoding('ascii-8bit'),
-            config: config
+      context 'when the worker is stopped and started again' do
+        subject do
+          described_class.new(
+              config,
+              queue,
+              serializers: serializers,
+              filters: filters,
+              conn_adapter: MockConnection
           )
+        end
 
-          expect(config.logger).to receive(:error).twice.and_call_original
+        before do
+          subject.ensure_running!
+          queue.push Transaction.new config: config
+          subject.stop!(0.1)
+          subject.ensure_running!
+          queue.push Transaction.new config: config
+          subject.stop!(0.1)
+        end
 
-          expect do
-            subject.process event
-          end.to_not raise_error
+        it 'stops and starts the thread' do
+          expect(subject.connection.calls.length).to be 2
+        end
+      end
 
-          subject.connection.flush
+      describe '#kill' do
+        subject do
+          described_class.new(
+              config,
+              queue,
+              serializers: serializers,
+              filters: filters,
+              conn_adapter: MockConnection
+          )
+        end
+
+        before do
+          subject.ensure_running!
+          queue.push Transaction.new config: config
+          sleep(0.1)
+          subject.kill!
+        end
+
+        it 'kills the thread' do
+          expect(subject.connection.calls.length).to be 1
+          expect(subject.alive?).to be false
+        end
+      end
+
+      describe '#stop' do
+        subject do
+          described_class.new(
+              config,
+              queue,
+              serializers: serializers,
+              filters: filters,
+              conn_adapter: MockConnection
+          )
+        end
+
+        before do
+          subject.ensure_running!
+          queue.push Transaction.new config: config
+          subject.stop!(0.1)
+        end
+
+        it 'stops the thread' do
+          expect(subject.connection.calls.length).to be 1
+          expect(subject.alive?).to be false
+        end
+      end
+
+      describe '#process' do
+        context 'when an exception is thrown' do
+          let(:event) do
+            Transaction.new(
+              "What's in a name ⁉️",
+              (+'👏').force_encoding('ascii-8bit'),
+              config: config
+            )
+          end
+
+          before do
+            expect(config.logger).to receive(:error).twice.and_call_original
+          end
+
+          it 'rescues the exception' do
+            expect do
+              subject.process event
+            end.to_not raise_error
+          end
         end
       end
     end

--- a/spec/elastic_apm/transport/worker_spec.rb
+++ b/spec/elastic_apm/transport/worker_spec.rb
@@ -88,11 +88,11 @@ module ElasticAPM
       context 'when the worker is stopped and started again' do
         subject do
           described_class.new(
-              config,
-              queue,
-              serializers: serializers,
-              filters: filters,
-              conn_adapter: MockConnection
+            config,
+            queue,
+            serializers: serializers,
+            filters: filters,
+            conn_adapter: MockConnection
           )
         end
 
@@ -113,11 +113,11 @@ module ElasticAPM
       describe '#kill' do
         subject do
           described_class.new(
-              config,
-              queue,
-              serializers: serializers,
-              filters: filters,
-              conn_adapter: MockConnection
+            config,
+            queue,
+            serializers: serializers,
+            filters: filters,
+            conn_adapter: MockConnection
           )
         end
 
@@ -137,11 +137,11 @@ module ElasticAPM
       describe '#stop' do
         subject do
           described_class.new(
-              config,
-              queue,
-              serializers: serializers,
-              filters: filters,
-              conn_adapter: MockConnection
+            config,
+            queue,
+            serializers: serializers,
+            filters: filters,
+            conn_adapter: MockConnection
           )
         end
 


### PR DESCRIPTION
This refactor of the worker has the following benefits:
- The worker manages its own thread so that only threads are created and stopped/killed, not workers. Previously, workers were created inside threads with nothing referencing them. This meant that when a thread was stopped or killed, the worker would be disposed of and garbage collected, thus wasting objects.
- The workers can now be easily accessed via `ElasticAPM.agent.transport.workers` and therefore be mocked easily. We can now, for example, use the dependency-injection (`conn_adapter`) built into the `Worker` in the Rails tests.
- There was a mismatch in naming between `transport.workers` and what they actually were. Previously, `transport.workers` returned a list of threads, not workers. Now `transport.workers` returns a list of `Worker`s.
- Workers are created greedily, only once, in `Transport#initialize`, instead of as part of `Transport#start`. They are now only *started* via `Transport#start`.