### PR TITLE
ci(jenkins): disable CodeCov comments on PRs

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,32 @@
+# Enable coverage report message for diff on commit
+# Docs can be found here: https://docs.codecov.io/v4.3.0/docs/commit-status
+coverage:
+  status:
+    project:
+      default:
+        target: 80%
+        threshold: 1
+        base: auto
+        branches: null
+        if_no_uploads: error
+        if_not_found: success
+        if_ci_failed: error
+        only_pulls: false
+        flags: null
+        paths: null
+    patch:
+      default:
+        target: auto
+        # Allows PRs without tests, overall stats count
+        threshold: 100
+        base: auto
+        branches: null
+        if_no_uploads: error
+        if_not_found: success
+        if_ci_failed: error
+        only_pulls: false
+        flags: null
+        paths: null
+
+# Disable comments on Pull Requests
+comment: false


### PR DESCRIPTION
## What does this pull request do?

Set some configuration for CodeCov

## Why is it important?

CodeCov comments on PRs are noise, so we want to disable them.
