### PR TITLE
Add Ruby 2.7 support

### DIFF
--- a/.ci/.jenkins_exclude.yml
+++ b/.ci/.jenkins_exclude.yml
@@ -26,7 +26,7 @@ exclude:
     FRAMEWORK: rails-6.0
 
   # Only test master on newest ruby
-  - RUBY_VERSION: ruby:2.7
+  - RUBY_VERSION: ruby:2.6
     FRAMEWORK: rails-master
   - RUBY_VERSION: ruby:2.5
     FRAMEWORK: rails-master
@@ -70,7 +70,7 @@ exclude:
   - RUBY_VERSION: docker.elastic.co/observability-ci/jruby:9.1-7-jdk
     FRAMEWORK: sinatra-master
 
-  - RUBY_VERSION: ruby:2.7
+  - RUBY_VERSION: ruby:2.6
     FRAMEWORK: grape-master
   - RUBY_VERSION: ruby:2.5
     FRAMEWORK: grape-master
@@ -93,7 +93,7 @@ exclude:
   - RUBY_VERSION: docker.elastic.co/observability-ci/jruby:9.1-7-jdk
     FRAMEWORK: grape-master
 
-  - RUBY_VERSION: ruby:2.7
+  - RUBY_VERSION: ruby:2.6
     FRAMEWORK: grape-1.2,sinatra-2.0,rails-6.0
   - RUBY_VERSION: ruby:2.5
     FRAMEWORK: grape-1.2,sinatra-2.0,rails-6.0

--- a/.ci/.jenkins_exclude.yml
+++ b/.ci/.jenkins_exclude.yml
@@ -1,5 +1,5 @@
 exclude:
-  - RUBY_VERSION: ruby:2.7-rc
+  - RUBY_VERSION: ruby:2.7
     FRAMEWORK: rails-4.2
   - RUBY_VERSION: jruby:9.2
     FRAMEWORK: rails-4.2
@@ -26,7 +26,7 @@ exclude:
     FRAMEWORK: rails-6.0
 
   # Only test master on newest ruby
-  - RUBY_VERSION: ruby:2.7-rc
+  - RUBY_VERSION: ruby:2.7
     FRAMEWORK: rails-master
   - RUBY_VERSION: ruby:2.5
     FRAMEWORK: rails-master
@@ -70,7 +70,7 @@ exclude:
   - RUBY_VERSION: docker.elastic.co/observability-ci/jruby:9.1-7-jdk
     FRAMEWORK: sinatra-master
 
-  - RUBY_VERSION: ruby:2.7-rc
+  - RUBY_VERSION: ruby:2.7
     FRAMEWORK: grape-master
   - RUBY_VERSION: ruby:2.5
     FRAMEWORK: grape-master
@@ -93,7 +93,7 @@ exclude:
   - RUBY_VERSION: docker.elastic.co/observability-ci/jruby:9.1-7-jdk
     FRAMEWORK: grape-master
 
-  - RUBY_VERSION: ruby:2.7-rc
+  - RUBY_VERSION: ruby:2.7
     FRAMEWORK: grape-1.2,sinatra-2.0,rails-6.0
   - RUBY_VERSION: ruby:2.5
     FRAMEWORK: grape-1.2,sinatra-2.0,rails-6.0

--- a/.ci/.jenkins_ruby.yml
+++ b/.ci/.jenkins_ruby.yml
@@ -1,5 +1,5 @@
 RUBY_VERSION:
-  - ruby:2.7-rc
+  - ruby:2.7
   - ruby:2.6
   - ruby:2.5
   - ruby:2.4

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -95,3 +95,6 @@ Style/SpecialGlobalVars:
 
 Style/MissingRespondToMissing:
   Enabled: false
+
+Style/BracesAroundHashParameters:
+  Enabled: false

--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -50,6 +50,11 @@ endif::[]
 
 - Allow action dispatch spy to be disabled via `disabled_instrumentations` {pull}657[#657]
 
+[float]
+===== Fixed
+
+- Fix a few Ruby 2.7 related deprecation warnings {pull}667[#667]
+
 [[release-notes-3.3.0]]
 ==== 3.3.0 (2019-12-05)
 

--- a/bin/run-tests
+++ b/bin/run-tests
@@ -21,7 +21,7 @@ if [[ $specific_spec = '' ]]; then
     echo "========================================"
     echo $i
     echo "========================================"
-    runRspec "$i"
+    RUBYOPT=-W:no-deprecated runRspec "$i"
   done
 else
   echo "Running only $specific_spec"

--- a/bin/run-tests
+++ b/bin/run-tests
@@ -21,7 +21,7 @@ if [[ $specific_spec = '' ]]; then
     echo "========================================"
     echo $i
     echo "========================================"
-    RUBYOPT=-W:no-deprecated runRspec "$i"
+    runRspec "$i"
   done
 else
   echo "Running only $specific_spec"

--- a/lib/elastic_apm/config/options.rb
+++ b/lib/elastic_apm/config/options.rb
@@ -83,9 +83,8 @@ module ElasticAPM
           @schema ||= {}
         end
 
-        def option(*args)
-          key = args.shift
-          schema[key] = *args
+        def option(key, **args)
+          schema[key] = args
         end
       end
 
@@ -93,7 +92,7 @@ module ElasticAPM
       module InstanceMethods
         def load_schema
           Hash[self.class.schema.map do |key, args|
-            [key, Option.new(key, *args)]
+            [key, Option.new(key, **args)]
           end]
         end
 

--- a/lib/elastic_apm/railtie.rb
+++ b/lib/elastic_apm/railtie.rb
@@ -7,7 +7,7 @@ module ElasticAPM
 
     Config.schema.each do |key, args|
       next unless args.length > 1
-      config.elastic_apm[key] = args.last[:default]
+      config.elastic_apm[key] = args[:default]
     end
 
     initializer 'elastic_apm.initialize' do |app|

--- a/lib/elastic_apm/span/context.rb
+++ b/lib/elastic_apm/span/context.rb
@@ -12,8 +12,8 @@ module ElasticAPM
         sync: nil
       )
         @sync = sync
-        @db = db && Db.new(db)
-        @http = http && Http.new(http)
+        @db = db && Db.new(**db)
+        @http = http && Http.new(**http)
         @destination =
           case destination
           when Destination then destination

--- a/lib/elastic_apm/transaction.rb
+++ b/lib/elastic_apm/transaction.rb
@@ -91,8 +91,8 @@ module ElasticAPM
 
     # context
 
-    def add_response(*args)
-      context.response = Context::Response.new(*args)
+    def add_response(status = nil, **args)
+      context.response = Context::Response.new(status, **args)
     end
 
     def set_user(user)

--- a/lib/elastic_apm/transport/connection/proxy_pipe.rb
+++ b/lib/elastic_apm/transport/connection/proxy_pipe.rb
@@ -62,8 +62,8 @@ module ElasticAPM
           end
         end
 
-        def self.pipe(*args)
-          pipe = new(*args)
+        def self.pipe(**args)
+          pipe = new(**args)
           [pipe.read, pipe.write]
         end
       end

--- a/spec/elastic_apm/central_config_spec.rb
+++ b/spec/elastic_apm/central_config_spec.rb
@@ -9,7 +9,7 @@ module ElasticAPM
 
     describe '#start' do
       it 'polls for config' do
-        req_stub = stub_response(transaction_sample_rate: '0.5')
+        req_stub = stub_response({ transaction_sample_rate: '0.5' })
         subject.start
         subject.promise.wait
         expect(req_stub).to have_been_requested.at_least_once
@@ -20,7 +20,7 @@ module ElasticAPM
         let(:config) { Config.new(central_config: false) }
 
         it 'does nothing' do
-          req_stub = stub_response(transaction_sample_rate: '0.5')
+          req_stub = stub_response({ transaction_sample_rate: '0.5' })
           subject.start
           expect(subject.promise).to be nil
           expect(req_stub).to_not have_been_requested
@@ -31,7 +31,7 @@ module ElasticAPM
 
     describe '#fetch_and_apply_config' do
       it 'queries APM Server and applies config' do
-        req_stub = stub_response(transaction_sample_rate: '0.5')
+        req_stub = stub_response({ transaction_sample_rate: '0.5' })
         expect(config.logger).to receive(:info)
 
         subject.fetch_and_apply_config
@@ -43,7 +43,7 @@ module ElasticAPM
       end
 
       it 'reverts config if later 404' do
-        stub_response(transaction_sample_rate: '0.5')
+        stub_response({ transaction_sample_rate: '0.5' })
 
         subject.fetch_and_apply_config
         subject.promise.wait
@@ -138,7 +138,7 @@ module ElasticAPM
     describe '#fetch_config' do
       context 'when successful' do
         it 'returns response object' do
-          stub_response(ok: 1)
+          stub_response({ ok: 1 })
 
           expect(subject.fetch_config).to be_a(HTTP::Response)
         end

--- a/spec/support/delegate_matcher.rb
+++ b/spec/support/delegate_matcher.rb
@@ -15,7 +15,12 @@ RSpec::Matchers.define :delegate do |method, opts|
       expect(to).to receive(method).at_least(:once).with(no_args) { true }
     end
 
-    delegator.send method, *args
+    if args&.last.is_a?(Hash)
+      kw = args.pop
+      delegator.send method, *args, **kw
+    else
+      delegator.send method, *args
+    end
   end
 
   description do


### PR DESCRIPTION
Biggest change is the deprecation of Hashes as keyword arguments. I've squashed them all so we don't emit any of the warnings.

Fixes #670 
Fixes #663 
Fixes #662 