### PR TITLE
ci(jenkins): trigger opbeans release process

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -24,6 +24,7 @@ pipeline {
     GITHUB_CHECK_ITS_NAME = 'Integration Tests'
     ITS_PIPELINE = 'apm-integration-tests-selector-mbp/master'
     RELEASE_SECRET = 'secret/apm-team/ci/apm-agent-ruby-rubygems-release'
+    OPBEANS_REPO = 'opbeans-ruby'
   }
   options {
     timeout(time: 2, unit: 'HOURS')
@@ -190,23 +191,44 @@ pipeline {
             tag pattern: 'v\\d+.*', comparator: 'REGEXP'
           }
         }
-        steps {
-          withGithubNotify(context: 'Release') {
-            deleteDir()
-            unstash 'source'
-            script {
-              dir(BASE_DIR){
-                docker.image("${env.RUBY_DOCKER_TAG}").inside('-v /etc/passwd:/etc/passwd -v ${HOME}/.ssh:${HOME}/.ssh') {
-                  withEnv(["HOME=${env.WORKSPACE}/${env.BASE_DIR ?: ''}"]) {
-                    rubygemsLogin.withApi(secret: "${env.RELEASE_SECRET}") {
-                      sshagent(['f6c7695a-671e-4f4f-a331-acdce44ff9ba']) {
-                        sh '.ci/prepare-git-context.sh'
-                        sh 'gem install rake yard rspec'
-                        sh 'rake release'
+        stages {
+          stage('Release') {
+            steps {
+              withGithubNotify(context: 'Release') {
+                deleteDir()
+                unstash 'source'
+                script {
+                  dir(BASE_DIR){
+                    docker.image("${env.RUBY_DOCKER_TAG}").inside('-v /etc/passwd:/etc/passwd -v ${HOME}/.ssh:${HOME}/.ssh') {
+                      withEnv(["HOME=${env.WORKSPACE}/${env.BASE_DIR ?: ''}"]) {
+                        rubygemsLogin.withApi(secret: "${env.RELEASE_SECRET}") {
+                          sshagent(['f6c7695a-671e-4f4f-a331-acdce44ff9ba']) {
+                            sh '.ci/prepare-git-context.sh'
+                            sh 'gem install rake yard rspec'
+                            sh 'rake release'
+                          }
+                        }
                       }
                     }
                   }
                 }
+              }
+            }
+          }
+          stage('Opbeans') {
+            environment {
+              REPO_NAME = "${OPBEANS_REPO}"
+            }
+            steps {
+              deleteDir()
+              dir("${OPBEANS_REPO}"){
+                git credentialsId: 'f6c7695a-671e-4f4f-a331-acdce44ff9ba',
+                    url: "git@github.com:elastic/${OPBEANS_REPO}.git"
+                sh script: ".ci/bump-version.sh ${env.BRANCH_NAME}", label: 'Bump version'
+                // The opbeans pipeline will trigger a release for the master branch
+                gitPush()
+                // The opbeans pipeline will trigger a release for the release tag
+                gitCreateTag(tag: "${env.BRANCH_NAME}")
               }
             }
           }


### PR DESCRIPTION
## What does this pull request do?

Add a final stage in the release process to bump the opbeans agent dependency.

## Why is it important?

When a new tag, aka a new release, is created then, the automation will kick the opbeans build which consists of the following tasks:
- [x] Bump dependency versions in the opbeans-ruby
- [x] Push changes. (Implementation within the opbeans-ruby but the call it's done within this pipeline)
- [x] Create a tag to trigger the release pipeline in the opbeans-ruby. That particular tag will match with the same one that the one in the agent itself.

This particular pipeline will push the changes into the `master` branch for the opbeans-ruby and tag it with the name of the tag version too. Therefore, the opbeans-ruby pipeline will trigger two builds, the one for its master branch and the other one for the just created tag. This particular flow is implemented within the opbeans-ruby.