### PR TITLE
ci(jenkins): mount the reference repo volume for the release with a docker container

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -24,6 +24,7 @@ pipeline {
     ITS_PIPELINE = 'apm-integration-tests-selector-mbp/master'
     RELEASE_SECRET = 'secret/apm-team/ci/apm-agent-ruby-rubygems-release'
     OPBEANS_REPO = 'opbeans-ruby'
+    REFERENCE_REPO = '/var/lib/jenkins/.git-references/apm-agent-ruby.git'
   }
   options {
     timeout(time: 2, unit: 'HOURS')
@@ -51,7 +52,7 @@ pipeline {
       steps {
         pipelineManager([ cancelPreviousRunningBuilds: [ when: 'PR' ] ])
         deleteDir()
-        gitCheckout(basedir: "${BASE_DIR}", githubNotifyFirstTimeContributor: true, reference: '/var/lib/jenkins/.git-references/apm-agent-ruby.git')
+        gitCheckout(basedir: "${BASE_DIR}", githubNotifyFirstTimeContributor: true, reference: "${env.REFERENCE_REPO}")
         stash allowEmpty: true, name: 'source', useDefaultExcludes: false
       }
     }
@@ -203,7 +204,7 @@ pipeline {
                 unstash 'source'
                 script {
                   dir(BASE_DIR){
-                    docker.image("${env.RUBY_DOCKER_TAG}").inside('-v /etc/passwd:/etc/passwd -v ${HOME}/.ssh:${HOME}/.ssh') {
+                    docker.image("${env.RUBY_DOCKER_TAG}").inside('-v ${REFERENCE_REPO}:${REFERENCE_REPO} -v /etc/passwd:/etc/passwd -v ${HOME}/.ssh:${HOME}/.ssh') {
                       withEnv(["HOME=${env.WORKSPACE}/${env.BASE_DIR ?: ''}"]) {
                         rubygemsLogin.withApi(secret: "${env.RELEASE_SECRET}") {
                           sshagent(['f6c7695a-671e-4f4f-a331-acdce44ff9ba']) {

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -56,31 +56,6 @@ pipeline {
         stash allowEmpty: true, name: 'source', useDefaultExcludes: false
       }
     }
-    stage('ReleaseDRY') {
-      options { skipDefaultCheckout() }
-      environment {
-        RUBY_DOCKER_TAG = 'ruby:2.6'
-        HOME = '/var/lib/jenkins'
-      }
-      steps {
-        deleteDir()
-        unstash 'source'
-        script {
-          dir(BASE_DIR){
-            docker.image("${env.RUBY_DOCKER_TAG}").inside('-v ${REFERENCE_REPO}:${REFERENCE_REPO} -v /etc/passwd:/etc/passwd -v ${HOME}/.ssh:${HOME}/.ssh') {
-              withEnv(["HOME=${env.WORKSPACE}/${env.BASE_DIR ?: ''}"]) {
-                rubygemsLogin.withApi(secret: "${env.RELEASE_SECRET}") {
-                  sshagent(['f6c7695a-671e-4f4f-a331-acdce44ff9ba']) {
-                    sh '.ci/prepare-git-context.sh'
-                    error 'Avoid next actions'
-                  }
-                }
-              }
-            }
-          }
-        }
-      }
-    }
     stage('Sanity checks') {
       when {
         beforeAgent true

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -56,6 +56,31 @@ pipeline {
         stash allowEmpty: true, name: 'source', useDefaultExcludes: false
       }
     }
+    stage('ReleaseDRY') {
+      options { skipDefaultCheckout() }
+      environment {
+        RUBY_DOCKER_TAG = 'ruby:2.6'
+        HOME = '/var/lib/jenkins'
+      }
+      steps {
+        deleteDir()
+        unstash 'source'
+        script {
+          dir(BASE_DIR){
+            docker.image("${env.RUBY_DOCKER_TAG}").inside('-v ${REFERENCE_REPO}:${REFERENCE_REPO} -v /etc/passwd:/etc/passwd -v ${HOME}/.ssh:${HOME}/.ssh') {
+              withEnv(["HOME=${env.WORKSPACE}/${env.BASE_DIR ?: ''}"]) {
+                rubygemsLogin.withApi(secret: "${env.RELEASE_SECRET}") {
+                  sshagent(['f6c7695a-671e-4f4f-a331-acdce44ff9ba']) {
+                    sh '.ci/prepare-git-context.sh'
+                    error 'Avoid next actions'
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
     stage('Sanity checks') {
       when {
         beforeAgent true

--- a/.ci/prepare-git-context.sh
+++ b/.ci/prepare-git-context.sh
@@ -10,8 +10,8 @@ git config remote.origin.fetch '+refs/heads/*:refs/remotes/origin/*'
 # Force the git user details when pushing using the last commit details
 USER_MAIL=$(git log -1 --pretty=format:'%ae')
 USER_NAME=$(git log -1 --pretty=format:'%an')
-git config --global user.email "${USER_MAIL}"
-git config --global user.name "${USER_NAME}"
+git config user.email "${USER_MAIL}"
+git config user.name "${USER_NAME}"
 
 # Checkout the branch as it's detached based by default.
 # See https://issues.jenkins-ci.org/browse/JENKINS-33171

--- a/.ci/prepare-git-context.sh
+++ b/.ci/prepare-git-context.sh
@@ -7,12 +7,6 @@ git config remote.origin.url "git@github.com:${ORG_NAME}/${REPO_NAME}.git"
 # Enable to fetch branches when cloning with a detached and shallow clone
 git config remote.origin.fetch '+refs/heads/*:refs/remotes/origin/*'
 
-# Force the git user details when pushing using the last commit details
-USER_MAIL=$(git log -1 --pretty=format:'%ae')
-USER_NAME=$(git log -1 --pretty=format:'%an')
-git config --global user.email "${USER_MAIL}"
-git config --global user.name "${USER_NAME}"
-
 # Checkout the branch as it's detached based by default.
 # See https://issues.jenkins-ci.org/browse/JENKINS-33171
 git fetch --all
@@ -25,3 +19,9 @@ git checkout master
 # when running the release pipeline.
 # used GIT_BASE_COMMIT instead GIT_COMMIT to support the MultiBranchPipelines.
 git reset --hard "${GIT_BASE_COMMIT}"
+
+# Force the git user details when pushing using the GIT_BASE_COMMIT commit details
+USER_MAIL=$(git log -1 --pretty=format:'%ae')
+USER_NAME=$(git log -1 --pretty=format:'%an')
+git config --global user.email "${USER_MAIL}"
+git config --global user.name "${USER_NAME}"

--- a/.ci/prepare-git-context.sh
+++ b/.ci/prepare-git-context.sh
@@ -7,6 +7,12 @@ git config remote.origin.url "git@github.com:${ORG_NAME}/${REPO_NAME}.git"
 # Enable to fetch branches when cloning with a detached and shallow clone
 git config remote.origin.fetch '+refs/heads/*:refs/remotes/origin/*'
 
+# Force the git user details when pushing using the last commit details
+USER_MAIL=$(git log -1 --pretty=format:'%ae')
+USER_NAME=$(git log -1 --pretty=format:'%an')
+git config --global user.email "${USER_MAIL}"
+git config --global user.name "${USER_NAME}"
+
 # Checkout the branch as it's detached based by default.
 # See https://issues.jenkins-ci.org/browse/JENKINS-33171
 git fetch --all
@@ -19,9 +25,3 @@ git checkout master
 # when running the release pipeline.
 # used GIT_BASE_COMMIT instead GIT_COMMIT to support the MultiBranchPipelines.
 git reset --hard "${GIT_BASE_COMMIT}"
-
-# Force the git user details when pushing using the GIT_BASE_COMMIT commit details
-USER_MAIL=$(git log -1 --pretty=format:'%ae')
-USER_NAME=$(git log -1 --pretty=format:'%an')
-git config --global user.email "${USER_MAIL}"
-git config --global user.name "${USER_NAME}"


### PR DESCRIPTION
## What does this pull request do?

Mount the volume with the cache reference repo in the docker container. Ensure the script doesn't change the global settings to avoid issues when running locally :)

## Why is it important?

Only when using git reference repos then the reference of that particular repo should be also included in the docker container as a volume, otherwise, any interactions with the git commands will fail.

See the error below:

```
10:30:18  + .ci/prepare-git-context.sh
10:30:18  + git config remote.origin.url git@github.com:elastic/apm-agent-ruby.git
10:30:18  + git config remote.origin.fetch '+refs/heads/*:refs/remotes/origin/*'
10:30:18  ++ git log -1 --pretty=format:%ae
10:30:18  error: object directory /var/lib/jenkins/.git-references/apm-agent-ruby.git/objects does not exist; check .git/objects/info/alternates
10:30:18  error: Could not read 0d5e3c37eeea22a616767bffc9e71a36d51c1f51
10:30:18  fatal: Failed to traverse parents of commit e5843d2bda8f0c9e8c6c185b1d2b0291b03f502f
```

## Related issues

Caused by the reference repo: https://github.com/elastic/apm-agent-ruby/pull/666

## Tests

- DRY release

![image](https://user-images.githubusercontent.com/2871786/72149983-57d96080-339c-11ea-8836-4c9373032579.png)
