### PR TITLE
Remove set_tag from docs, replace with set_label

### DIFF
--- a/docs/api.asciidoc
+++ b/docs/api.asciidoc
@@ -277,35 +277,6 @@ Returns `[String]` ID of the generated `[ElasticAPM::Error]` object.
 === Context
 
 [float]
-[[api-agent-set-tag]]
-==== `ElasticAPM.set_tag`
-
-Add a tag to the current transaction.
-Tags are basic key-value pairs that are indexed in your Elasticsearch database
-and therefore searchable. The value will always be converted to a String.
-
-TIP: Before using custom tags, ensure you understand the different types of
-{apm-overview-ref-v}/metadata.html[metadata] that are available.
-
-[source,ruby]
-----
-before_action do
-  ElasticAPM.set_tag(:company_id, current_user.company.id)
-end
-----
-
-Arguments:
-
-  * `key`: A string key. Note that `.`, `*` or `"` will be converted to `_`.
-  * `value`: A string value.
-
-Returns the set `value`.
-
-WARNING: Be aware that tags are indexed in Elasticsearch. Using too many unique keys will result in *https://www.elastic.co/blog/found-crash-elasticsearch#mapping-explosion[Mapping explosion]*.
-
-NOTE: This method has been deprecated in favor of `set_label`, which does not convert values to Strings.
-
-[float]
 [[api-agent-set-label]]
 ==== `ElasticAPM.set_label`
 

--- a/docs/context.asciidoc
+++ b/docs/context.asciidoc
@@ -19,14 +19,14 @@ end
 ----
 
 [float]
-==== Adding tags
+==== Adding labels
 
-Tags are special in that they are indexed in your Elasticsearch database and
-therefore searchable.
+Labels are special in that they are indexed in your Elasticsearch database and
+therefore queryable.
 
 [source,ruby]
 ----
-ElasticAPM.set_tag(:company_name, 'Acme, Inc.')
+ElasticAPM.set_label(:company_name, 'Acme, Inc.')
 ----
 
 Note that `.`, `*` and `"` in keys are converted to `_`.


### PR DESCRIPTION
Fixes elastic/apm-agent-ruby#644 

I'll investigate updating the blog post too.

**Edit:** Found it, updated it: https://www.elastic.co/blog/how-to-instrument-your-ruby-app-with-the-elastic-apm-ruby-agent