### PR TITLE
Add documentation for api keys

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -54,7 +54,7 @@ endif::[]
 - Add more precise (experimental) SQL summarizer {pull}640[#640]
 - Add support for Shoryuken (AWS SQS) {pull}674[#674]
 - Add support for Sneakers (Experimental) {pull}676[#676]
-- Add option `api_key` to specify an Api key to use with the apm server {pull}655[#655]
+- Add option `api_key` (experimental) to specify an Api key to use with the apm server {pull}655[#655]
 
 [float]
 ===== Changed

--- a/docs/configuration.asciidoc
+++ b/docs/configuration.asciidoc
@@ -148,6 +148,22 @@ ruby -r securerandom -e 'print SecureRandom.uuid'
 WARNING: Secret tokens only provide any real security if your APM server uses TLS.
 
 [float]
+[[config-api-key]]
+==== `api_key`
+
+[options="header"]
+|============
+| Environment           | `Config` key | Default | Example
+| `ELASTIC_APM_API_KEY` | `api_key`    | `nil`   | A base64-encoded string
+|============
+
+This base64-encoded string is used to ensure that only your agents can send data to your APM server.
+You must have created the api key using the APM server command line tool. Please see the APM server
+documentation for details on how to do that.
+
+WARNING: Api keys only provide any real security if your APM server uses TLS.
+
+[float]
 [[config-active]]
 ==== `active`
 |============

--- a/docs/configuration.asciidoc
+++ b/docs/configuration.asciidoc
@@ -159,7 +159,8 @@ WARNING: Secret tokens only provide any real security if your APM server uses TL
 
 This base64-encoded string is used to ensure that only your agents can send data to your APM server.
 You must have created the api key using the APM server command line tool. Please see the APM server
-documentation for details on how to do that.
+documentation for details on how to do that. Please note that this feature is experimental in the
+APM server in version 7.6.
 
 WARNING: Api keys only provide any real security if your APM server uses TLS.
 


### PR DESCRIPTION
Add documentation for api keys.

Update: the feature is experimental in version 7.6 of the server. So the documentation added in this PR adds a note saying it's experimental.

Implementation is _private_ (as in undocumented) until a version of APM Server with API Key support is released.

Closes #654