### PR TITLE
Sanitise auth info from outgoing HTTP requests' span.context.url

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -44,6 +44,7 @@ endif::[]
 ===== Fixed
 
 - Make Filters thread-safe {pull}624[#624]
+- Omit passwords in outgoing urls {pull}629[#629]
 
 [[release-notes-3.2.0]]
 ==== 3.2.0 (2019-11-19)

--- a/lib/elastic_apm/span/context.rb
+++ b/lib/elastic_apm/span/context.rb
@@ -28,12 +28,28 @@ module ElasticAPM
       # @api private
       class Http
         def initialize(url: nil, status_code: nil, method: nil)
-          @url = url
+          @url = sanitize_url(url)
           @status_code = status_code
           @method = method
         end
 
         attr_accessor :url, :status_code, :method
+
+        private
+
+        def sanitize_url(url)
+          uri = URI(url)
+
+          return url unless uri.userinfo
+
+          format(
+            '%s://%s@%s%s',
+            uri.scheme,
+            uri.userinfo.split(':')[0], # username, no password
+            uri.hostname,
+            uri.path
+          )
+        end
       end
     end
   end

--- a/lib/elastic_apm/span/context.rb
+++ b/lib/elastic_apm/span/context.rb
@@ -45,7 +45,7 @@ module ElasticAPM
           format(
             '%s://%s@%s%s',
             uri.scheme,
-            uri.userinfo.split(':')[0], # username, no password
+            uri.user,
             uri.hostname,
             uri.path
           )

--- a/spec/elastic_apm/context/request/url_spec.rb
+++ b/spec/elastic_apm/context/request/url_spec.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+module ElasticAPM
+  class Context
+    class Request
+      RSpec.describe Url do
+        context 'from a rack req' do
+          let(:url) { 'https://elastic.co:8080/nested/path?abc=123' }
+          let(:req) { Rack::Request.new(Rack::MockRequest.env_for(url)) }
+
+          subject { described_class.new(req) }
+
+          its(:protocol) { is_expected.to eq 'https' }
+          its(:hostname) { is_expected.to eq 'elastic.co' }
+          its(:port) { is_expected.to eq '8080' }
+          its(:pathname) { is_expected.to eq '/nested/path' }
+          its(:search) { is_expected.to eq 'abc=123' }
+          its(:hash) { is_expected.to eq nil }
+          its(:full) { is_expected.to eq url }
+        end
+      end
+    end
+  end
+end

--- a/spec/elastic_apm/span/context_spec.rb
+++ b/spec/elastic_apm/span/context_spec.rb
@@ -31,7 +31,7 @@ module ElasticAPM
             )
           end
 
-          it 'strips the auth part' do
+          it 'omits the password' do
             expect(subject.http.url).to eq 'https://user%40email.com@example.com/q=a@b'
           end
         end

--- a/spec/elastic_apm/span/context_spec.rb
+++ b/spec/elastic_apm/span/context_spec.rb
@@ -22,6 +22,19 @@ module ElasticAPM
         it 'adds a http object' do
           expect(subject.http.url).to eq 'asd'
         end
+
+        context 'when given auth info' do
+          subject do
+            described_class.new(
+              http: { url: 'https://user%40email.com:pass@example.com/q=a@b' }
+              #                         %40 => @
+            )
+          end
+
+          it 'strips the auth part' do
+            expect(subject.http.url).to eq 'https://user%40email.com@example.com/q=a@b'
+          end
+        end
       end
     end
   end


### PR DESCRIPTION
1. For incoming reqs I've confirmed that Rack doesn't pass the _userinfo_ through.
1. For outgoing reqs I added code to strip the password part.

---

Test setup:

```ruby
# config.ru
require 'rack'
require 'elastic_apm/context/request/url'

class App
  def call(env)
    req = Rack::Request.new(env)
    puts req.host # => localhost

    url = ElasticAPM::Context::Request::Url.new(req)

    [200, {}, [url.inspect]]
  end
end

use Rack::Auth::Basic do |user, pass|
  user == 'user' && pass = 'pass'
end

run App.new
```

Fixes elastic/apm-agent-ruby#474 