### PR TITLE
Add span.context.destination to relevant spans

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -40,6 +40,11 @@ endif::[]
 ==== Unreleased
 
 [float]
+===== Added
+
+- Add `span.context.destination` fields {pull}647[#647]
+
+[float]
 ===== Changed
 
 - Allow action dispatch spy to be disabled via `disabled_instrumentations` {pull}657[#657]

--- a/lib/elastic_apm/normalizers/rails/active_record.rb
+++ b/lib/elastic_apm/normalizers/rails/active_record.rb
@@ -25,14 +25,20 @@ module ElasticAPM
           return :skip if SKIP_NAMES.include?(payload[:name])
 
           name = summarize(payload[:sql]) || payload[:name]
+          subtype = subtype_for(payload)
+
           context =
-            Span::Context.new(db: { statement: payload[:sql], type: 'sql' })
-          [name, TYPE, subtype(payload), ACTION, context]
+            Span::Context.new(
+              db: { statement: payload[:sql], type: 'sql' },
+              destination: { name: subtype, resource: subtype, type: TYPE }
+            )
+
+          [name, TYPE, subtype, ACTION, context]
         end
 
         private
 
-        def subtype(payload)
+        def subtype_for(payload)
           cached_adapter_name(
             payload[:connection]&.adapter_name ||
               ::ActiveRecord::Base.connection_config[:adapter]

--- a/lib/elastic_apm/span/context.rb
+++ b/lib/elastic_apm/span/context.rb
@@ -29,9 +29,6 @@ module ElasticAPM
         :labels,
         :sync
       )
-
-      def self.from_uri(uri)
-      end
     end
   end
 end

--- a/lib/elastic_apm/span/context.rb
+++ b/lib/elastic_apm/span/context.rb
@@ -4,53 +4,37 @@ module ElasticAPM
   class Span
     # @api private
     class Context
-      def initialize(db: nil, http: nil, labels: {}, sync: nil)
+      def initialize(
+        db: nil,
+        destination: nil,
+        http: nil,
+        labels: {},
+        sync: nil
+      )
         @sync = sync
         @db = db && Db.new(db)
         @http = http && Http.new(http)
+        @destination = destination && Destination.new(destination)
         @labels = labels
       end
 
       attr_accessor :sync, :db, :http, :labels
+      attr_reader :destination
 
-      # @api private
-      class Db
-        def initialize(instance: nil, statement: nil, type: nil, user: nil)
-          @instance = instance
-          @statement = statement
-          @type = type
-          @user = user
-        end
-
-        attr_accessor :instance, :statement, :type, :user
-      end
-
-      # @api private
-      class Http
-        def initialize(url: nil, status_code: nil, method: nil)
-          @url = sanitize_url(url)
-          @status_code = status_code
-          @method = method
-        end
-
-        attr_accessor :url, :status_code, :method
-
-        private
-
-        def sanitize_url(url)
-          uri = URI(url)
-
-          return url unless uri.userinfo
-
-          format(
-            '%s://%s@%s%s',
-            uri.scheme,
-            uri.user,
-            uri.hostname,
-            uri.path
-          )
-        end
+      def self.from_uri(uri)
+        new(
+          http: { url: uri.to_s },
+          destination: {
+            name: uri.to_s,
+            resource: "#{uri.host}:#{uri.port}",
+            type: 'external'
+          }
+        )
       end
     end
   end
 end
+
+require 'elastic_apm/span/context/db'
+require 'elastic_apm/span/context/http'
+require 'elastic_apm/span/context/destination'

--- a/lib/elastic_apm/span/context.rb
+++ b/lib/elastic_apm/span/context.rb
@@ -14,7 +14,11 @@ module ElasticAPM
         @sync = sync
         @db = db && Db.new(db)
         @http = http && Http.new(http)
-        @destination = destination && Destination.new(destination)
+        @destination =
+          case destination
+          when Destination then destination
+          when Hash then Destination.new(**destination)
+          end
         @labels = labels
       end
 

--- a/lib/elastic_apm/span/context.rb
+++ b/lib/elastic_apm/span/context.rb
@@ -18,18 +18,15 @@ module ElasticAPM
         @labels = labels
       end
 
-      attr_accessor :sync, :db, :http, :labels
-      attr_reader :destination
+      attr_reader(
+        :db,
+        :destination,
+        :http,
+        :labels,
+        :sync
+      )
 
       def self.from_uri(uri)
-        new(
-          http: { url: uri.to_s },
-          destination: {
-            name: uri.to_s,
-            resource: "#{uri.host}:#{uri.port}",
-            type: 'external'
-          }
-        )
       end
     end
   end

--- a/lib/elastic_apm/span/context/db.rb
+++ b/lib/elastic_apm/span/context/db.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module ElasticAPM
+  class Span
+    class Context
+      # @api private
+      class Db
+        def initialize(instance: nil, statement: nil, type: nil, user: nil)
+          @instance = instance
+          @statement = statement
+          @type = type
+          @user = user
+        end
+
+        attr_accessor :instance, :statement, :type, :user
+      end
+    end
+  end
+end

--- a/lib/elastic_apm/span/context/destination.rb
+++ b/lib/elastic_apm/span/context/destination.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module ElasticAPM
+  class Span
+    class Context
+      # @api private
+      class Destination
+        def initialize(name: nil, resource: nil, type: nil)
+          @name = name
+          @resource = resource
+          @type = type
+        end
+
+        attr_reader :name, :resource, :type
+      end
+    end
+  end
+end

--- a/lib/elastic_apm/span/context/destination.rb
+++ b/lib/elastic_apm/span/context/destination.rb
@@ -12,6 +12,14 @@ module ElasticAPM
         end
 
         attr_reader :name, :resource, :type
+
+        def self.from_uri(uri)
+          new(
+            name: Util.sanitize_url(uri),
+            resource: "#{uri.host}:#{uri.port}",
+            type: 'external'
+          )
+        end
       end
     end
   end

--- a/lib/elastic_apm/span/context/destination.rb
+++ b/lib/elastic_apm/span/context/destination.rb
@@ -13,7 +13,9 @@ module ElasticAPM
 
         attr_reader :name, :resource, :type
 
-        def self.from_uri(uri, type: 'external')
+        def self.from_uri(uri_or_str, type: 'external')
+          uri = normalize(uri_or_str)
+
           new(
             name: only_scheme_and_host(uri),
             resource: "#{uri.host}:#{uri.port}",
@@ -22,10 +24,19 @@ module ElasticAPM
         end
 
         def self.only_scheme_and_host(uri_or_str)
-          uri = uri_or_str.is_a?(URI) ? uri_or_str.dup : URI(uri_or_str)
+          uri = normalize(uri_or_str)
           uri.path = ''
           uri.password = uri.query = uri.fragment = nil
           uri.to_s
+        end
+
+        class << self
+          private
+
+          def normalize(uri_or_str)
+            return uri_or_str.dup if uri_or_str.is_a?(URI)
+            URI(uri_or_str)
+          end
         end
       end
     end

--- a/lib/elastic_apm/span/context/destination.rb
+++ b/lib/elastic_apm/span/context/destination.rb
@@ -13,12 +13,19 @@ module ElasticAPM
 
         attr_reader :name, :resource, :type
 
-        def self.from_uri(uri)
+        def self.from_uri(uri, type: 'external')
           new(
-            name: Util.sanitize_url(uri),
+            name: only_scheme_and_host(uri),
             resource: "#{uri.host}:#{uri.port}",
-            type: 'external'
+            type: type
           )
+        end
+
+        def self.only_scheme_and_host(uri_or_str)
+          uri = uri_or_str.is_a?(URI) ? uri_or_str.dup : URI(uri_or_str)
+          uri.path = ''
+          uri.password = uri.query = uri.fragment = nil
+          uri.to_s
         end
       end
     end

--- a/lib/elastic_apm/span/context/http.rb
+++ b/lib/elastic_apm/span/context/http.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+module ElasticAPM
+  class Span
+    class Context
+      # @api private
+      class Http
+        def initialize(url: nil, status_code: nil, method: nil)
+          @url = sanitize_url(url)
+          @status_code = status_code
+          @method = method
+        end
+
+        attr_accessor :url, :status_code, :method
+
+        private
+
+        def sanitize_url(url)
+          uri = URI(url)
+
+          return url unless uri.userinfo
+
+          format(
+            '%s://%s@%s%s',
+            uri.scheme,
+            uri.user,
+            uri.hostname,
+            uri.path
+          )
+        end
+      end
+    end
+  end
+end

--- a/lib/elastic_apm/span/context/http.rb
+++ b/lib/elastic_apm/span/context/http.rb
@@ -6,12 +6,20 @@ module ElasticAPM
       # @api private
       class Http
         def initialize(url: nil, status_code: nil, method: nil)
-          @url = Util.sanitize_url(url)
+          @url = sanitize_url(url)
           @status_code = status_code
           @method = method
         end
 
         attr_accessor :url, :status_code, :method
+
+        private
+
+        def sanitize_url(uri_or_str)
+          uri = uri_or_str.is_a?(URI) ? uri_or_str.dup : URI(uri_or_str)
+          uri.password = nil
+          uri.to_s
+        end
       end
     end
   end

--- a/lib/elastic_apm/span/context/http.rb
+++ b/lib/elastic_apm/span/context/http.rb
@@ -6,28 +6,12 @@ module ElasticAPM
       # @api private
       class Http
         def initialize(url: nil, status_code: nil, method: nil)
-          @url = sanitize_url(url)
+          @url = Util.sanitize_url(url)
           @status_code = status_code
           @method = method
         end
 
         attr_accessor :url, :status_code, :method
-
-        private
-
-        def sanitize_url(url)
-          uri = URI(url)
-
-          return url unless uri.userinfo
-
-          format(
-            '%s://%s@%s%s',
-            uri.scheme,
-            uri.user,
-            uri.hostname,
-            uri.path
-          )
-        end
       end
     end
   end

--- a/lib/elastic_apm/spies/elasticsearch.rb
+++ b/lib/elastic_apm/spies/elasticsearch.rb
@@ -6,7 +6,9 @@ module ElasticAPM
     # @api private
     class ElasticsearchSpy
       NAME_FORMAT = '%s %s'
-      TYPE = 'db.elasticsearch'
+      TYPE = 'db'
+      SUBTYPE = 'elasticsearch'
+
       def install
         ::Elasticsearch::Transport::Client.class_eval do
           alias perform_request_without_apm perform_request
@@ -24,9 +26,12 @@ module ElasticAPM
               }
             )
 
-            ElasticAPM.with_span name, TYPE, context: context do
-              perform_request_without_apm(method, path, *args, &block)
-            end
+            ElasticAPM.with_span(
+              name,
+              TYPE,
+              subtype: SUBTYPE,
+              context: context
+            ) { perform_request_without_apm(method, path, *args, &block) }
           end
         end
       end

--- a/lib/elastic_apm/spies/elasticsearch.rb
+++ b/lib/elastic_apm/spies/elasticsearch.rb
@@ -14,7 +14,15 @@ module ElasticAPM
           def perform_request(method, path, *args, &block)
             name = format(NAME_FORMAT, method, path)
             statement = args[0].is_a?(String) ? args[0] : args[0].to_json
-            context = Span::Context.new(db: { statement: statement })
+
+            context = Span::Context.new(
+              db: { statement: statement },
+              destination: {
+                name: 'elasticsearch',
+                resource: 'elasticsearch',
+                type: 'db'
+              }
+            )
 
             ElasticAPM.with_span name, TYPE, context: context do
               perform_request_without_apm(method, path, *args, &block)

--- a/lib/elastic_apm/spies/elasticsearch.rb
+++ b/lib/elastic_apm/spies/elasticsearch.rb
@@ -20,9 +20,9 @@ module ElasticAPM
             context = Span::Context.new(
               db: { statement: statement },
               destination: {
-                name: 'elasticsearch',
-                resource: 'elasticsearch',
-                type: 'db'
+                name: SUBTYPE,
+                resource: SUBTYPE,
+                type: TYPE
               }
             )
 

--- a/lib/elastic_apm/spies/http.rb
+++ b/lib/elastic_apm/spies/http.rb
@@ -19,17 +19,31 @@ module ElasticAPM
             method = req.verb.to_s.upcase
             host = req.uri.host
 
+            destination =
+              ElasticAPM::Span::Context::Destination.from_uri(req.uri)
+            context = ElasticAPM::Span::Context.new(
+              http: { url: req.uri, method: method },
+              destination: destination
+            )
+
             name = "#{method} #{host}"
 
             ElasticAPM.with_span(
               name,
               TYPE,
               subtype: SUBTYPE,
-              action: method
+              action: method,
+              context: context
             ) do |span|
               trace_context = span&.trace_context || transaction.trace_context
               req['Elastic-Apm-Traceparent'] = trace_context.to_header
-              perform_without_apm(req, options)
+              result = perform_without_apm(req, options)
+
+              if (http = span&.context&.http)
+                http.status_code = result.status.to_s
+              end
+
+              result
             end
           end
         end

--- a/lib/elastic_apm/spies/mongo.rb
+++ b/lib/elastic_apm/spies/mongo.rb
@@ -81,6 +81,11 @@ module ElasticAPM
               statement: event.command.to_s,
               type: 'mongodb',
               user: nil
+            },
+            destination: {
+              name: SUBTYPE,
+              resource: SUBTYPE,
+              type: TYPE
             }
           )
         end

--- a/lib/elastic_apm/spies/net_http.rb
+++ b/lib/elastic_apm/spies/net_http.rb
@@ -50,14 +50,13 @@ module ElasticAPM
             cls = use_ssl? ? URI::HTTPS : URI::HTTP
             uri = cls.build([nil, host, port, path, query, nil])
 
+            destination =
+              ElasticAPM::Span::Context::Destination.from_uri(uri)
+
             context =
               ElasticAPM::Span::Context.new(
                 http: { url: uri, method: method },
-                destination: {
-                  name: Util.sanitize_url(uri),
-                  resource: "#{uri.host}:#{uri.port}",
-                  type: 'external'
-                }
+                destination: destination
               )
 
             ElasticAPM.with_span(

--- a/lib/elastic_apm/spies/net_http.rb
+++ b/lib/elastic_apm/spies/net_http.rb
@@ -29,6 +29,7 @@ module ElasticAPM
         end
       end
 
+      # rubocop:disable Metrics/CyclomaticComplexity
       def install
         Net::HTTP.class_eval do
           alias request_without_apm request
@@ -79,6 +80,7 @@ module ElasticAPM
           end
         end
       end
+      # rubocop:enable Metrics/CyclomaticComplexity
     end
 
     register 'Net::HTTP', 'net/http', NetHTTPSpy.new

--- a/lib/elastic_apm/spies/sequel.rb
+++ b/lib/elastic_apm/spies/sequel.rb
@@ -34,7 +34,7 @@ module ElasticAPM
 
             context = ElasticAPM::Span::Context.new(
               db: { statement: sql, type: 'sql', user: opts[:user] },
-              destination: { name: subtype, resource: subtype, type: 'db' }
+              destination: { name: subtype, resource: subtype, type: TYPE }
             )
 
             ElasticAPM.with_span(

--- a/lib/elastic_apm/spies/sequel.rb
+++ b/lib/elastic_apm/spies/sequel.rb
@@ -7,16 +7,11 @@ module ElasticAPM
   module Spies
     # @api private
     class SequelSpy
-      TYPE = 'db.sequel.sql'
+      TYPE = 'db'
+      ACTION = 'query'
 
       def self.summarizer
         @summarizer ||= SqlSummarizer.new
-      end
-
-      def self.build_context(sql, opts)
-        Span::Context.new(
-          db: { statement: sql, type: 'sql', user: opts[:user] }
-        )
       end
 
       def install
@@ -25,16 +20,31 @@ module ElasticAPM
         ::Sequel::Database.class_eval do
           alias log_connection_yield_without_apm log_connection_yield
 
-          def log_connection_yield(sql, *args, &block)
+          def log_connection_yield(sql, connection, args = nil, &block)
             unless ElasticAPM.current_transaction
-              return log_connection_yield_without_apm(sql, *args, &block)
+              return log_connection_yield_without_apm(
+                sql, connection, args, &block
+              )
             end
 
-            summarizer = ElasticAPM::Spies::SequelSpy.summarizer
-            name = summarizer.summarize sql
-            context = ElasticAPM::Spies::SequelSpy.build_context(sql, opts)
+            subtype = database_type.to_s
 
-            ElasticAPM.with_span(name, TYPE, context: context, &block)
+            name =
+              ElasticAPM::Spies::SequelSpy.summarizer.summarize sql
+
+            context = ElasticAPM::Span::Context.new(
+              db: { statement: sql, type: 'sql', user: opts[:user] },
+              destination: { name: subtype, resource: subtype, type: 'db' }
+            )
+
+            ElasticAPM.with_span(
+              name,
+              TYPE,
+              subtype: subtype,
+              action: ACTION,
+              context: context,
+              &block
+            )
           end
         end
       end

--- a/lib/elastic_apm/transport/serializers/span_serializer.rb
+++ b/lib/elastic_apm/transport/serializers/span_serializer.rb
@@ -12,6 +12,7 @@ module ElasticAPM
         end
 
         attr_reader :context_serializer
+
         def build(span)
           {
             span: {
@@ -36,7 +37,7 @@ module ElasticAPM
 
             base = {}
 
-            base[:sync] = context.sync if context.sync
+            base[:sync] = context.sync unless context.sync.nil?
             base[:db] = build_db(context.db) if context.db
             base[:http] = build_http(context.http) if context.http
 

--- a/lib/elastic_apm/transport/serializers/span_serializer.rb
+++ b/lib/elastic_apm/transport/serializers/span_serializer.rb
@@ -69,9 +69,9 @@ module ElasticAPM
           def build_destination(destination)
             {
               service: {
-                name: destination.name,
-                resource: destination.resource,
-                type: destination.type
+                name: keyword_field(destination.name),
+                resource: keyword_field(destination.resource),
+                type: keyword_field(destination.type)
               }
             }
           end

--- a/lib/elastic_apm/util.rb
+++ b/lib/elastic_apm/util.rb
@@ -33,11 +33,5 @@ module ElasticAPM
 
       value[0...(max_length - 1)] + '…'
     end
-
-    def self.sanitize_url(uri)
-      uri = URI(uri) # accepts String or URI
-      uri.password = nil
-      uri.to_s
-    end
   end
 end

--- a/lib/elastic_apm/util.rb
+++ b/lib/elastic_apm/util.rb
@@ -33,5 +33,11 @@ module ElasticAPM
 
       value[0...(max_length - 1)] + '…'
     end
+
+    def self.sanitize_url(uri)
+      uri = URI(uri) # accepts String or URI
+      uri.password = nil
+      uri.to_s
+    end
   end
 end

--- a/spec/elastic_apm/span/context/destination_spec.rb
+++ b/spec/elastic_apm/span/context/destination_spec.rb
@@ -5,7 +5,7 @@ module ElasticAPM
     class Context
       RSpec.describe Destination do
         describe '.from_uri' do
-          let(:uri) { URI('http://example.com') }
+          let(:uri) { URI('http://example.com/path/?a=1') }
 
           subject { described_class.from_uri(uri) }
 
@@ -14,12 +14,12 @@ module ElasticAPM
           its(:type) { is_expected.to eq 'external' }
 
           context 'https' do
-            let(:uri) { URI('https://example.com') }
+            let(:uri) { URI('https://example.com/path?a=1') }
             its(:resource) { is_expected.to eq 'example.com:443' }
           end
 
           context 'non-default port' do
-            let(:uri) { URI('http://example.com:8080') }
+            let(:uri) { URI('http://example.com:8080/path?a=1') }
             its(:resource) { is_expected.to eq 'example.com:8080' }
           end
         end

--- a/spec/elastic_apm/span/context/destination_spec.rb
+++ b/spec/elastic_apm/span/context/destination_spec.rb
@@ -24,6 +24,14 @@ module ElasticAPM
             its(:name) { is_expected.to eq 'http://example.com:8080' }
             its(:resource) { is_expected.to eq 'example.com:8080' }
           end
+
+          context 'when given a string' do
+            let(:uri) { 'http://example.com/path?a=1' }
+
+            its(:name) { is_expected.to eq 'http://example.com' }
+            its(:resource) { is_expected.to eq 'example.com:80' }
+            its(:type) { is_expected.to eq 'external' }
+          end
         end
       end
     end

--- a/spec/elastic_apm/span/context/destination_spec.rb
+++ b/spec/elastic_apm/span/context/destination_spec.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+module ElasticAPM
+  class Span
+    class Context
+      RSpec.describe Destination do
+        describe '.from_uri' do
+          let(:uri) { URI('http://example.com') }
+
+          subject { described_class.from_uri(uri) }
+
+          its(:name) { is_expected.to eq 'http://example.com' }
+          its(:resource) { is_expected.to eq 'example.com:80' }
+          its(:type) { is_expected.to eq 'external' }
+
+          context 'https' do
+            let(:uri) { URI('https://example.com') }
+            its(:resource) { is_expected.to eq 'example.com:443' }
+          end
+
+          context 'non-default port' do
+            let(:uri) { URI('http://example.com:8080') }
+            its(:resource) { is_expected.to eq 'example.com:8080' }
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/elastic_apm/span/context/destination_spec.rb
+++ b/spec/elastic_apm/span/context/destination_spec.rb
@@ -15,11 +15,13 @@ module ElasticAPM
 
           context 'https' do
             let(:uri) { URI('https://example.com/path?a=1') }
+            its(:name) { is_expected.to eq 'https://example.com' }
             its(:resource) { is_expected.to eq 'example.com:443' }
           end
 
           context 'non-default port' do
             let(:uri) { URI('http://example.com:8080/path?a=1') }
+            its(:name) { is_expected.to eq 'http://example.com:8080' }
             its(:resource) { is_expected.to eq 'example.com:8080' }
           end
         end

--- a/spec/elastic_apm/span/context_spec.rb
+++ b/spec/elastic_apm/span/context_spec.rb
@@ -36,6 +36,20 @@ module ElasticAPM
           end
         end
       end
+
+      context 'with destination' do
+        subject do
+          described_class.new(
+            destination: { name: 'nam', resource: 'res', type: 'typ' }
+          )
+        end
+
+        it 'adds a Destination object' do
+          expect(subject.destination.name).to eq 'nam'
+          expect(subject.destination.resource).to eq 'res'
+          expect(subject.destination.type).to eq 'typ'
+        end
+      end
     end
   end
 end

--- a/spec/elastic_apm/spies/elasticsearch_spec.rb
+++ b/spec/elastic_apm/spies/elasticsearch_spec.rb
@@ -23,6 +23,11 @@ module ElasticAPM
       expect(span.context.db.statement).to eq('{"q":"test"}')
 
       expect(net_span.name).to eq 'GET localhost'
+
+      destination = span.context.destination
+      expect(destination.name).to eq 'elasticsearch'
+      expect(destination.resource).to eq 'elasticsearch'
+      expect(destination.type).to eq 'db'
     end
   end
 end

--- a/spec/elastic_apm/spies/faraday_spec.rb
+++ b/spec/elastic_apm/spies/faraday_spec.rb
@@ -57,7 +57,7 @@ module ElasticAPM
       span, = @intercepted.spans
 
       destination = span.context.destination
-      expect(destination.name).to match('http://example.com/page.html')
+      expect(destination.name).to match('http://example.com')
       expect(destination.resource).to match('example.com:80')
       expect(destination.type).to match('external')
     end

--- a/spec/elastic_apm/spies/faraday_spec.rb
+++ b/spec/elastic_apm/spies/faraday_spec.rb
@@ -25,7 +25,41 @@ module ElasticAPM
       expect(span.name).to eq 'GET example.com'
       expect(span.type).to eq 'ext'
       expect(span.subtype).to eq 'faraday'
-      expect(span.action).to eq 'get'
+      expect(span.action).to eq 'GET'
+    end
+
+    it 'adds http context' do
+      WebMock.stub_request(:get, %r{http://example.com/.*})
+
+      with_agent do
+        ElasticAPM.with_transaction 'Faraday test' do
+          client.get('http://example.com/page.html')
+        end
+      end
+
+      span, = @intercepted.spans
+
+      http = span.context.http
+      expect(http.url).to match('http://example.com/page.html')
+      expect(http.method).to match('GET')
+      expect(http.status_code).to match('200')
+    end
+
+    it 'adds destination information' do
+      WebMock.stub_request(:get, %r{http://example.com/.*})
+
+      with_agent do
+        ElasticAPM.with_transaction 'Faraday test' do
+          client.get('http://example.com/page.html')
+        end
+      end
+
+      span, = @intercepted.spans
+
+      destination = span.context.destination
+      expect(destination.name).to match('http://example.com/page.html')
+      expect(destination.resource).to match('example.com:80')
+      expect(destination.type).to match('external')
     end
 
     it 'spans http calls with prefix' do
@@ -43,7 +77,7 @@ module ElasticAPM
       expect(span.name).to eq 'GET example.com'
       expect(span.type).to eq 'ext'
       expect(span.subtype).to eq 'faraday'
-      expect(span.action).to eq 'get'
+      expect(span.action).to eq 'GET'
     end
 
     it 'spans http calls when url in block' do
@@ -64,7 +98,7 @@ module ElasticAPM
       expect(span.name).to eq 'GET example.com'
       expect(span.type).to eq 'ext'
       expect(span.subtype).to eq 'faraday'
-      expect(span.action).to eq 'get'
+      expect(span.action).to eq 'GET'
     end
 
     it 'adds traceparent header' do

--- a/spec/elastic_apm/spies/http_spec.rb
+++ b/spec/elastic_apm/spies/http_spec.rb
@@ -21,6 +21,40 @@ module ElasticAPM
       expect(span.name).to eq 'GET example.com'
     end
 
+    it 'adds http context' do
+      WebMock.stub_request(:get, %r{http://example.com/.*})
+
+      with_agent do
+        ElasticAPM.with_transaction 'Http.rb test' do
+          HTTP.get('http://example.com/page.html')
+        end
+      end
+
+      span, = @intercepted.spans
+
+      http = span.context.http
+      expect(http.url).to match('http://example.com/page.html')
+      expect(http.method).to match('GET')
+      expect(http.status_code).to match('200')
+    end
+
+    it 'adds destination information' do
+      WebMock.stub_request(:get, %r{http://example.com/.*})
+
+      with_agent do
+        ElasticAPM.with_transaction 'Http.rb test' do
+          HTTP.get('http://example.com/page.html')
+        end
+      end
+
+      span, = @intercepted.spans
+
+      destination = span.context.destination
+      expect(destination.name).to match('http://example.com/page.html')
+      expect(destination.resource).to match('example.com:80')
+      expect(destination.type).to match('external')
+    end
+
     it 'adds traceparent header' do
       req_stub =
         WebMock.stub_request(:get, %r{http://example.com/.*}).with do |req|

--- a/spec/elastic_apm/spies/http_spec.rb
+++ b/spec/elastic_apm/spies/http_spec.rb
@@ -50,7 +50,7 @@ module ElasticAPM
       span, = @intercepted.spans
 
       destination = span.context.destination
-      expect(destination.name).to match('http://example.com/page.html')
+      expect(destination.name).to match('http://example.com')
       expect(destination.resource).to match('example.com:80')
       expect(destination.type).to match('external')
     end

--- a/spec/elastic_apm/spies/mongo_spec.rb
+++ b/spec/elastic_apm/spies/mongo_spec.rb
@@ -33,6 +33,11 @@ module ElasticAPM
         expect(db.type).to eq 'mongodb'
         expect(db.statement).to eq('{"listCollections"=>1}')
         expect(db.user).to be nil
+
+        destination = span.context.destination
+        expect(destination.name).to eq 'mongodb'
+        expect(destination.resource).to eq 'mongodb'
+        expect(destination.type).to eq 'db'
       end
     end
 

--- a/spec/elastic_apm/spies/sequel_spec.rb
+++ b/spec/elastic_apm/spies/sequel_spec.rb
@@ -31,6 +31,11 @@ module ElasticAPM
       expect(span.name).to eq 'SELECT FROM users'
       expect(span.context.db.statement)
         .to eq "SELECT count(*) AS 'count' FROM `users` LIMIT 1"
+
+      destination = span.context.destination
+      expect(destination.name).to eq 'sqlite'
+      expect(destination.resource).to eq 'sqlite'
+      expect(destination.type).to eq 'db'
     end
   end
 end

--- a/spec/elastic_apm/transport/serializers/span_serializer_spec.rb
+++ b/spec/elastic_apm/transport/serializers/span_serializer_spec.rb
@@ -94,6 +94,26 @@ module ElasticAPM
             end
           end
 
+          context 'with a destination' do
+            it 'adds destination object' do
+              span = Span.new(
+                name: 'Span',
+                transaction: transaction,
+                parent: transaction,
+                trace_context: trace_context,
+                context: Span::Context.new(
+                  destination: { name: 'a', resource: 'b', type: 'c' }
+                )
+              )
+
+              result = subject.build(span)
+
+              expect(result.dig(:span, :context, :destination)).to match(
+                service: { name: 'a', resource: 'b', type: 'c' }
+              )
+            end
+          end
+
           context 'with a large db.statement' do
             it 'truncates to 10k chars' do
               span = Span.new(


### PR DESCRIPTION
This PR adds information to a new field for all _outgoing_ spans, eg. HTTP, databases.

> For the service maps feature, we need to report the logical destination of a span in order to discover the unique connections between services without processing every single span. We also need to have a field that will eventually help detect if two non-instrumented services are the same. Sameness detection will not be perfect in this iteration, but it will be good enough for the first version.

Closes elastic/apm-agent-ruby#613 