### PR TITLE
Improve SQL summarizing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ spec/junit-reports
 .gem
 *.bulk
 vendor/
+log/test.log

--- a/.rspec
+++ b/.rspec
@@ -1,3 +1,3 @@
 --color
+--require spec_helper
 --exclude-pattern spec/integration/**/*_spec.rb
---fail-fast

--- a/.rspec
+++ b/.rspec
@@ -1,3 +1,3 @@
 --color
---require spec_helper
 --exclude-pattern spec/integration/**/*_spec.rb
+--fail-fast

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -44,6 +44,9 @@ Metrics/ModuleLength:
 Metrics/BlockLength:
   Enabled: false
 
+Metrics/BlockNesting:
+  Enabled: false
+
 Metrics/MethodLength:
   Enabled: false
 

--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -43,6 +43,7 @@ endif::[]
 ===== Added
 
 - Add `span.context.destination` fields {pull}647[#647]
+- Add more precise (experimental) SQL summarizer {pull}640[#640]
 
 [float]
 ===== Changed

--- a/bench/sql.rb
+++ b/bench/sql.rb
@@ -31,3 +31,17 @@ benchmark(CAPTION, 7, FORMAT, 'avg/ex:') do |bm|
 
   [(new - old) / examples.length]
 end
+
+## Stackprof
+
+require 'stackprof'
+
+puts 'Running stackprof'
+profile = StackProf.run(mode: :cpu) do
+  10.times do
+    examples.map { |i| ElasticAPM::Sql::Signature.parse(i) }
+  end
+end
+puts ''
+
+StackProf::Report.new(profile).print_text

--- a/bench/sql.rb
+++ b/bench/sql.rb
@@ -1,0 +1,33 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+$LOAD_PATH.unshift(File.expand_path('../lib', __dir__))
+
+require 'json'
+require 'benchmark'
+include Benchmark # rubocop:disable Style/MixinUsage
+
+require 'elastic_apm/sql_summarizer'
+require 'elastic_apm/sql/signature'
+
+examples =
+  JSON
+  .parse(File.read('./spec/fixtures/sql_signature_examples.json'))
+  .map { |ex| ex['input'] }
+
+examples = Array.new(100).map { examples }.flatten
+
+puts "#{'=' * 14} Parsing #{examples.length} examples #{'=' * 14}"
+
+summarizer = ElasticAPM::SqlSummarizer.new
+
+benchmark(CAPTION, 7, FORMAT, 'avg/ex:') do |bm|
+  old = bm.report('old:') do
+    examples.map { |i| summarizer.summarize(i) }
+  end
+  new = bm.report('new:') do
+    examples.map { |i| ElasticAPM::Sql::Signature.parse(i) }
+  end
+
+  [(new - old) / examples.length]
+end

--- a/bench/sql.rb
+++ b/bench/sql.rb
@@ -12,10 +12,8 @@ require 'elastic_apm/sql/signature'
 
 examples =
   JSON
-  .parse(File.read('./spec/fixtures/sql_signature_examples.json'))
+  .parse(File.read('../apm/tests/random_sql_query_set.json'))
   .map { |ex| ex['input'] }
-
-examples = Array.new(100).map { examples }.flatten
 
 puts "#{'=' * 14} Parsing #{examples.length} examples #{'=' * 14}"
 
@@ -38,9 +36,7 @@ require 'stackprof'
 
 puts 'Running stackprof'
 profile = StackProf.run(mode: :cpu) do
-  10.times do
-    examples.each { |i| ElasticAPM::Sql::Signature.parse(i) }
-  end
+  examples.each { |i| ElasticAPM::Sql::Signature.parse(i) }
 end
 puts ''
 

--- a/bench/sql.rb
+++ b/bench/sql.rb
@@ -39,7 +39,7 @@ require 'stackprof'
 puts 'Running stackprof'
 profile = StackProf.run(mode: :cpu) do
   10.times do
-    examples.map { |i| ElasticAPM::Sql::Signature.parse(i) }
+    examples.each { |i| ElasticAPM::Sql::Signature.parse(i) }
   end
 end
 puts ''

--- a/bin/build_docs
+++ b/bin/build_docs
@@ -2,4 +2,4 @@
 set -ex
 
 # Requires elastic/docs to be checked out at ../docs
-../docs/build_docs.pl --doc docs/index.asciidoc --chunk 1
+../docs/build_docs --doc docs/index.asciidoc --chunk 1

--- a/docs/configuration.asciidoc
+++ b/docs/configuration.asciidoc
@@ -736,7 +736,7 @@ context information, tags, or spans.
 
 Use a newer, more precise but still experimental approach to generating summaries of
 your app's SQL statements.
-Without this your SQL statements will still be summarized albeit less accurately.
+Without this, your SQL statements will still be summarized albeit less accurately.
 
 The summaries become the spans' names -- what it says in the waterfall view in Kibana.
 

--- a/docs/configuration.asciidoc
+++ b/docs/configuration.asciidoc
@@ -736,6 +736,7 @@ context information, tags, or spans.
 
 Use a newer, more precise but still experimental approach to generating summaries of
 your app's SQL statements.
+Without this your SQL statements will still be summarized albeit less accurately.
 
 The summaries become the spans' names -- what it says in the waterfall view in Kibana.
 

--- a/docs/configuration.asciidoc
+++ b/docs/configuration.asciidoc
@@ -727,6 +727,22 @@ We still record overall time and the result for unsampled transactions, but no
 context information, tags, or spans.
 
 [float]
+[[config-use-experimental-sql-parser]]
+==== `use_experimental_sql_parser`
+|============
+| Environment                               | `Config` key                  | Default
+| `ELASTIC_APM_USE_EXPERIMENTAL_SQL_PARSER` | `use_experimental_sql_parser` | `false`
+|============
+
+Use a newer, more precise but still experimental approach to generating summaries of
+your app's SQL statements.
+
+The summaries become the spans' names -- what it says in the waterfall view in Kibana.
+
+NOTE: This should work just fine but is still deamed experimental. That means it is
+subject to change. Please let us know if you come across any issues.
+
+[float]
 [[config-verify-server-cert]]
 ==== `verify_server_cert`
 |============

--- a/lib/elastic_apm/config.rb
+++ b/lib/elastic_apm/config.rb
@@ -70,7 +70,7 @@ module ElasticAPM
     option :transaction_sample_rate,           type: :float,  default: 1.0
     option :verify_server_cert,                type: :bool,   default: true
 
-    option :use_experimental_sql_parsing,      type: :bool,   default: false
+    option :use_experimental_sql_parser,      type: :bool,   default: false
 
     # rubocop:enable Metrics/LineLength, Layout/ExtraSpacing
     def initialize(options = {})

--- a/lib/elastic_apm/config.rb
+++ b/lib/elastic_apm/config.rb
@@ -69,6 +69,9 @@ module ElasticAPM
     option :transaction_max_spans,             type: :int,    default: 500
     option :transaction_sample_rate,           type: :float,  default: 1.0
     option :verify_server_cert,                type: :bool,   default: true
+
+    option :use_experimental_sql_parsing,      type: :bool,   default: false
+
     # rubocop:enable Metrics/LineLength, Layout/ExtraSpacing
     def initialize(options = {})
       @options = load_schema

--- a/lib/elastic_apm/normalizers/rails/active_record.rb
+++ b/lib/elastic_apm/normalizers/rails/active_record.rb
@@ -17,13 +17,7 @@ module ElasticAPM
         def initialize(*args)
           super
 
-          @summarizer ||=
-            if ElasticAPM.agent&.config&.use_experimental_sql_parsing
-              require 'elastic_apm/sql/signature'
-              Sql::Signature::Summarizer.new
-            else
-              SqlSummarizer.new
-            end
+          @summarizer = Sql.summarizer
 
           @adapters = {}
         end

--- a/lib/elastic_apm/normalizers/rails/active_record.rb
+++ b/lib/elastic_apm/normalizers/rails/active_record.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'elastic_apm/sql_summarizer'
+require 'elastic_apm/sql'
 
 module ElasticAPM
   module Normalizers

--- a/lib/elastic_apm/normalizers/rails/active_record.rb
+++ b/lib/elastic_apm/normalizers/rails/active_record.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'elastic_apm/sql_summarizer'
-require 'elastic_apm/sql/tokenizer'
 
 module ElasticAPM
   module Normalizers

--- a/lib/elastic_apm/normalizers/rails/active_record.rb
+++ b/lib/elastic_apm/normalizers/rails/active_record.rb
@@ -17,7 +17,14 @@ module ElasticAPM
         def initialize(*args)
           super
 
-          @summarizer = SqlSummarizer.new
+          @summarizer ||=
+            if ElasticAPM.agent&.config&.use_experimental_sql_parsing
+              require 'elastic_apm/sql/signature'
+              Sql::Signature::Summarizer.new
+            else
+              SqlSummarizer.new
+            end
+
           @adapters = {}
         end
 

--- a/lib/elastic_apm/normalizers/rails/active_record.rb
+++ b/lib/elastic_apm/normalizers/rails/active_record.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'elastic_apm/sql_summarizer'
+require 'elastic_apm/sql/tokenizer'
 
 module ElasticAPM
   module Normalizers

--- a/lib/elastic_apm/spies/sequel.rb
+++ b/lib/elastic_apm/spies/sequel.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'elastic_apm/sql_summarizer'
-require 'elastic_apm/sql/tokenizer'
 
 module ElasticAPM
   # @api private

--- a/lib/elastic_apm/spies/sequel.rb
+++ b/lib/elastic_apm/spies/sequel.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'elastic_apm/sql_summarizer'
+require 'elastic_apm/sql'
 
 module ElasticAPM
   # @api private

--- a/lib/elastic_apm/spies/sequel.rb
+++ b/lib/elastic_apm/spies/sequel.rb
@@ -11,13 +11,7 @@ module ElasticAPM
       ACTION = 'query'
 
       def self.summarizer
-        @summarizer ||=
-          if ElasticAPM.agent&.config&.use_experimental_sql_parsing
-            require 'elastic_apm/sql/signature'
-            Sql::Signature::Summarizer.new
-          else
-            SqlSummarizer.new
-          end
+        @summarizer = Sql.summarizer
       end
 
       def install

--- a/lib/elastic_apm/spies/sequel.rb
+++ b/lib/elastic_apm/spies/sequel.rb
@@ -11,7 +11,13 @@ module ElasticAPM
       ACTION = 'query'
 
       def self.summarizer
-        @summarizer ||= SqlSummarizer.new
+        @summarizer ||=
+          if ElasticAPM.agent&.config&.use_experimental_sql_parsing
+            require 'elastic_apm/sql/signature'
+            Sql::Signature::Summarizer.new
+          else
+            SqlSummarizer.new
+          end
       end
 
       def install

--- a/lib/elastic_apm/spies/sequel.rb
+++ b/lib/elastic_apm/spies/sequel.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'elastic_apm/sql_summarizer'
+require 'elastic_apm/sql/tokenizer'
 
 module ElasticAPM
   # @api private

--- a/lib/elastic_apm/sql.rb
+++ b/lib/elastic_apm/sql.rb
@@ -11,6 +11,7 @@ module ElasticAPM
           require 'elastic_apm/sql/signature'
           Sql::Signature::Summarizer.new
         else
+          require 'elastic_apm/sql_summarizer'
           SqlSummarizer.new
         end
     end

--- a/lib/elastic_apm/sql.rb
+++ b/lib/elastic_apm/sql.rb
@@ -7,7 +7,7 @@ module ElasticAPM
     # both implementations ~mikker
     def self.summarizer
       @summarizer ||=
-        if ElasticAPM.agent&.config&.use_experimental_sql_parsing
+        if ElasticAPM.agent&.config&.use_experimental_sql_parser
           require 'elastic_apm/sql/signature'
           Sql::Signature::Summarizer.new
         else

--- a/lib/elastic_apm/sql.rb
+++ b/lib/elastic_apm/sql.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module ElasticAPM
+  # @api private
+  module Sql
+    # This method is only here as a shortcut while the agent ships with
+    # both implementations ~mikker
+    def self.summarizer
+      @summarizer ||=
+        if ElasticAPM.agent&.config&.use_experimental_sql_parsing
+          require 'elastic_apm/sql/signature'
+          Sql::Signature::Summarizer.new
+        else
+          SqlSummarizer.new
+        end
+    end
+  end
+end

--- a/lib/elastic_apm/sql/signature.rb
+++ b/lib/elastic_apm/sql/signature.rb
@@ -8,6 +8,16 @@ module ElasticAPM
     class Signature
       include Tokens
 
+      # Mostly here to provide a similar API to new SqlSummarizer for easier
+      # swapping out
+      #
+      # @api private
+      class Summarizer
+        def summarize(sql)
+          Signature.parse(sql)
+        end
+      end
+
       def initialize(sql)
         @sql = sql
         @tokenizer = Tokenizer.new(sql)

--- a/lib/elastic_apm/sql/signature.rb
+++ b/lib/elastic_apm/sql/signature.rb
@@ -107,6 +107,7 @@ module ElasticAPM
       # rubocop:enable Metrics/CyclomaticComplexity
       # rubocop:enable Metrics/PerceivedComplexity
 
+      # Scans until finding token of `kind`
       def scan_until(kind)
         while @tokenizer.scan
           break true if @tokenizer.token == kind
@@ -114,6 +115,8 @@ module ElasticAPM
         end
       end
 
+      # Scans next token, ignoring comments
+      # Returns whether next token is of `kind`
       def scan_token(kind)
         while @tokenizer.scan
           next if @tokenizer.token == COMMENT

--- a/lib/elastic_apm/sql/signature.rb
+++ b/lib/elastic_apm/sql/signature.rb
@@ -1,0 +1,139 @@
+# frozen_string_literal: true
+
+require 'elastic_apm/sql/tokenizer'
+
+module ElasticAPM
+  module Sql
+    # @api private
+    class Signature
+      include Tokens
+
+      def initialize(sql)
+        @sql = sql
+        @tokenizer = Tokenizer.new(sql)
+      end
+
+      def parse
+        @tokenizer.scan # until tokenizer.token != COMMENT
+
+        parsed = parse_tokens
+        return parsed if parsed
+
+        # If all else fails, just return the first token of the query.
+        parts = @sql.split
+        return '' unless parts.any?
+
+        parts.first.upcase
+      end
+
+      def self.parse(sql)
+        new(sql).parse
+      end
+
+      private
+
+      # rubocop:disable Metrics/CyclomaticComplexity
+      # rubocop:disable Metrics/PerceivedComplexity
+      def parse_tokens
+        t = @tokenizer
+
+        case t.token
+
+        when CALL
+          return unless scan_until IDENT
+          "CALL #{t.text}"
+
+        when DELETE
+          return unless scan_until FROM
+          return unless scan_token IDENT
+          table = scan_dotted_identifier
+          "DELETE FROM #{table}"
+
+        when INSERT, REPLACE
+          action = t.text
+          return unless scan_until INTO
+          return unless scan_token IDENT
+          table = scan_dotted_identifier
+          "#{action} INTO #{table}"
+
+        when SELECT
+          level = 0
+          while t.scan
+            case t.token
+            when LPAREN then level += 1
+            when RPAREN then level -= 1
+            when FROM
+              next unless level == 0
+              break unless scan_token IDENT
+              table = scan_dotted_identifier
+              return "SELECT FROM #{table}"
+            end
+          end
+
+        when UPDATE
+          # Scan for the table name. Some dialects allow option keywords before
+          # the table name.
+          return 'UPDATE' unless scan_token IDENT
+
+          table = t.text
+
+          period = false
+          first_period = false
+
+          while t.scan
+            case t.token
+            when IDENT
+              if period
+                table += t.text
+                period = false
+              end
+
+              unless first_period
+                table = t.text
+              end
+
+              # Two adjacent identifiers found after the first period. Ignore
+              # the secondary ones, in case they are unknown keywords.
+            when PERIOD
+              period = true
+              first_period = true
+              table += '.'
+            else
+              return "UPDATE #{table}"
+            end
+          end
+        end
+      end
+      # rubocop:enable Metrics/CyclomaticComplexity
+      # rubocop:enable Metrics/PerceivedComplexity
+
+      def scan_until(kind)
+        while @tokenizer.scan
+          break true if @tokenizer.token == kind
+          false
+        end
+      end
+
+      def scan_token(kind)
+        while @tokenizer.scan
+          next if @tokenizer.token == COMMENT
+          break
+        end
+
+        return true if @tokenizer.token == kind
+
+        false
+      end
+
+      def scan_dotted_identifier
+        table = @tokenizer.text
+
+        while scan_token(PERIOD) && scan_token(IDENT)
+          table += ".#{@tokenizer.text}"
+        end
+
+        table
+      end
+    end
+  end
+end

--- a/lib/elastic_apm/sql/tokenizer.rb
+++ b/lib/elastic_apm/sql/tokenizer.rb
@@ -85,16 +85,17 @@ module ElasticAPM
         peek_char(length + 1)
       end
 
-      # rubocop:disable Metrics/CyclomaticComplexity
+      # rubocop:disable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
       def scan_keyword_or_identifier(possible_keyword:)
         while (peek = peek_char)
-          case peek
-          when ALPHA then nil # next
-          when DIGIT, '_', '$' then possible_keyword = false
-          else break
+          if peek == '_' || peek == '$' || peek =~ DIGIT
+            possible_keyword = false
+            next next_char
           end
 
-          next_char
+          next next_char if peek =~ ALPHA
+
+          break
         end
 
         return IDENT unless possible_keyword
@@ -110,10 +111,9 @@ module ElasticAPM
 
         IDENT
       end
-      # rubocop:enable Metrics/CyclomaticComplexity
+      # rubocop:enable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
 
-      # rubocop:disable Metrics/CyclomaticComplexity
-      # rubocop:disable Metrics/PerceivedComplexity
+      # rubocop:disable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
       def scan_dollar_sign
         while (peek = peek_char)
           case peek
@@ -148,8 +148,7 @@ module ElasticAPM
 
         OTHER
       end
-      # rubocop:enable Metrics/PerceivedComplexity
-      # rubocop:enable Metrics/CyclomaticComplexity
+      # rubocop:enable Metrics/PerceivedComplexity, Metrics/CyclomaticComplexity
 
       def scan_quoted_indentifier(delimiter)
         while (char = next_char)

--- a/lib/elastic_apm/sql/tokenizer.rb
+++ b/lib/elastic_apm/sql/tokenizer.rb
@@ -63,29 +63,20 @@ module ElasticAPM
       # rubocop:enable Metrics/CyclomaticComplexity
 
       def next_char
-        @scanner.getch.tap do
-          @byte_end = @scanner.pos
-        end
+        char = @scanner.getch
+        @byte_end = @scanner.pos
+        char
       end
 
-      # TODO: Unlike getch, this may return incomplete utf chars
-      # Need to figure out a way to detect and seek longer
-
-      # Returns next byte, fails with multibyte chars
-      # def peek_char
-      #   @scanner.peek(1)
-      # end
-
-      # Works, but messes with pos
-      # def peek_char
-      #   @scanner.getch.tap do |char|
-      #     @scanner.pos -= char.bytesize if char
-      #   end
-      # end
-
-      # Works, but need to check how performant `valid_encoding?` is and needs
-      # to abort if length reaches max unicode char byte size(?)
+      # StringScanner#peek returns next byte which could be an incomplete utf
+      # multi-byte character
       def peek_char(length = 1)
+        # The maximum byte count of utf chars is 4:
+        # > In UTF-8, characters from the U+0000..U+10FFFF range (the UTF-16
+        #   accessible range) are encoded using sequences of 1 to 4 octets.
+        # # https://tools.ietf.org/html/rfc3629
+        return nil if length > 4
+
         char = @scanner.peek(length)
 
         return nil if char.empty?

--- a/lib/elastic_apm/sql/tokenizer.rb
+++ b/lib/elastic_apm/sql/tokenizer.rb
@@ -1,0 +1,208 @@
+# frozen_string_literal: true
+
+require 'elastic_apm/sql/tokens'
+
+module ElasticAPM
+  module Sql
+    # @api private
+    class Tokenizer
+      include Tokens
+
+      ALPHA = /[[:alpha:]]/.freeze
+      DIGIT = /[[:digit:]]/.freeze
+      SPACE = /[[:space:]]+/.freeze
+
+      def initialize(input)
+        @input = input
+        @scanner = StringScanner.new(input)
+        @start = 0
+      end
+
+      attr_reader :input, :scanner, :token
+
+      def text
+        @input[@start...@end]
+      end
+
+      def scan
+        scanner.skip(SPACE)
+
+        @start = scanner.pos
+        @token = next_token
+
+        true
+      end
+
+      private
+
+      # rubocop:disable Metrics/CyclomaticComplexity
+      def next_token
+        char = next_char
+
+        case char
+        when '_'   then scan_keyword_or_identifier(possible_keyword: false)
+        when '.'   then PERIOD
+        when '$'   then scan_dollar_sign
+        when '`'   then scan_quoted_indentifier('`')
+        when '"'   then scan_quoted_indentifier('"')
+        when '['   then scan_quoted_indentifier(']')
+        when '('   then LPAREN
+        when ')'   then RPAREN
+        when '/'   then scan_bracketed_comment
+        when '-'   then scan_simple_comment
+        when "'"   then scan_string_literal
+        when ALPHA then scan_keyword_or_identifier(possible_keyword: true)
+        when DIGIT then scan_numeric_literal
+        else            OTHER
+        end
+      end
+      # rubocop:enable Metrics/CyclomaticComplexity
+
+      def next_char
+        @scanner.getch.tap do
+          @end = @scanner.pos
+        end
+      end
+
+      def peek_char
+        @scanner.peek(1)
+      end
+
+      # rubocop:disable Metrics/CyclomaticComplexity
+      def scan_keyword_or_identifier(possible_keyword:)
+        while (peek = peek_char)
+          case peek
+          when ALPHA then nil # next
+          when DIGIT, '_', '$' then possible_keyword = false
+          else break
+          end
+
+          next_char
+        end
+
+        return IDENT unless possible_keyword
+
+        snap = text
+
+        return IDENT if snap.length > KEYWORD_MAX_LENGTH
+
+        keyword = KEYWORDS[snap.length].find { |kw| snap.upcase == kw.to_s }
+        return keyword if keyword
+
+        IDENT
+      end
+      # rubocop:enable Metrics/CyclomaticComplexity
+
+      # rubocop:disable Metrics/CyclomaticComplexity
+      # rubocop:disable Metrics/PerceivedComplexity
+      def scan_dollar_sign
+        while (peek = peek_char)
+          case peek
+          when DIGIT
+            next_char while peek_char =~ DIGIT
+          when '$', '_', ALPHA
+            # PostgreSQL supports dollar-quoted string literal syntax,
+            # like $foo$...$foo$. The tag (foo in this case) is optional,
+            # and if present follows identifier rules.
+            while (char = next_char)
+              case char
+              when '$'
+                # This marks the end of the initial $foo$.
+                snap = text
+                slice = input.slice(scanner.pos, input.length)
+                index = slice.index(snap)
+                next unless index && index >= 0
+
+                delta = index + snap.length
+                @end += delta
+                scanner.pos += delta
+                return STRING
+              when SPACE
+                # Unknown token starting with $, consume chars until space.
+                @end -= 1
+                return OTHER
+              end
+            end
+          end
+
+          break OTHER
+        end
+      end
+      # rubocop:enable Metrics/PerceivedComplexity
+      # rubocop:enable Metrics/CyclomaticComplexity
+
+      def scan_quoted_indentifier(delimiter)
+        while (char = next_char)
+          next unless char == delimiter
+
+          if delimiter == '"' && peek_char == delimiter
+            next next_char
+          end
+
+          break
+        end
+
+        # Remove quotes from identifier
+        @start += 1
+        @end -= 1
+
+        IDENT
+      end
+
+      # rubocop:disable Metrics/CyclomaticComplexity
+      def scan_bracketed_comment
+        return OTHER unless peek_char == '*'
+
+        nesting = 1
+
+        while (char = next_char)
+          case char
+          when '/'
+            next unless peek_char == '*'
+            next_char
+            nesting += 1
+          when '*'
+            next unless peek_char == '/'
+            next_char
+            nesting -= 1
+            return COMMENT if nesting == 0
+          end
+        end
+      end
+      # rubocop:enable Metrics/CyclomaticComplexity
+
+      def scan_simple_comment
+        return OTHER unless peek_char == '-'
+
+        while (char = next_char)
+          break if char == "\n"
+        end
+
+        COMMENT
+      end
+
+      def scan_string_literal
+        delimiter = "'"
+
+        while (char = next_char)
+          if char == '\\'
+            # Skip escaped character, e.g. 'what\'s up?'
+            next_char
+            next
+          end
+
+          next unless char == delimiter
+
+          return STRING unless peek_char
+          return STRING if peek_char != delimiter
+
+          next_char
+        end
+      end
+
+      def scan_numeric_literal
+
+      end
+    end
+  end
+end

--- a/lib/elastic_apm/sql/tokenizer.rb
+++ b/lib/elastic_apm/sql/tokenizer.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require 'strscan'
 require 'elastic_apm/sql/tokens'
 
 module ElasticAPM

--- a/lib/elastic_apm/sql/tokenizer.rb
+++ b/lib/elastic_apm/sql/tokenizer.rb
@@ -29,7 +29,11 @@ module ElasticAPM
         scanner.skip(SPACE)
 
         @byte_start = scanner.pos
-        @token = next_token(next_char)
+        char = next_char
+
+        return false unless char
+
+        @token = next_token(char)
 
         true
       end
@@ -105,7 +109,9 @@ module ElasticAPM
 
         snap = text
 
-        return IDENT if snap.length > KEYWORD_MAX_LENGTH
+        if snap.length < KEYWORD_MIN_LENGTH || snap.length > KEYWORD_MAX_LENGTH
+          return IDENT
+        end
 
         keyword = KEYWORDS[snap.length].find { |kw| snap.upcase == kw.to_s }
         return keyword if keyword
@@ -121,7 +127,7 @@ module ElasticAPM
           case peek
           when DIGIT
             next_char while peek_char =~ DIGIT
-          when '$', '_', ALPHA
+          when '$', '_', ALPHA, SPACE
             # PostgreSQL supports dollar-quoted string literal syntax,
             # like $foo$...$foo$. The tag (foo in this case) is optional,
             # and if present follows identifier rules.
@@ -144,6 +150,7 @@ module ElasticAPM
                 return OTHER
               end
             end
+          else break
           end
         end
 

--- a/lib/elastic_apm/sql/tokens.rb
+++ b/lib/elastic_apm/sql/tokens.rb
@@ -39,7 +39,8 @@ module ElasticAPM
         8 => [TRUNCATE]
       }.freeze
 
-      KEYWORD_MAX_LENGTH = 8
+      KEYWORD_MIN_LENGTH = KEYWORDS.keys.first
+      KEYWORD_MAX_LENGTH = KEYWORDS.keys.last
     end
   end
 end

--- a/lib/elastic_apm/sql/tokens.rb
+++ b/lib/elastic_apm/sql/tokens.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+module ElasticAPM
+  module Sql
+    # @api private
+    module Tokens
+      OTHER = :OTHER
+      COMMENT = :COMMENT
+      IDENT = :IDENT
+      NUMBER = :NUMBER
+      STRING = :STRING
+
+      PERIOD = :PERIOD
+      COMMA = :COMMA
+      LPAREN = :LPAREN
+      RPAREN = :RPAREN
+
+      AS = :AS
+      CALL = :CALL
+      DELETE = :DELETE
+      FROM = :FROM
+      INSERT = :INSERT
+      INTO = :INTO
+      OR = :OR
+      REPLACE = :REPLACE
+      SELECT = :SELECT
+      SET = :SET
+      TABLE = :TABLE
+      TRUNCATE = :TRUNCATE
+      UPDATE = :UPDATE
+
+      KEYWORDS = {
+        2 => [AS, OR],
+        3 => [SET],
+        4 => [CALL, FROM, INTO],
+        5 => [TABLE],
+        6 => [DELETE, INSERT, SELECT, UPDATE],
+        7 => [REPLACE],
+        8 => [TRUNCATE]
+      }.freeze
+
+      KEYWORD_MAX_LENGTH = 8
+    end
+  end
+end

--- a/lib/elastic_apm/sql_summarizer.rb
+++ b/lib/elastic_apm/sql_summarizer.rb
@@ -18,14 +18,13 @@ module ElasticAPM
     }.freeze
 
     FORMAT = '%s%s'
-    UTF8 = 'UTF-8'
 
     def self.cache
       @cache ||= Util::LruCache.new
     end
 
     def summarize(sql)
-      sql = sql.encode(UTF8, invalid: :replace, undef: :replace)
+      sql = sql.encode('utf-8', invalid: :replace, undef: :replace)
       self.class.cache[sql] ||=
         REGEXES.find do |regex, sig|
           if (match = sql[0...1000].match(regex))

--- a/spec/elastic_apm/spies/sequel_spec.rb
+++ b/spec/elastic_apm/spies/sequel_spec.rb
@@ -20,7 +20,7 @@ module ElasticAPM
 
       db[:users].count # warm up
 
-      with_agent(use_experimental_sql_parsing: true) do
+      with_agent(use_experimental_sql_parser: true) do
         ElasticAPM.with_transaction 'Sequel test' do
           db[:users].count
         end

--- a/spec/elastic_apm/spies/sequel_spec.rb
+++ b/spec/elastic_apm/spies/sequel_spec.rb
@@ -20,7 +20,7 @@ module ElasticAPM
 
       db[:users].count # warm up
 
-      with_agent do
+      with_agent(use_experimental_sql_parsing: true) do
         ElasticAPM.with_transaction 'Sequel test' do
           db[:users].count
         end

--- a/spec/elastic_apm/sql/signature_spec.rb
+++ b/spec/elastic_apm/sql/signature_spec.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require 'elastic_apm/sql/signature'
+require 'json'
+
+module ElasticAPM
+  module Sql
+    RSpec.describe Signature do
+      describe 'examples:' do
+        examples =
+          JSON.parse(File.read('spec/fixtures/sql_signature_examples.json'))
+
+        examples.each_with_index.each do |info, i|
+          desc = "0#{i}"[-2..-1] + ': '
+
+          if info['comment']
+            desc += info['comment']
+          else
+            desc += info['input'][0...60].inspect
+            desc += ' => '
+            desc += info['output'].inspect
+          end
+
+          it(desc) do
+            expect(described_class.parse(info['input'])).to eq(info['output'])
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/elastic_apm/sql/tokenizer_spec.rb
+++ b/spec/elastic_apm/sql/tokenizer_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
-require 'json'
-require './lib/elastic_apm/sql/tokenizer'
+require 'elastic_apm/sql/tokenizer'
 
 module ElasticAPM
   module Sql

--- a/spec/elastic_apm/sql/tokenizer_spec.rb
+++ b/spec/elastic_apm/sql/tokenizer_spec.rb
@@ -10,7 +10,9 @@ module ElasticAPM
           JSON.parse(File.read('spec/fixtures/sql_lexer_examples.json'))
 
         examples.each do |info|
-          it info['comment'] do
+          desc = info['name']
+          desc += ": #{info['comment']}" if info['comment']
+          it desc do
             scanner = described_class.new(info['input'])
 
             info.fetch('tokens', []).each do |expected|

--- a/spec/elastic_apm/sql/tokenizer_spec.rb
+++ b/spec/elastic_apm/sql/tokenizer_spec.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require 'json'
+require './lib/elastic_apm/sql/tokenizer'
+
+module ElasticAPM
+  module Sql
+    RSpec.describe Tokenizer do
+      describe 'examples:' do
+        examples =
+          JSON.parse(File.read('spec/fixtures/sql_lexer_examples.json'))
+
+        examples.each do |info|
+          it info['comment'] do
+            scanner = described_class.new(info['input'])
+
+            info.fetch('tokens', []).each do |expected|
+              expect(scanner.scan).to be true
+              expect(
+                'kind' => scanner.token.to_s,
+                'text' => scanner.text
+              ).to eq(expected), info['input']
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/elastic_apm/sql/tokenizer_spec.rb
+++ b/spec/elastic_apm/sql/tokenizer_spec.rb
@@ -1,13 +1,14 @@
 # frozen_string_literal: true
 
 require 'elastic_apm/sql/tokenizer'
+require 'json'
 
 module ElasticAPM
   module Sql
     RSpec.describe Tokenizer do
       describe 'examples:' do
         examples =
-          JSON.parse(File.read('spec/fixtures/sql_lexer_examples.json'))
+          JSON.parse(File.read('spec/fixtures/sql_tokenizer_examples.json'))
 
         examples.each do |info|
           desc = info['name']
@@ -23,6 +24,16 @@ module ElasticAPM
               ).to eq(expected), info['input']
             end
           end
+        end
+      end
+
+      describe '#scan' do
+        it 'is true until end of string' do
+          scanner = described_class.new('a b c')
+          expect(scanner.scan).to be true
+          expect(scanner.scan).to be true
+          expect(scanner.scan).to be true
+          expect(scanner.scan).to be false
         end
       end
     end

--- a/spec/fixtures/sql_lexer_examples.json
+++ b/spec/fixtures/sql_lexer_examples.json
@@ -1,0 +1,230 @@
+[
+  {
+    "name": "whitespace-only",
+    "comment": "whitespace between tokens is ignored",
+    "input": "  "
+  },
+  {
+    "name": "keywords",
+    "comment": "keywords each have their own kind, and are scanned case-insensitively",
+    "input": "INSERT or rEpLaCe",
+    "tokens": [
+      {
+        "kind": "INSERT",
+        "text": "INSERT"
+      },
+      {
+        "kind": "OR",
+        "text": "or"
+      },
+      {
+        "kind": "REPLACE",
+        "text": "rEpLaCe"
+      }
+    ]
+  },
+  {
+    "name": "qualified-table",
+    "input": "schema.Abc_123",
+    "tokens": [
+      {
+        "kind": "IDENT",
+        "text": "schema"
+      },
+      {
+        "kind": "PERIOD",
+        "text": "."
+      },
+      {
+        "kind": "IDENT",
+        "text": "Abc_123"
+      }
+    ]
+  },
+  {
+    "name": "dollar-variable",
+    "comment": "dollar variables mustn't confuse dollar quoting",
+    "input": "$123",
+    "tokens": [
+      {
+        "kind": "OTHER",
+        "text": "$123"
+      }
+    ]
+  },
+  {
+    "name": "identifiers",
+    "input": "_foo foo$",
+    "tokens": [
+      {
+        "kind": "IDENT",
+        "text": "_foo"
+      },
+      {
+        "kind": "IDENT",
+        "text": "foo$"
+      }
+    ]
+  },
+  {
+    "name": "quoted-identifiers",
+    "input": "`SELECT` \"SELECT \"\"\" [SELECT '']",
+    "tokens": [
+      {
+        "kind": "IDENT",
+        "text": "SELECT"
+      },
+      {
+        "kind": "IDENT",
+        "text": "SELECT \"\""
+      },
+      {
+        "kind": "IDENT",
+        "text": "SELECT ''"
+      }
+    ]
+  },
+  {
+    "name": "punctuation",
+    "input": "().",
+    "tokens": [
+      {
+        "kind": "LPAREN",
+        "text": "("
+      },
+      {
+        "kind": "RPAREN",
+        "text": ")"
+      },
+      {
+        "kind": "PERIOD",
+        "text": "."
+      }
+    ]
+  },
+  {
+    "name": "comments",
+    "input": "/* /*nested*/ */ -- SELECT /*",
+    "tokens": [
+      {
+        "kind": "COMMENT",
+        "text": "/* /*nested*/ */"
+      },
+      {
+        "kind": "COMMENT",
+        "text": "-- SELECT /*"
+      }
+    ]
+  },
+  {
+    "name": "string-literal",
+    "input": "'abc '' def\\''",
+    "tokens": [
+      {
+        "kind": "STRING",
+        "text": "'abc '' def\\''"
+      }
+    ]
+  },
+  {
+    "name": "dollar-quoted-string-literal",
+    "input": "$$f$o$o$$ $$ $$ $foo$'`$$$$\"$foo$ $foo $bar",
+    "tokens": [
+      {
+        "kind": "STRING",
+        "text": "$$f$o$o$$"
+      },
+      {
+        "kind": "STRING",
+        "text": "$$ $$"
+      },
+      {
+        "kind": "STRING",
+        "text": "$foo$'`$$$$\"$foo$"
+      },
+      {
+        "kind": "OTHER",
+        "text": "$foo"
+      },
+      {
+        "kind": "OTHER",
+        "text": "$bar"
+      }
+    ]
+  },
+  {
+    "name": "unterminated-dollar-quoted-string-literal",
+    "comment": "Unterminated dollar-quoted string rewinds back to the first whitespace, under the assumption that the input is valid and we've interpreted it wrongly",
+    "input": "$foo$ banana $",
+    "tokens": [
+      {
+        "kind": "OTHER",
+        "text": "$foo$"
+      },
+      {
+        "kind": "IDENT",
+        "text": "banana"
+      },
+      {
+        "kind": "OTHER",
+        "text": "$"
+      }
+    ]
+  },
+  {
+    "name": "numeric-literals",
+    "input": "123 123.456 123E45 123e+45 123e-45 1.2.3",
+    "tokens": [
+      {
+        "kind": "NUMBER",
+        "text": "123"
+      },
+      {
+        "kind": "NUMBER",
+        "text": "123.456"
+      },
+      {
+        "kind": "NUMBER",
+        "text": "123E45"
+      },
+      {
+        "kind": "NUMBER",
+        "text": "123e+45"
+      },
+      {
+        "kind": "NUMBER",
+        "text": "123e-45"
+      },
+      {
+        "kind": "NUMBER",
+        "text": "1.2"
+      },
+      {
+        "kind": "PERIOD",
+	"text": "."
+      },
+      {
+        "kind": "NUMBER",
+	"text": "3"
+      }
+    ]
+  },
+  {
+	  "name": "unicode",
+	  "input": "选择 FROM foo",
+	  "tokens": [
+		  {
+			  "kind": "IDENT",
+			  "text": "选择"
+		  },
+		  {
+			  "kind": "FROM",
+			  "text": "FROM"
+		  },
+		  {
+			  "kind": "IDENT",
+			  "text": "foo"
+		  }
+	  ]
+  }
+]

--- a/spec/fixtures/sql_signature_examples.json
+++ b/spec/fixtures/sql_signature_examples.json
@@ -1,0 +1,146 @@
+[
+  {
+    "input": "",
+    "output": ""
+  },
+  {
+    "input": " ",
+    "output": ""
+  },
+  {
+    "input": "SELECT * FROM foo.bar",
+    "output": "SELECT FROM foo.bar"
+  },
+  {
+    "input": "SELECT * FROM foo.bar.baz",
+    "output": "SELECT FROM foo.bar.baz"
+  },
+  {
+    "input": "SELECT * FROM `foo.bar`",
+    "output": "SELECT FROM foo.bar"
+  },
+  {
+    "input": "SELECT * FROM \"foo.bar\"",
+    "output": "SELECT FROM foo.bar"
+  },
+  {
+    "input": "SELECT * FROM [foo.bar]",
+    "output": "SELECT FROM foo.bar"
+  },
+  {
+    "input": "SELECT (x, y) FROM foo,bar,baz",
+    "output": "SELECT FROM foo"
+  },
+  {
+    "input": "SELECT * FROM foo JOIN bar",
+    "output": "SELECT FROM foo"
+  },
+  {
+    "input": "SELECT * FROM dollar$bill",
+    "output": "SELECT FROM dollar$bill"
+  },
+  {
+    "input": "SELECT id FROM \"myta\n-æøåble\" WHERE id = 2323",
+    "output": "SELECT FROM myta\n-æøåble"
+  },
+  {
+    "input": "SELECT * FROM foo-- abc\n./*def*/bar",
+    "output": "SELECT FROM foo.bar"
+  },
+  {
+    "comment": "We capture the first table of the outermost select statement",
+    "input": "SELECT *,(SELECT COUNT(*) FROM table2 WHERE table2.field1 = table1.id) AS count FROM table1 WHERE table1.field1 = 'value'",
+    "output": "SELECT FROM table1"
+  },
+  {
+    "comment": "If the outermost select operates on derived tables, then we just return 'SELECT' (i.e. the fallback)",
+    "input": "SELECT * FROM (SELECT foo FROM bar) AS foo_bar",
+    "output": "SELECT"
+  },
+  {
+    "input": "DELETE FROM foo.bar WHERE baz=1",
+    "output": "DELETE FROM foo.bar"
+  },
+  {
+    "input": "UPDATE IGNORE foo.bar SET bar=1 WHERE baz=2",
+    "output": "UPDATE foo.bar"
+  },
+  {
+    "input": "UPDATE ONLY foo AS bar SET baz=1",
+    "output": "UPDATE foo"
+  },
+  {
+    "input": "INSERT INTO foo.bar (col) VALUES(?)",
+    "output": "INSERT INTO foo.bar"
+  },
+  {
+    "input": "INSERT LOW_PRIORITY IGNORE INTO foo.bar (col) VALUES(?)",
+    "output": "INSERT INTO foo.bar"
+  },
+  {
+    "input": "CALL foo(bar, 123)",
+    "output": "CALL foo"
+  },
+  {
+    "comment": "For DDL we only capture the first token",
+    "input": "ALTER TABLE foo ADD ()",
+    "output": "ALTER"
+  },
+  {
+    "input": "CREATE TABLE foo ...",
+    "output": "CREATE"
+  },
+  {
+    "input": "DROP TABLE foo",
+    "output": "DROP"
+  },
+  {
+    "input": "SAVEPOINT x_asd1234",
+    "output": "SAVEPOINT"
+  },
+  {
+    "input": "BEGIN",
+    "output": "BEGIN"
+  },
+  {
+    "input": "COMMIT",
+    "output": "COMMIT"
+  },
+  {
+    "input": "ROLLBACK",
+    "output": "ROLLBACK"
+  },
+  {
+    "comment": "For broken statements we only capture the first token",
+    "input": "SELECT * FROM (SELECT EOF",
+    "output": "SELECT"
+  },
+  {
+    "input": "SELECT 'neverending literal FROM (SELECT * FROM ...",
+    "output": "SELECT"
+  },
+  {
+    "input": "INSERT COIN TO PLAY",
+    "output": "INSERT"
+  },
+  {
+    "input": "INSERT $2 INTO",
+    "output": "INSERT"
+  },
+  {
+    "input": "UPDATE 99",
+    "output": "UPDATE"
+  },
+  {
+    "input": "DELETE 99",
+    "output": "DELETE"
+  },
+  {
+    "input": "DELETE FROM",
+    "output": "DELETE"
+  },
+  {
+    "input": "CALL",
+    "output": "CALL"
+  }
+]

--- a/spec/fixtures/sql_signature_examples.json
+++ b/spec/fixtures/sql_signature_examples.json
@@ -120,6 +120,10 @@
     "output": "SELECT"
   },
   {
+    "input": "SELECT REPLACE('this','is','at') FROM users",
+    "output": "SELECT FROM users"
+  },
+  {
     "input": "INSERT COIN TO PLAY",
     "output": "INSERT"
   },

--- a/spec/fixtures/sql_tokenizer_examples.json
+++ b/spec/fixtures/sql_tokenizer_examples.json
@@ -201,30 +201,30 @@
       },
       {
         "kind": "PERIOD",
-	"text": "."
+        "text": "."
       },
       {
         "kind": "NUMBER",
-	"text": "3"
+        "text": "3"
       }
     ]
   },
   {
-	  "name": "unicode",
-	  "input": "选择 FROM foo",
-	  "tokens": [
-		  {
-			  "kind": "IDENT",
-			  "text": "选择"
-		  },
-		  {
-			  "kind": "FROM",
-			  "text": "FROM"
-		  },
-		  {
-			  "kind": "IDENT",
-			  "text": "foo"
-		  }
-	  ]
+    "name": "unicode",
+    "input": "选择 FROM foo",
+    "tokens": [
+      {
+        "kind": "IDENT",
+        "text": "选择"
+      },
+      {
+        "kind": "FROM",
+        "text": "FROM"
+      },
+      {
+        "kind": "IDENT",
+        "text": "foo"
+      }
+    ]
   }
 ]

--- a/spec/integration/rails_spec.rb
+++ b/spec/integration/rails_spec.rb
@@ -12,7 +12,7 @@ if enabled
   require 'action_controller/railtie'
   require 'action_mailer/railtie'
 
-  RSpec.describe 'Rails integration', :allow_running_agent do
+  RSpec.describe 'Rails integration', :allow_running_agent, :spec_logger do
     include Rack::Test::Methods
     include_context 'event_collector'
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -59,6 +59,7 @@ module RailsTestHelpers
     config.consider_all_requests_local = false
     config.eager_load = false
     config.action_mailer.perform_deliveries = false
+    config.logger = Logger.new(SpecLogger)
 
     # Silence deprecation warning
     return unless defined?(ActionView::Railtie::NULL_OPTION)


### PR DESCRIPTION
This PR adds a new approach to summarising SQL queries for span names, eg `SELECT * FROM users WHERE ...` into `SELECT FROM users`.

It is borrowing heavily from [to Go agent's implementation](https://github.com/elastic/apm-agent-go/blob/master/internal/sqlscanner/scanner.go), including its JSON based test examples.

My suggestions is we add this as an experimental, opt-in feature first and then after testing we can consider replacing the old Regexp code.

- [x] Tokenisation
- [x] Summaries
- [x] Benchmarks
- [x] Feature flag
- [x] Docs
- [x] Changelog entry

---

### Benchmarks

1. This implementation is a bit slower than the current one. However, the overhead/query is tiny, eg. `0.000026` by average for the bundled examples.
    1. The bundled examples are all relatively short. This might be different for longer queries.
1. Have not made any efforts to speed up things yet.
1. The old `SqlSummarizer` has a built-in Least Recently Used cache. This is a relatively easy way to sacrifice memory over performance if need be.
1. The new implementation passes all the provided test examples while the old one chickens out on almost half of them, returning just `"SQL"`.

```sh
$ bench/sql.rb
============== Parsing 3600 examples ==============
              user     system      total        real
old:      0.004957   0.000218   0.005175 (  0.005247)
new:      0.141375   0.003283   0.144658 (  0.159984)
avg/ex:   0.000038   0.000001   0.000039 (  0.000043)
Running stackprof

==================================
  Mode: cpu(1000)
  Samples: 658 (0.00% miss rate)
  GC: 130 (19.76%)
==================================
     TOTAL    (pct)     SAMPLES    (pct)     FRAME
       203  (30.9%)         203  (30.9%)     ElasticAPM::Sql::Tokenizer#next_char
       130  (19.8%)         130  (19.8%)     (garbage collection)
       342  (52.0%)         107  (16.3%)     ElasticAPM::Sql::Tokenizer#scan_keyword_or_identifier
       441  (67.0%)          86  (13.1%)     ElasticAPM::Sql::Tokenizer#next_token
        47   (7.1%)          47   (7.1%)     ElasticAPM::Sql::Tokenizer#peek_char
       480  (72.9%)          23   (3.5%)     ElasticAPM::Sql::Tokenizer#scan
       314  (47.7%)          17   (2.6%)     ElasticAPM::Sql::Signature#parse_tokens
        15   (2.3%)          15   (2.3%)     ElasticAPM::Sql::Tokenizer#initialize
        10   (1.5%)          10   (1.5%)     ElasticAPM::Sql::Tokenizer#text
       513  (78.0%)          10   (1.5%)     ElasticAPM::Sql::Signature#parse
         6   (0.9%)           3   (0.5%)     ElasticAPM::Sql::Tokenizer#scan_quoted_indentifier
        98  (14.9%)           3   (0.5%)     ElasticAPM::Sql::Signature#scan_token
        43   (6.5%)           2   (0.3%)     ElasticAPM::Sql::Signature#scan_until
         5   (0.8%)           1   (0.2%)     ElasticAPM::Sql::Tokenizer#scan_string_literal
         2   (0.3%)           1   (0.2%)     ElasticAPM::Sql::Tokenizer#scan_dollar_sign
       528  (80.2%)           0   (0.0%)     <main>
       528  (80.2%)           0   (0.0%)     <main>
        41   (6.2%)           0   (0.0%)     ElasticAPM::Sql::Signature#scan_dotted_identifier
       528  (80.2%)           0   (0.0%)     block in <main>
       528  (80.2%)           0   (0.0%)     block (2 levels) in <main>
       528  (80.2%)           0   (0.0%)     block (3 levels) in <main>
       528  (80.2%)           0   (0.0%)     ElasticAPM::Sql::Signature.parse
        15   (2.3%)           0   (0.0%)     ElasticAPM::Sql::Signature#initialize
```
---

Reference doc for thoughts on how/why we summarise like we do: https://docs.google.com/document/d/1sblkAP1NHqk4MtloUta7tXjDuI_l64sT2ZQ_UFHuytA/edit#heading=h.549ltma0zvhu

Casandra CQL's special keywords are currently not included in this PR.

Closes elastic/apm-agent-ruby#622 