### PR TITLE
Add support for Sneakers

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -45,6 +45,7 @@ endif::[]
 - Add `span.context.destination` fields {pull}647[#647]
 - Add more precise (experimental) SQL summarizer {pull}640[#640]
 - Add support for Shoryuken (AWS SQS) {pull}674[#674]
+- Add support for Sneakers (Experimental) {pull}676[#676]
 
 [float]
 ===== Changed

--- a/Gemfile
+++ b/Gemfile
@@ -29,6 +29,7 @@ gem 'shoryuken', require: nil
 gem 'sidekiq', require: nil
 gem 'simplecov', require: false, group: :test
 gem 'simplecov-cobertura', require: false, group: :test
+gem 'sneakers', require: nil
 gem 'yard', require: nil
 gem 'yarjuf'
 

--- a/Gemfile
+++ b/Gemfile
@@ -29,7 +29,7 @@ gem 'shoryuken', require: nil
 gem 'sidekiq', require: nil
 gem 'simplecov', require: false, group: :test
 gem 'simplecov-cobertura', require: false, group: :test
-gem 'sneakers', require: nil
+gem "sneakers", "~> 2.12.0", require: nil
 gem 'yard', require: nil
 gem 'yarjuf'
 

--- a/Gemfile
+++ b/Gemfile
@@ -29,7 +29,7 @@ gem 'shoryuken', require: nil
 gem 'sidekiq', require: nil
 gem 'simplecov', require: false, group: :test
 gem 'simplecov-cobertura', require: false, group: :test
-gem "sneakers", "~> 2.12.0", require: nil
+gem "sneakers", "~> 2.12", require: nil
 gem 'yard', require: nil
 gem 'yarjuf'
 

--- a/Gemfile
+++ b/Gemfile
@@ -29,7 +29,7 @@ gem 'shoryuken', require: nil
 gem 'sidekiq', require: nil
 gem 'simplecov', require: false, group: :test
 gem 'simplecov-cobertura', require: false, group: :test
-gem "sneakers", "~> 2.12", require: nil
+gem 'sneakers', '~> 2.12', require: nil
 gem 'yard', require: nil
 gem 'yarjuf'
 

--- a/docs/supported-technologies.asciidoc
+++ b/docs/supported-technologies.asciidoc
@@ -85,3 +85,4 @@ We automatically instrument background processing using:
 - DelayedJob
 - Sidekiq
 - Shoryuken
+- Sneakers (v2.1.2+) (Experimental, see {pull}676[#676])

--- a/docs/supported-technologies.asciidoc
+++ b/docs/supported-technologies.asciidoc
@@ -85,4 +85,4 @@ We automatically instrument background processing using:
 - DelayedJob
 - Sidekiq
 - Shoryuken
-- Sneakers (v2.1.2+) (Experimental, see {pull}676[#676])
+- Sneakers (v2.12.0+) (Experimental, see {pull}676[#676])

--- a/lib/elastic_apm/config.rb
+++ b/lib/elastic_apm/config.rb
@@ -122,6 +122,7 @@ module ElasticAPM
         shoryuken
         sidekiq
         sinatra
+        sneakers
         tilt
       ]
     end

--- a/lib/elastic_apm/spies/sneakers.rb
+++ b/lib/elastic_apm/spies/sneakers.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+module ElasticAPM
+  # @api private
+  module Spies
+    # @api private
+    class SneakersSpy
+      include Logging
+
+      def install
+        # sneakers 2.12.0 introduced middleware concept and the spy needs that
+        if Gem.loaded_specs["sneakers"].version < Gem::Version.create("2.12.0")
+          warn("Sneakers version is below 2.12.0. Sneakers spy installation failed")
+        else
+          Sneakers.middleware.use(Middleware, nil)
+        end
+      end
+      # @api private
+      class Middleware
+        def initialize(app, *args)
+          @app = app
+          @args = args
+        end
+
+        def call(deserialized_msg, delivery_info, metadata, handler)
+          transaction = ElasticAPM.start_transaction(delivery_info.consumer.queue.name, 'Sneakers')
+          ElasticAPM.set_label(:routing_key, delivery_info.routing_key)
+          res = @app.call(deserialized_msg, delivery_info, metadata, handler)
+          transaction.done :success if transaction
+          res
+        rescue ::Exception => e
+          ElasticAPM.report(e, handled: false)
+          transaction.done :error if transaction
+          raise
+        ensure
+          ElasticAPM.end_transaction
+        end
+      end
+    end
+    register 'Sneakers', 'sneakers', SneakersSpy.new
+  end
+end

--- a/spec/elastic_apm/spies/sneakers_spec.rb
+++ b/spec/elastic_apm/spies/sneakers_spec.rb
@@ -1,0 +1,89 @@
+require 'sneakers'
+require 'elastic_apm/spies/sneakers'
+module ElasticAPM
+  RSpec.describe 'Spy: Sneakers', :intercept do
+    # sneakers 2.12.0 introduced middleware concept and the spy needs that
+    sneakers_middleware_not_avail = Gem.loaded_specs["sneakers"].version < Gem::Version.create("2.12.0")
+
+    class Queue
+      def name
+        'q1'
+      end
+    end
+
+    class Consumer
+      def queue
+        Queue.new
+      end
+    end
+
+    class DeliveryInfo
+      def routing_key
+        'r1234'
+      end
+      def consumer
+        Consumer.new
+      end
+    end
+
+    class TestWorker
+      include Sneakers::Worker
+      from_queue 'q1',
+                 ack: false
+      def work(message)
+      end
+    end
+
+    class TestErrorWorker
+      include Sneakers::Worker
+      from_queue 'q1',
+                 ack: false
+      def work(message)
+        1/0
+      end
+    end
+
+    before :all do
+      Sneakers.configure
+    end
+
+    before { ElasticAPM.start }
+    after { ElasticAPM.stop }
+
+    it 'instruments job transaction' do
+      worker = TestWorker.new
+      worker.process_work(DeliveryInfo.new, nil, nil, nil)
+      transaction, = @intercepted.transactions
+
+      if sneakers_middleware_not_avail
+        expect(transaction).to eq nil
+      else
+        expect(transaction.name).to eq DeliveryInfo.new.consumer.queue.name
+        label, = transaction.context.labels
+        expect(label[:routing_key]).to eq DeliveryInfo.new.routing_key
+        expect(transaction.type).to eq 'Sneakers'
+        expect(transaction.result).to eq :success
+      end
+    end
+
+    it 'reports errors' do
+      worker = TestErrorWorker.new
+      worker.process_work(DeliveryInfo.new, nil, nil, nil)
+      transaction, = @intercepted.transactions
+
+      if sneakers_middleware_not_avail
+        expect(transaction).to eq nil
+      else
+        expect(transaction.name).to eq DeliveryInfo.new.consumer.queue.name
+        label, = transaction.context.labels
+        expect(label[:routing_key]).to eq DeliveryInfo.new.routing_key
+        expect(transaction.type).to eq 'Sneakers'
+        expect(transaction.result).to eq :error
+        error, = @intercepted.errors
+        expect(error.exception.type).to eq 'ZeroDivisionError'
+      end
+    end
+  end
+end
+
+

--- a/spec/elastic_apm/spies/sneakers_spec.rb
+++ b/spec/elastic_apm/spies/sneakers_spec.rb
@@ -1,10 +1,10 @@
+# frozen_string_literal: true
+
 require 'sneakers'
 require 'elastic_apm/spies/sneakers'
+
 module ElasticAPM
   RSpec.describe 'Spy: Sneakers', :intercept do
-    # sneakers 2.12.0 introduced middleware concept and the spy needs that
-    sneakers_middleware_not_avail = Gem.loaded_specs["sneakers"].version < Gem::Version.create("2.12.0")
-
     class Queue
       def name
         'q1'
@@ -21,6 +21,7 @@ module ElasticAPM
       def routing_key
         'r1234'
       end
+
       def consumer
         Consumer.new
       end
@@ -28,62 +29,61 @@ module ElasticAPM
 
     class TestWorker
       include Sneakers::Worker
-      from_queue 'q1',
-                 ack: false
+
+      from_queue 'q1', ack: false
+
       def work(message)
       end
     end
 
     class TestErrorWorker
       include Sneakers::Worker
-      from_queue 'q1',
-                 ack: false
-      def work(message)
-        1/0
+
+      from_queue 'q1', ack: false
+
+      def work(_message)
+        1 / 0
       end
     end
 
     before :all do
       Sneakers.configure
+      Sneakers.logger = Logger.new(nil) # silence
     end
 
-    before { ElasticAPM.start }
-    after { ElasticAPM.stop }
-
     it 'instruments job transaction' do
-      worker = TestWorker.new
-      worker.process_work(DeliveryInfo.new, nil, nil, nil)
+      with_agent do
+        worker = TestWorker.new
+        worker.process_work(DeliveryInfo.new, nil, nil, nil)
+      end
+
       transaction, = @intercepted.transactions
 
-      if sneakers_middleware_not_avail
-        expect(transaction).to eq nil
-      else
-        expect(transaction.name).to eq DeliveryInfo.new.consumer.queue.name
-        label, = transaction.context.labels
-        expect(label[:routing_key]).to eq DeliveryInfo.new.routing_key
-        expect(transaction.type).to eq 'Sneakers'
-        expect(transaction.result).to eq :success
-      end
+      expect(transaction.name).to eq 'q1'
+      expect(transaction.type).to eq 'Sneakers'
+      expect(transaction.result).to eq :success
+
+      label, = transaction.context.labels
+      expect(label[:routing_key]).to eq 'r1234'
     end
 
     it 'reports errors' do
-      worker = TestErrorWorker.new
-      worker.process_work(DeliveryInfo.new, nil, nil, nil)
+      with_agent do
+        worker = TestErrorWorker.new
+        worker.process_work(DeliveryInfo.new, nil, nil, nil)
+      end
+
       transaction, = @intercepted.transactions
 
-      if sneakers_middleware_not_avail
-        expect(transaction).to eq nil
-      else
-        expect(transaction.name).to eq DeliveryInfo.new.consumer.queue.name
-        label, = transaction.context.labels
-        expect(label[:routing_key]).to eq DeliveryInfo.new.routing_key
-        expect(transaction.type).to eq 'Sneakers'
-        expect(transaction.result).to eq :error
-        error, = @intercepted.errors
-        expect(error.exception.type).to eq 'ZeroDivisionError'
-      end
+      expect(transaction.name).to eq 'q1'
+
+      label, = transaction.context.labels
+      expect(label[:routing_key]).to eq 'r1234'
+      expect(transaction.type).to eq 'Sneakers'
+      expect(transaction.result).to eq :error
+
+      error, = @intercepted.errors
+      expect(error.exception.type).to eq 'ZeroDivisionError'
     end
   end
 end
-
-


### PR DESCRIPTION
Continued from elastic/apm-agent-ruby#599 

Updating the implementation and spec a little bit. I don't feel we need to include version checking in the spec unless explicitly testing with different versions.

@redwrx has an open PR here (https://github.com/jondot/sneakers/pull/414) to pass the worker itself to middleware. Until that is merged I don't think there's a way to get the worker name for the transaction names. Too bad, and we fall back on the queue name.

@estolfo, how do you feel about marking Sneakers support as _experimental_ until a way to get the worker name is provided? That way we won't need to do the whole version dance around breaking changes when we change the names of all Sneakers transactions?