### PR TITLE
ci(jenkins): checkout master branch for the rebase

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -51,8 +51,7 @@ pipeline {
       steps {
         pipelineManager([ cancelPreviousRunningBuilds: [ when: 'PR' ] ])
         deleteDir()
-        gitCheckout(basedir: "${BASE_DIR}", githubNotifyFirstTimeContributor: true,
-                    shallow: false, reference: "/var/lib/jenkins/.git-references/${REPO}.git")
+        gitCheckout(basedir: "${BASE_DIR}", githubNotifyFirstTimeContributor: true)
         stash allowEmpty: true, name: 'source', useDefaultExcludes: false
       }
     }

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -51,7 +51,8 @@ pipeline {
       steps {
         pipelineManager([ cancelPreviousRunningBuilds: [ when: 'PR' ] ])
         deleteDir()
-        gitCheckout(basedir: "${BASE_DIR}", githubNotifyFirstTimeContributor: true)
+        gitCheckout(basedir: "${BASE_DIR}", githubNotifyFirstTimeContributor: true,
+                    shallow: false, reference: "/var/lib/jenkins/.git-references/${REPO}.git")
         stash allowEmpty: true, name: 'source', useDefaultExcludes: false
       }
     }

--- a/.ci/prepare-git-context.sh
+++ b/.ci/prepare-git-context.sh
@@ -18,6 +18,9 @@ git config --global user.name "${USER_NAME}"
 git fetch --all
 git checkout "${BRANCH_NAME}"
 
+# Checkout the master branch to be able to rebase the *.x branch
+git checkout master
+
 # Ensure the master branch points to the original commit to avoid commit injection
 # when running the release pipeline.
 # used GIT_BASE_COMMIT instead GIT_COMMIT to support the MultiBranchPipelines.


### PR DESCRIPTION
## What does this PR do?

Checkout the master branch

## Why is it important?

In order to rebase the `*.x` branch with the master branch is required all the references to be in the repo. The current git Jenkins implementation uses the detached mode. See the below error:

```
09:23:06  + rake release
09:23:06  elastic-apm 3.3.0 built to pkg/elastic-apm-3.3.0.gem.
09:23:06  Tag v3.3.0 has already been created.
09:23:09  Pushed elastic-apm 3.3.0 to rubygems.org
09:23:09  Previous HEAD position was 7aee883 v3.3.0
09:23:09  Switched to a new branch '3.x'
09:23:09  fatal: invalid upstream 'master'
```

## Test

```
jenkins@apm-ci-immutable-ubuntu-1604-1575622900680185192:~/workspace/test/src/github.com/elastic/apm-agent-ruby$ git checkout 3.x
Previous HEAD position was 3530940... ci(jenkins): avoid shallow cloning
Branch 3.x set up to track remote branch 3.x from origin.
Switched to a new branch '3.x'
jenkins@apm-ci-immutable-ubuntu-1604-1575622900680185192:~/workspace/test/src/github.com/elastic/apm-agent-ruby$ git rebase master
fatal: Needed a single revision
invalid upstream master
...

## With the checkout of the master branch then

+ git fetch --all
Fetching origin
+ git checkout v3.3.0
HEAD is now at 7aee883... v3.3.0
+ git checkout master
...

$ git checkout 3.x
Switched to branch '3.x'
Your branch is up-to-date with 'origin/3.x'.
$ git rebase master
First, rewinding head to replay your work on top of it...
```