### PR TITLE
Remove default framework and add env var in benchmark script

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,15 +8,10 @@ repos:
     -   id: check-merge-conflict
     -   id: check-yaml
     -   id: check-xml
-    -   id: end-of-file-fixer
 
 -   repo: git@github.com:elastic/apm-pipeline-library
     rev: current
     hooks:
     -   id: check-bash-syntax
-    -   id: check-abstract-classes-and-trait
-    -   id: check-jsonslurper-class
     -   id: check-jenkins-pipelines
-    -   id: check-unicode-non-breaking-spaces
-    -   id: remove-unicode-non-breaking-spaces
     -   id: check-jjbb

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,3 +15,4 @@ repos:
     -   id: check-bash-syntax
     -   id: check-jenkins-pipelines
     -   id: check-jjbb
+    -   id: check-unicode-non-breaking-spaces

--- a/Gemfile
+++ b/Gemfile
@@ -45,7 +45,7 @@ GITHUB_REPOS = {
 }.freeze
 
 #                new               || legacy           || default
-env_frameworks = ENV['FRAMEWORKS'] || ENV['FRAMEWORK'] || 'rails'
+env_frameworks = ENV['FRAMEWORKS'] || ENV['FRAMEWORK'] || ''
 parsed_frameworks = env_frameworks.split(',')
 frameworks_versions = parsed_frameworks.inject({}) do |frameworks, str|
   framework, *version = str.split('-')

--- a/spec/scripts/benchmarks.sh
+++ b/spec/scripts/benchmarks.sh
@@ -31,6 +31,7 @@ docker build --pull --force-rm --build-arg "RUBY_IMAGE=${RUBY_IMAGE}" -t "apm-ag
 RUBY_VERSION=${VERSION} docker-compose run \
   --user $UID \
   -e HOME=/app \
+  -e FRAMEWORK=rails \
   -w /app \
   -e LOCAL_USER_ID=$UID \
   -v "$local_vendor_path:$container_vendor_path" \


### PR DESCRIPTION
This removes a default framework in the `Gemfile` and adds a `FRAMEWORK` environment variable to the docker container running the benchmark tests.