### PR TITLE
Refer to url instance variable in Connection#inspect

### DIFF
--- a/lib/elastic_apm/transport/connection.rb
+++ b/lib/elastic_apm/transport/connection.rb
@@ -67,7 +67,7 @@ module ElasticAPM
       def inspect
         format(
           '<%s url:%s closed:%s >',
-          super.split.first, url, http&.closed?
+          super.split.first, @url, http&.closed?
         )
       end
 

--- a/spec/elastic_apm/transport/connection_spec.rb
+++ b/spec/elastic_apm/transport/connection_spec.rb
@@ -16,6 +16,14 @@ module ElasticAPM
         end
       end
 
+      describe '#inspect' do
+        it 'returns a string with the connection\'s attributes' do
+          expect(subject.inspect).to match(
+            /ElasticAPM::Transport::Connection.*url:.*closed:.*/
+          )
+        end
+      end
+
       describe 'write' do
         it 'opens a connection and writes' do
           stub = build_stub(body: /{"msg": "hey!"}/)


### PR DESCRIPTION
I noticed this minor bug while working on mocking `Logging#error`.
`@url` is not defined as a `attr_reader`.