### PR TITLE
Serialize Span Context labels

### DIFF
--- a/lib/elastic_apm/transport/serializers/span_serializer.rb
+++ b/lib/elastic_apm/transport/serializers/span_serializer.rb
@@ -32,11 +32,13 @@ module ElasticAPM
 
         # @api private
         class ContextSerializer < Serializer
+          # rubocop:disable Metrics/CyclomaticComplexity
           def build(context)
             return unless context
 
-            base = { tags: mixed_object(context.labels) }
+            base = {}
 
+            base[:tags] = mixed_object(context.labels) if context.labels.any?
             base[:sync] = context.sync unless context.sync.nil?
             base[:db] = build_db(context.db) if context.db
             base[:http] = build_http(context.http) if context.http
@@ -47,6 +49,7 @@ module ElasticAPM
 
             base
           end
+          # rubocop:enable Metrics/CyclomaticComplexity
 
           private
 

--- a/spec/elastic_apm/transport/serializers/span_serializer_spec.rb
+++ b/spec/elastic_apm/transport/serializers/span_serializer_spec.rb
@@ -41,7 +41,7 @@ module ElasticAPM
                 trace_id: span.trace_id,
                 name: 'Span',
                 type: 'custom',
-                context: { sync: true, tags: {} },
+                context: { sync: true },
                 stacktrace: [],
                 timestamp: 694_224_000_000_000,
                 duration: 10


### PR DESCRIPTION
Bringing this home. Merged `master`, changed to only include labels in the payload when they are set.

Continued from #653

Closes elastic/apm-agent-ruby#653