### PR TITLE
Add missing parameters to documentation in elastic_apm.rb

### DIFF
--- a/docs/api.asciidoc
+++ b/docs/api.asciidoc
@@ -146,6 +146,7 @@ Arguments:
   * `action`: The action type of span eg. `connect` or `query`.
   * `context`: An instance of `Span::Context`.
   * `include_stacktrace`: Whether or not to collect a Stacktrace.
+  * `trace_context:`: An optional `TraceContext` object for Distributed Tracing.
   * `&block`: An optional block to wrap with the span.
   The block is passed the span as an optional argument.
 
@@ -171,6 +172,7 @@ Arguments:
   * `action`: The action type of span eg. `connect` or `query`.
   * `context`: An instance of `Span::Context`.
   * `include_stacktrace`: Whether or not to collect a Stacktrace.
+  * `trace_context:`: An optional `TraceContext` object for Distributed Tracing.
   * `&block`: An optional block to wrap with the span.
   The block is passed the span as an optional argument.
 

--- a/lib/elastic_apm.rb
+++ b/lib/elastic_apm.rb
@@ -97,6 +97,8 @@ module ElasticAPM
     # @param type [String] The kind of the transaction, eg `app.request.get` or
     # `db.mysql2.query`
     # @param context [Context] An optional [Context]
+    # @param trace_context [TraceContext] An optional [TraceContext] object for
+    #   Distributed Tracing.
     # @return [Transaction]
     def start_transaction(
       name = nil,
@@ -127,6 +129,8 @@ module ElasticAPM
     # @param type [String] The kind of the transaction, eg `app.request.get` or
     # `db.mysql2.query`
     # @param context [Context] An optional [Context]
+    # @param trace_context [TraceContext] An optional [TraceContext] object for
+    #   Distributed Tracing.
     # @yield [Transaction]
     # @return result of block
     def with_transaction(
@@ -165,6 +169,8 @@ module ElasticAPM
     # @param action [String] The span action type, eq `connect` or `query`
     # @param context [Span::Context] Context information about the span
     # @param include_stacktrace [Boolean] Whether or not to capture a stacktrace
+    # @param trace_context [TraceContext] An optional [TraceContext] object for
+    #   Distributed Tracing.
     # @return [Span]
     def start_span(
       name,
@@ -203,8 +209,12 @@ module ElasticAPM
     #
     # @param name [String] A description of the span, eq `SELECT FROM "users"`
     # @param type [String] The kind of span, eq `db.mysql2.query`
+    # @param subtype [String] The subtype of span eg. `postgresql`.
+    # @param action [String] The action type of span eg. `connect` or `query`.
     # @param context [Span::Context] Context information about the span
     # @param include_stacktrace [Boolean] Whether or not to capture a stacktrace
+    # @param trace_context [TraceContext] An optional [TraceContext] object for
+    #   Distributed Tracing.
     # @yield [Span]
     # @return Result of block
     def with_span(

--- a/lib/elastic_apm.rb
+++ b/lib/elastic_apm.rb
@@ -208,7 +208,7 @@ module ElasticAPM
     # Wrap a block in a Span, ending it after the block
     #
     # @param name [String] A description of the span, eq `SELECT FROM "users"`
-    # @param type [String] The kind of span, eq `db.mysql2.query`
+     # @param type [String] The kind of span, eq `db`
     # @param subtype [String] The subtype of span eg. `postgresql`.
     # @param action [String] The action type of span eg. `connect` or `query`.
     # @param context [Span::Context] Context information about the span


### PR DESCRIPTION
I noticed these minor documentation issues when adding the `sync` parameter in [another PR](https://github.com/elastic/apm-agent-ruby/pull/571).