### PR TITLE
Fix Console top-level namespace

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -50,6 +50,11 @@ endif::[]
 
 - Allow action dispatch spy to be disabled via `disabled_instrumentations` {pull}657[#657]
 
+[float]
+===== Fixed
+
+- Fix Rails Console detection when top-level `Console` constant defined {pull}664[#664]
+
 [[release-notes-3.3.0]]
 ==== 3.3.0 (2019-12-05)
 

--- a/lib/elastic_apm/rails.rb
+++ b/lib/elastic_apm/rails.rb
@@ -44,7 +44,7 @@ module ElasticAPM
     private
 
     def should_skip?(_config)
-      if ::Rails.const_defined? 'Rails::Console'
+      if ::Rails.const_defined?('Console', false)
         return 'Rails console'
       end
 


### PR DESCRIPTION
If you have `Console` top-level constant defined, then `::Rails.const_defined? 'Rails::Console'` will always return true. This is how ruby handles namespaces: traverse all the way to the top-level. To prevent this you have to pass optional argument set to false. In this case `::Rails.const_defined?('Console', false)` we're telling Ruby to search only `Rails` namespace and do not go outside.