### PR TITLE
Add reference repo for apm-agent-ruby

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -51,7 +51,7 @@ pipeline {
       steps {
         pipelineManager([ cancelPreviousRunningBuilds: [ when: 'PR' ] ])
         deleteDir()
-        gitCheckout(basedir: "${BASE_DIR}", githubNotifyFirstTimeContributor: true)
+        gitCheckout(basedir: "${BASE_DIR}", githubNotifyFirstTimeContributor: true, reference: '/var/lib/jenkins/.git-references/apm-agent-ruby.git')
         stash allowEmpty: true, name: 'source', useDefaultExcludes: false
       }
     }

--- a/.ci/jobs/apm-agent-ruby-downstream.yml
+++ b/.ci/jobs/apm-agent-ruby-downstream.yml
@@ -32,6 +32,7 @@
           recursive: true
           parent-credentials: true
           timeout: 100
+          reference-repo: /var/lib/jenkins/.git-references/apm-agent-ruby.git
         timeout: '15'
         use-author: true
         wipe-workspace: 'True'

--- a/.ci/jobs/apm-agent-ruby-linting-mbp.yml
+++ b/.ci/jobs/apm-agent-ruby-linting-mbp.yml
@@ -33,6 +33,7 @@
           recursive: true
           parent-credentials: true
           timeout: 100
+          reference-repo: /var/lib/jenkins/.git-references/apm-agent-ruby.git
         timeout: '15'
         use-author: true
         wipe-workspace: 'True'

--- a/.ci/jobs/apm-agent-ruby-mbp.yml
+++ b/.ci/jobs/apm-agent-ruby-mbp.yml
@@ -36,6 +36,7 @@
           recursive: true
           parent-credentials: true
           timeout: 100
+          reference-repo: /var/lib/jenkins/.git-references/apm-agent-ruby.git
         timeout: '15'
         use-author: true
         wipe-workspace: 'True'


### PR DESCRIPTION
Adds reference repos.

These correspond to repos and download locations which can be seen in [the Jenkins job which mirrors them](https://apm-ci.elastic.co/job/jenkins-git-fetch-reference/).