### PR TITLE
Add Ruby 2.7-rc (currently preview-3) to test matrix

### DIFF
--- a/.ci/.jenkins_exclude.yml
+++ b/.ci/.jenkins_exclude.yml
@@ -1,5 +1,6 @@
 exclude:
-  # Tests fail, but we don't care
+  - RUBY_VERSION: ruby:2.7-rc
+    FRAMEWORK: rails-4.2
   - RUBY_VERSION: jruby:9.2
     FRAMEWORK: rails-4.2
   - RUBY_VERSION: jruby:9.1

--- a/.ci/.jenkins_exclude.yml
+++ b/.ci/.jenkins_exclude.yml
@@ -25,6 +25,8 @@ exclude:
     FRAMEWORK: rails-6.0
 
   # Only test master on newest ruby
+  - RUBY_VERSION: ruby:2.7-rc
+    FRAMEWORK: rails-master
   - RUBY_VERSION: ruby:2.5
     FRAMEWORK: rails-master
   - RUBY_VERSION: ruby:2.4
@@ -67,6 +69,8 @@ exclude:
   - RUBY_VERSION: docker.elastic.co/observability-ci/jruby:9.1-7-jdk
     FRAMEWORK: sinatra-master
 
+  - RUBY_VERSION: ruby:2.7-rc
+    FRAMEWORK: grape-master
   - RUBY_VERSION: ruby:2.5
     FRAMEWORK: grape-master
   - RUBY_VERSION: ruby:2.4
@@ -88,6 +92,8 @@ exclude:
   - RUBY_VERSION: docker.elastic.co/observability-ci/jruby:9.1-7-jdk
     FRAMEWORK: grape-master
 
+  - RUBY_VERSION: ruby:2.7-rc
+    FRAMEWORK: grape-1.2,sinatra-2.0,rails-6.0
   - RUBY_VERSION: ruby:2.5
     FRAMEWORK: grape-1.2,sinatra-2.0,rails-6.0
   - RUBY_VERSION: ruby:2.4

--- a/.ci/.jenkins_ruby.yml
+++ b/.ci/.jenkins_ruby.yml
@@ -1,4 +1,5 @@
 RUBY_VERSION:
+  - ruby:2.7-rc
   - ruby:2.6
   - ruby:2.5
   - ruby:2.4


### PR DESCRIPTION
Released on Christmas day (25/12) we should probably start looking at compatibility.