### PR TITLE
Convert Response HTTP header values to string

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -55,6 +55,7 @@ endif::[]
 
 - Fix Rails Console detection when top-level `Console` constant defined {pull}664[#664]
 - Fix a few Ruby 2.7 related deprecation warnings {pull}667[#667]
+- Fix response header values not being converted to strings {pull}675[#675]
 
 [[release-notes-3.3.0]]
 ==== 3.3.0 (2019-12-05)

--- a/lib/elastic_apm/context/response.rb
+++ b/lib/elastic_apm/context/response.rb
@@ -11,12 +11,20 @@ module ElasticAPM
         finished: true
       )
         @status_code = status_code
-        @headers = headers
         @headers_sent = headers_sent
         @finished = finished
+
+        self.headers = headers
       end
 
-      attr_accessor :status_code, :headers, :headers_sent, :finished
+      attr_accessor :status_code, :headers_sent, :finished
+      attr_reader :headers
+
+      def headers=(headers)
+        @headers = headers.each_with_object({}) do |(k, v), hsh|
+          hsh[k] = v.to_s
+        end
+      end
     end
   end
 end

--- a/lib/elastic_apm/context_builder.rb
+++ b/lib/elastic_apm/context_builder.rb
@@ -76,9 +76,9 @@ module ElasticAPM
         next unless key == key.upcase
 
         if key.start_with?('HTTP_')
-          http[camel_key(key)] = value.to_s
+          http[camel_key(key)] = value
         else
-          env[key] = value.to_s
+          env[key] = value
         end
       end
     end

--- a/lib/elastic_apm/context_builder.rb
+++ b/lib/elastic_apm/context_builder.rb
@@ -76,9 +76,9 @@ module ElasticAPM
         next unless key == key.upcase
 
         if key.start_with?('HTTP_')
-          http[camel_key(key)] = value
+          http[camel_key(key)] = value.to_s
         else
-          env[key] = value
+          env[key] = value.to_s
         end
       end
     end

--- a/spec/elastic_apm/context/response_spec.rb
+++ b/spec/elastic_apm/context/response_spec.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+module ElasticAPM
+  RSpec.describe Context::Response do
+    it 'converts header values to string' do
+      resp = described_class.new(
+        nil,
+        headers: {
+          a: 1,
+          b: '2',
+          c: [1, 2, 3]
+        }
+      )
+
+      expect(resp.headers).to match(
+        a: '1',
+        b: '2',
+        c: '[1, 2, 3]'
+      )
+    end
+  end
+end


### PR DESCRIPTION
Ensures header values are saved as strings so they pass APM Server's JSON Schema.

Fixes #672 
