### PR TITLE
Serialize Span Context labels

### DIFF
--- a/lib/elastic_apm/transport/serializers/span_serializer.rb
+++ b/lib/elastic_apm/transport/serializers/span_serializer.rb
@@ -34,7 +34,7 @@ module ElasticAPM
           def build(context)
             return unless context
 
-            {}.tap do |base|
+            { tags: mixed_object(context.labels) }.tap do |base|
               base[:sync] = context.sync unless context.sync.nil?
               base[:db] = build_db(context.db) if context.db
               base[:http] = build_http(context.http) if context.http

--- a/spec/elastic_apm/transport/serializers/span_serializer_spec.rb
+++ b/spec/elastic_apm/transport/serializers/span_serializer_spec.rb
@@ -41,7 +41,7 @@ module ElasticAPM
                 trace_id: span.trace_id,
                 name: 'Span',
                 type: 'custom',
-                context: { sync: true },
+                context: { sync: true, tags: {} },
                 stacktrace: [],
                 timestamp: 694_224_000_000_000,
                 duration: 10
@@ -59,7 +59,8 @@ module ElasticAPM
                 context: Span::Context.new(
                   db: { statement: 'asd' },
                   http: { url: 'dsa' },
-                  sync: false
+                  sync: false,
+                  labels: { foo: 'bar' }
                 )
               )
             end
@@ -69,6 +70,7 @@ module ElasticAPM
                 .to eq 'asd'
               expect(result.dig(:span, :context, :http, :url)).to eq 'dsa'
               expect(result.dig(:span, :context, :sync)).to eq false
+              expect(result.dig(:span, :context, :tags, :foo)).to eq 'bar'
             end
 
             context 'when sync is nil' do


### PR DESCRIPTION
Include labels when sending a Span#context to the APM server

elastic/apm-agent-ruby#652