### PR TITLE
Rails stacktraces for controller actions

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -50,6 +50,7 @@ endif::[]
 - Omit passwords in outgoing urls {pull}629[#629]
 - Add missing mutex to Counter metrics {pull}636[#636]
 - Correct span context collection name for Mongo getMore commands {pull}637[#637]
+- Stacktraces are generated for Rails controller action spans {pull}639[#639]
 
 [[release-notes-3.2.0]]
 ==== 3.2.0 (2019-11-19)

--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -35,6 +35,14 @@ endif::[]
 [[release-notes-3.x]]
 === Ruby Agent version 3.x
 
+[float]
+[[unreleased]]
+==== Unreleased
+
+[float]
+===== Fixed
+- Stacktraces are generated for Rails controller action spans {pull}639[#639]
+
 [[release-notes-3.3.0]]
 ==== 3.3.0 (2019-12-05)
 
@@ -50,7 +58,6 @@ endif::[]
 - Omit passwords in outgoing urls {pull}629[#629]
 - Add missing mutex to Counter metrics {pull}636[#636]
 - Correct span context collection name for Mongo getMore commands {pull}637[#637]
-- Stacktraces are generated for Rails controller action spans {pull}639[#639]
 
 [[release-notes-3.2.0]]
 ==== 3.2.0 (2019-11-19)

--- a/docs/supported-technologies.asciidoc
+++ b/docs/supported-technologies.asciidoc
@@ -34,6 +34,8 @@ We test against all supported minor versions of Rails and Sinatra.
 
 We currently support all versions of Rails since 4.2.
 This follows Rails' own https://rubyonrails.org/security/[Security policy].
+Please note, however, that we only generate stacktraces for controller
+action spans in Rails versions 5.x and up.
 
 See <<getting-started-rails>>.
 

--- a/lib/elastic_apm/config.rb
+++ b/lib/elastic_apm/config.rb
@@ -119,6 +119,7 @@ module ElasticAPM
         tilt
         rake
         action_controller
+        action_dispatch
       ]
     end
 

--- a/lib/elastic_apm/config.rb
+++ b/lib/elastic_apm/config.rb
@@ -118,6 +118,7 @@ module ElasticAPM
         sinatra
         tilt
         rake
+        action_controller
       ]
     end
 

--- a/lib/elastic_apm/rails.rb
+++ b/lib/elastic_apm/rails.rb
@@ -30,14 +30,6 @@ module ElasticAPM
       ElasticAPM.start(config).tap do |agent|
         attach_subscriber(agent)
       end
-
-      if ElasticAPM.running? &&
-         !ElasticAPM.agent.config.disabled_instrumentations.include?(
-           'action_dispatch'
-         )
-        require 'elastic_apm/spies/action_dispatch'
-      end
-
       ElasticAPM.running?
     rescue StandardError => e
       if config.disable_start_message?

--- a/lib/elastic_apm/rails.rb
+++ b/lib/elastic_apm/rails.rb
@@ -36,6 +36,7 @@ module ElasticAPM
            'action_dispatch'
          )
         require 'elastic_apm/spies/action_dispatch'
+        require 'elastic_apm/spies/action_controller'
       end
 
       ElasticAPM.running?

--- a/lib/elastic_apm/rails.rb
+++ b/lib/elastic_apm/rails.rb
@@ -36,7 +36,6 @@ module ElasticAPM
            'action_dispatch'
          )
         require 'elastic_apm/spies/action_dispatch'
-        require 'elastic_apm/spies/action_controller'
       end
 
       ElasticAPM.running?

--- a/lib/elastic_apm/spies/action_controller.rb
+++ b/lib/elastic_apm/spies/action_controller.rb
@@ -5,6 +5,7 @@ module ElasticAPM
   module Spies
     # @api private
     module ActionController
+      # @api private
       class BasicImplicitRenderSpy
         def install
           ::ActionController::BasicImplicitRender.module_eval do

--- a/lib/elastic_apm/spies/action_controller.rb
+++ b/lib/elastic_apm/spies/action_controller.rb
@@ -12,7 +12,7 @@ module ElasticAPM
             alias send_action_without_apm send_action
 
             def send_action(method_name, *args)
-              ElasticAPM.current_span.original_backtrace ||= caller
+              ElasticAPM.current_span&.original_backtrace ||= caller
               send_action_without_apm method_name, *args
             end
           end

--- a/lib/elastic_apm/spies/action_controller.rb
+++ b/lib/elastic_apm/spies/action_controller.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+module ElasticAPM
+  # @api private
+  module Spies
+    # @api private
+    module ActionController
+      class BasicImplicitRenderSpy
+        def install
+          ::ActionController::BasicImplicitRender.module_eval do
+            alias send_action_without_apm send_action
+
+            def send_action(method_name, *args)
+              ElasticAPM.current_span.original_backtrace ||= caller
+              send_action_without_apm method_name, *args
+            end
+          end
+        end
+      end
+    end
+
+    register(
+      'ActionController::BasicImplicitRender',
+      'action_controller/metal/basic_implicit_render',
+      ActionController::BasicImplicitRenderSpy.new
+    )
+  end
+end

--- a/spec/integration/rails_spec.rb
+++ b/spec/integration/rails_spec.rb
@@ -155,7 +155,7 @@ if enabled
           expect(name).to eq 'ApplicationController#index'
         end
 
-        it 'captures the backtrace for the span' do
+        it 'captures the stacktrace for the span' do
           get '/'
 
           EventCollector.wait_for transactions: 1, spans: 2

--- a/spec/integration/rails_spec.rb
+++ b/spec/integration/rails_spec.rb
@@ -163,7 +163,7 @@ if enabled
           span1, span2 = EventCollector.spans
           expect(span2['stacktrace'][0]).not_to be(nil)
           expect(span2['stacktrace'][0]['filename'])
-              .to eq('abstract_controller/base.rb')
+            .to eq('abstract_controller/base.rb')
         end
       end
 

--- a/spec/integration/rails_spec.rb
+++ b/spec/integration/rails_spec.rb
@@ -155,7 +155,7 @@ if enabled
           expect(name).to eq 'ApplicationController#index'
         end
 
-        it 'captures the stacktrace for the span' do
+        it 'captures the stacktrace for the span', if: ::Rails.version > '5' do
           get '/'
 
           EventCollector.wait_for transactions: 1, spans: 2

--- a/spec/integration/rails_spec.rb
+++ b/spec/integration/rails_spec.rb
@@ -160,9 +160,9 @@ if enabled
 
           EventCollector.wait_for transactions: 1, spans: 2
 
-          span1, span2 = EventCollector.spans
-          expect(span2['stacktrace'][0]).not_to be(nil)
-          expect(span2['stacktrace'][0]['filename'])
+          _, span = EventCollector.spans
+          expect(span['stacktrace'][0]).not_to be(nil)
+          expect(span['stacktrace'][0]['filename'])
             .to eq('abstract_controller/base.rb')
         end
       end

--- a/spec/integration/rails_spec.rb
+++ b/spec/integration/rails_spec.rb
@@ -37,6 +37,7 @@ if enabled
           config.elastic_apm.capture_body = 'all'
           config.elastic_apm.pool_size = Concurrent.processor_count
           config.elastic_apm.log_path = 'spec/elastic_apm.log'
+          config.elastic_apm.span_frames_min_duration = '-1'
         end
       end
 
@@ -152,6 +153,17 @@ if enabled
 
           name = EventCollector.transactions.fetch(0)['name']
           expect(name).to eq 'ApplicationController#index'
+        end
+
+        it 'captures the backtrace for the span' do
+          get '/'
+
+          EventCollector.wait_for transactions: 1, spans: 2
+
+          span1, span2 = EventCollector.spans
+          expect(span2['stacktrace'][0]).not_to be(nil)
+          expect(span2['stacktrace'][0]['filename'])
+              .to eq('abstract_controller/base.rb')
         end
       end
 


### PR DESCRIPTION
This PR adds a spy on the`BasicImplicitRender` module to capture the stacktrace before a controller action is called. It's missing the final call to the user's controller method but they could use the request metadata (the route specifically) to determine which action was called.

It would work for [Rails 5.x](https://github.com/rails/rails/blob/v5.2.4/actionpack/lib/action_controller/metal/basic_implicit_render.rb#L5-L7) and [Rails 6.x](https://github.com/rails/rails/blob/master/actionpack/lib/action_controller/metal/basic_implicit_render.rb#L5-L7).