### PR TITLE
ci(jenkins): cancel previous running builds

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -44,21 +44,12 @@ pipeline {
   }
   stages {
     /**
-    Cancel all the previous running old builds for the current PR.
-    */
-    stage('Cancel old builds') {
-      when { changeRequest() }
-      options { skipDefaultCheckout() }
-      steps {
-        cancelPreviousRunningBuilds()
-      }
-    }
-    /**
     Checkout the code and stash it, to use it on other stages.
     */
     stage('Checkout') {
       options { skipDefaultCheckout() }
       steps {
+        pipelineManager([ cancelPreviousRunningBuilds: [ when: 'PR' ] ])
         deleteDir()
         gitCheckout(basedir: "${BASE_DIR}", githubNotifyFirstTimeContributor: true)
         stash allowEmpty: true, name: 'source', useDefaultExcludes: false

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -44,6 +44,19 @@ pipeline {
   }
   stages {
     /**
+    Cancel all the previous running old builds for the current PR.
+    */
+    stage('cancelPreviousRunningBuilds') {
+      when {
+        beforeAgent true
+        changeRequest()
+      }
+      options { skipDefaultCheckout() }
+      steps {
+        cancelPreviousRunningBuilds()
+      }
+    }
+    /**
     Checkout the code and stash it, to use it on other stages.
     */
     stage('Checkout') {

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -46,11 +46,8 @@ pipeline {
     /**
     Cancel all the previous running old builds for the current PR.
     */
-    stage('cancelPreviousRunningBuilds') {
-      when {
-        beforeAgent true
-        changeRequest()
-      }
+    stage('Cancel old builds') {
+      when { changeRequest() }
       options { skipDefaultCheckout() }
       steps {
         cancelPreviousRunningBuilds()


### PR DESCRIPTION
## Description

Optimize and abort all the old builds which are still running in the CI then we can reduce the number of active resources, aka Jenkins workers, and being able to have a healthy build queue.

## When does it happen?

Only for PRs. As for any branches/tags we want to keep track when a particular build failed. The pipeline for the branches/tags might be slightly different in some cases, sometimes it's required to run more exhaustive tests, benchmarks or other goals.

## Issues
- It depends on the new release of the library. Waiting for [build](https://apm-ci.elastic.co/job/apm-shared/job/apm-pipeline-library-mbp/job/master/355/)
- It might not be 100% effective if there are try/catch/catchWarn/catchErr steps within downstream jobs. But that's the closest we can enable this behavior at the moment without tweaking the pipelines.

## Tests

- If not previous builds to be killed

![image](https://user-images.githubusercontent.com/2871786/69814804-e6c75a80-11ec-11ea-9cea-006eaafea80a.png)

- If previous builds on-going

![image](https://user-images.githubusercontent.com/2871786/69814899-1b3b1680-11ed-11ea-89e8-583db27a0e34.png)

Then caused the #build3 to be killed

![image](https://user-images.githubusercontent.com/2871786/69814937-2e4de680-11ed-11ea-911e-a6412270072b.png)
