### PR TITLE
ci(jenkins): trigger benchmark always and tweak whens

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -152,14 +152,14 @@ pipeline {
               }
             }
           }
-          stage('Populate Test failures') {
-            when {
-              expression { return rubyTasksFailed }
-            }
-            steps {
-              error('There were some failures when running the "Test" stage')
-            }
-          }
+        }
+      }
+      stage('Populate Test failures') {
+        when {
+          expression { return rubyTasksFailed }
+        }
+        steps {
+          error('There were some failures when running the "Test" stage')
         }
       }
       stage('Integration Tests') {

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -271,5 +271,8 @@ def runJob(rubyVersion){
     )
   } catch(e) {
     rubyTasksFailed = true
+    warnError('Test Failures') {
+      error("Downstream job for '${rubyVersion}' failed")
+    }
   }
 }

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -5,10 +5,9 @@ import co.elastic.matrix.*
 import groovy.transform.Field
 
 /**
-This is the parallel tasks generator,
-it is need as field to store the results of the tests.
+ This is required to store the results of the tests.
 */
-@Field def rubyTasksGen
+@Field def rubyTasksFailed = false
 
 pipeline {
   agent { label 'linux && immutable' }
@@ -153,17 +152,23 @@ pipeline {
               }
             }
           }
+          stage('Populate Test failures') {
+            when {
+              expression { return rubyTasksFailed }
+            }
+            steps {
+              error('There were some failures when running the "Test" stage')
+            }
+          }
         }
       }
       stage('Integration Tests') {
         agent none
         when {
           beforeAgent true
-          allOf {
-            anyOf {
-              environment name: 'GIT_BUILD_CAUSE', value: 'pr'
-              expression { return !params.Run_As_Master_Branch }
-            }
+          anyOf {
+            changeRequest()
+            expression { return !params.Run_As_Master_Branch }
           }
         }
         steps {
@@ -186,9 +191,7 @@ pipeline {
         }
         when {
           beforeAgent true
-          anyOf {
-            tag pattern: 'v\\d+.*', comparator: 'REGEXP'
-          }
+          tag pattern: 'v\\d+.*', comparator: 'REGEXP'
         }
         steps {
           withGithubNotify(context: 'Release') {
@@ -258,11 +261,15 @@ def runBenchmark(version){
 }
 
 def runJob(rubyVersion){
-  build( job: "apm-agent-ruby/apm-agent-ruby-downstream/${env.BRANCH_NAME}",
-    parameters: [
-      string(name: 'RUBY_VERSION', value: "${rubyVersion}"),
-      string(name: 'BRANCH_SPECIFIER', value: "${env.GIT_BASE_COMMIT}")
-    ],
-    quietPeriod: 15
-  )
+  try {
+    build( job: "apm-agent-ruby/apm-agent-ruby-downstream/${env.BRANCH_NAME}",
+      parameters: [
+        string(name: 'RUBY_VERSION', value: "${rubyVersion}"),
+        string(name: 'BRANCH_SPECIFIER', value: "${env.GIT_BASE_COMMIT}")
+      ],
+      quietPeriod: 15
+    )
+  } catch(e) {
+    rubyTasksFailed = true
+  }
 }


### PR DESCRIPTION
As requested, let's run the benchmark stage independently that the Test stage failed. For such, it's required a variable to trap the error.

Minor changes in some deprecated when conditions.

### Pipeline View

- When a failure in one of the branches in the Test stage:

![image](https://user-images.githubusercontent.com/2871786/69759521-3a3c9880-115a-11ea-8943-b16d56caa971.png)

- When everything goes smooth

![image](https://user-images.githubusercontent.com/2871786/69759561-550f0d00-115a-11ea-8661-a88e974e35b3.png)


