### PR TITLE
Make Filters thread-safe

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -31,6 +31,15 @@ endif::[]
 [[release-notes-3.x]]
 === Ruby Agent version 3.x
 
+[float]
+[[unreleased]]
+==== Unreleased
+
+[float]
+===== Fixed
+
+- Make Filters thread-safe {pull}624[#624]
+
 [[release-notes-3.2.0]]
 ==== 3.2.0 (2019-11-19)
 

--- a/lib/elastic_apm/transport/filters.rb
+++ b/lib/elastic_apm/transport/filters.rb
@@ -20,9 +20,7 @@ module ElasticAPM
         end
 
         def add(key, filter)
-          LOCK.synchronize do
-            @filters[key] = filter
-          end
+          @filters = @filters.dup.merge!(key => filter)
         end
 
         def remove(key)
@@ -30,12 +28,10 @@ module ElasticAPM
         end
 
         def apply!(payload)
-          LOCK.synchronize do
-            @filters.reduce(payload) do |result, (_key, filter)|
-              result = filter.call(result)
-              break SKIP if result.nil?
-              result
-            end
+          @filters.reduce(payload) do |result, (_key, filter)|
+            result = filter.call(result)
+            break SKIP if result.nil?
+            result
           end
         end
 

--- a/lib/elastic_apm/transport/filters.rb
+++ b/lib/elastic_apm/transport/filters.rb
@@ -20,7 +20,7 @@ module ElasticAPM
         end
 
         def add(key, filter)
-          @filters = @filters.dup.merge!(key => filter)
+          @filters = @filters.merge(key => filter)
         end
 
         def remove(key)

--- a/lib/elastic_apm/transport/filters.rb
+++ b/lib/elastic_apm/transport/filters.rb
@@ -7,7 +7,6 @@ module ElasticAPM
     # @api private
     module Filters
       SKIP = :skip
-      LOCK = Mutex.new
 
       def self.new(config)
         Container.new(config)

--- a/spec/elastic_apm/transport/filters_spec.rb
+++ b/spec/elastic_apm/transport/filters_spec.rb
@@ -45,14 +45,18 @@ module ElasticAPM
         end
       end
 
-      describe 'thread safety' do
-        it 'may add filters while applying' do
+      describe 'from multiple threads' do
+        it "doesn't complain" do
           threads =
             (0...100).map do |i|
-              Thread.new { subject.apply!(payload: i) }
+              Thread.new do
+                if i.even?
+                  subject.apply!(payload: i)
+                else
+                  subject.add :"filter_#{i}", ->(_) { '' }
+                end
+              end
             end
-
-          subject.add :new, ->(_) { '' }
 
           threads.each(&:join)
         end

--- a/spec/elastic_apm/transport/filters_spec.rb
+++ b/spec/elastic_apm/transport/filters_spec.rb
@@ -44,6 +44,19 @@ module ElasticAPM
           expect(untouched).to_not have_received(:call)
         end
       end
+
+      describe 'thread safety' do
+        it 'may add filters while applying' do
+          threads =
+            (0...100).map do |i|
+              Thread.new { subject.apply!(payload: i) }
+            end
+
+          subject.add :new, ->(_) { '' }
+
+          threads.each(&:join)
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
Re: #582 

As the `Filters` object is shared between the workers, one worker may try to add a filter while another is applying the current filters.

This PR fixes it by altering a copy of the filters hash instead of modifying the original.