### PR TITLE
ci(jenkins): transform tag name to the version

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -228,12 +228,12 @@ pipeline {
               dir("${OPBEANS_REPO}"){
                 git credentialsId: 'f6c7695a-671e-4f4f-a331-acdce44ff9ba',
                     url: "git@github.com:elastic/${OPBEANS_REPO}.git"
-                sh script: ".ci/bump-version.sh ${env.BRANCH_NAME}", label: 'Bump version'
+                // It's required to transform the tag value to the gem version
+                sh script: ".ci/bump-version.sh ${env.BRANCH_NAME.replaceAll('^v', '')}", label: 'Bump version'
                 // The opbeans pipeline will trigger a release for the master branch
                 gitPush()
                 // The opbeans pipeline will trigger a release for the release tag
-                // It's required to transform the tag value to the gem version
-                gitCreateTag(tag: "${env.BRANCH_NAME.replaceAll('^v', '')}")
+                gitCreateTag(tag: "${env.BRANCH_NAME}")
               }
             }
           }

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -232,7 +232,8 @@ pipeline {
                 // The opbeans pipeline will trigger a release for the master branch
                 gitPush()
                 // The opbeans pipeline will trigger a release for the release tag
-                gitCreateTag(tag: "${env.BRANCH_NAME}")
+                // It's required to transform the tag value to the gem version
+                gitCreateTag(tag: "${env.BRANCH_NAME.replaceAll('^v', '')}")
               }
             }
           }


### PR DESCRIPTION
There are two approaches as far as I see:
- Grab the `VERSION` in `lib/elastic_apm/version.rb`
- Edit the `BRANCH_NAME` and replace `v` at the beginning.


The first approach might require some scripted pipelien to generate the value on the fly, while the second one is just an interpolation. Second one does require the overlap of the tag name with the version itself, if that' the case for all the upcoming release tags then we are safe otherwise we might need to consider the first approach though.