### PR TITLE
ci(jenkins): notify downstream timeout and test failure issues

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -24,6 +24,7 @@ pipeline {
     ITS_PIPELINE = 'apm-integration-tests-selector-mbp/master'
     RELEASE_SECRET = 'secret/apm-team/ci/apm-agent-ruby-rubygems-release'
     OPBEANS_REPO = 'opbeans-ruby'
+    REFERENCE_REPO = '/var/lib/jenkins/.git-references/apm-agent-ruby.git'
   }
   options {
     timeout(time: 2, unit: 'HOURS')
@@ -51,7 +52,7 @@ pipeline {
       steps {
         pipelineManager([ cancelPreviousRunningBuilds: [ when: 'PR' ] ])
         deleteDir()
-        gitCheckout(basedir: "${BASE_DIR}", githubNotifyFirstTimeContributor: true, reference: '/var/lib/jenkins/.git-references/apm-agent-ruby.git')
+        gitCheckout(basedir: "${BASE_DIR}", githubNotifyFirstTimeContributor: true, reference: "${env.REFERENCE_REPO}")
         stash allowEmpty: true, name: 'source', useDefaultExcludes: false
       }
     }
@@ -203,7 +204,7 @@ pipeline {
                 unstash 'source'
                 script {
                   dir(BASE_DIR){
-                    docker.image("${env.RUBY_DOCKER_TAG}").inside('-v /etc/passwd:/etc/passwd -v ${HOME}/.ssh:${HOME}/.ssh') {
+                    docker.image("${env.RUBY_DOCKER_TAG}").inside('-v ${REFERENCE_REPO}:${REFERENCE_REPO} -v /etc/passwd:/etc/passwd -v ${HOME}/.ssh:${HOME}/.ssh') {
                       withEnv(["HOME=${env.WORKSPACE}/${env.BASE_DIR ?: ''}"]) {
                         rubygemsLogin.withApi(secret: "${env.RELEASE_SECRET}") {
                           sshagent(['f6c7695a-671e-4f4f-a331-acdce44ff9ba']) {

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -1,5 +1,5 @@
 #!/usr/bin/env groovy
-@Library('apm@test-downstream-notification') _
+@Library('apm@current') _
 
 import co.elastic.matrix.*
 import groovy.transform.Field

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -1,5 +1,5 @@
 #!/usr/bin/env groovy
-@Library('apm@7b341f35859bcefeead9a7f9646c638b1bc53bf0') _
+@Library('apm@test-downstream-notification') _
 
 import co.elastic.matrix.*
 import groovy.transform.Field

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -297,9 +297,10 @@ def runBenchmark(version){
   }
 }
 
-def runJob(rubyVersion, int sleep = 1){
+def runJob(String rubyVersion, int sleep = 1){
   def buildObject
   try {
+    def quiet = (sleep * randomNumber(min: 2, max: 6)) + 5
     buildObject = build(job: "apm-agent-ruby/apm-agent-ruby-downstream/${env.BRANCH_NAME}",
                         parameters: [
                           string(name: 'RUBY_VERSION', value: "${rubyVersion}"),

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -298,12 +298,11 @@ def runJob(rubyVersion){
                           string(name: 'RUBY_VERSION', value: "${rubyVersion}"),
                           string(name: 'BRANCH_SPECIFIER', value: "${env.GIT_BASE_COMMIT}")
                         ],
-                        quietPeriod: 15
-                      )
+                        quietPeriod: 15)
   } catch(e) {
     rubyTasksFailed = true
     buildObject = e
-    warnError('Test Failures') {
+    warnError('Downstream Failed') {
       error("Downstream job for '${rubyVersion}' failed")
     }
   } finally {

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -5,7 +5,7 @@ import co.elastic.matrix.*
 import groovy.transform.Field
 
 /**
- This is required know if there any failures when running the downstream jobs.
+ This is required to know if there any failures when running the downstream jobs.
 */
 @Field def rubyTasksFailed = false
 

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -7,7 +7,7 @@ import groovy.transform.Field
 /**
  This is required to store the results of the tests.
 */
-@Field def rubyTasksFailed = [:]
+@Field def rubyTasksFailed = false
 
 pipeline {
   agent { label 'linux && immutable' }
@@ -159,15 +159,10 @@ pipeline {
       }
       stage('Populate Test failures') {
         when {
-          expression { return !rubyTasksFailed.isEmpty() }
+          expression { return rubyTasksFailed }
         }
         steps {
-          script {
-            if (rubyTasksFailed.find { k, v -> v.contains('timeout') }) {
-              currentBuild.description = 'Issue: timeout checkout in downstreams'
-            }
-          }
-          error("There were some failures when running the 'Test' stage. See ${rubyTasksFailed}")
+          error('There were some failures when running the "Test" stage')
         }
       }
       stage('Integration Tests') {
@@ -290,19 +285,17 @@ def runBenchmark(version){
   }
 }
 
-def runJob(rubyVersion) {
-  def downstreamBuild
+def runJob(rubyVersion){
   try {
-    downstreamBuild = build(job: "apm-agent-ruby/apm-agent-ruby-downstream/${env.BRANCH_NAME}",
-                            parameters: [
-                              string(name: 'RUBY_VERSION', value: "${rubyVersion}"),
-                              string(name: 'BRANCH_SPECIFIER', value: "${env.GIT_BASE_COMMIT}")
-                            ],
-                            quietPeriod: 15
-                          )
+    build( job: "apm-agent-ruby/apm-agent-ruby-downstream/${env.BRANCH_NAME}",
+      parameters: [
+        string(name: 'RUBY_VERSION', value: "${rubyVersion}"),
+        string(name: 'BRANCH_SPECIFIER', value: "${env.GIT_BASE_COMMIT}")
+      ],
+      quietPeriod: 15
+    )
   } catch(e) {
-    // This will help to report the status for the failure in the downstreams.
-    rubyTasksFailed["${rubyVersion}"] = downstreamBuild?.description?.trim() ? downstreamBuild?.description : 'failed'
+    rubyTasksFailed = true
     warnError('Test Failures') {
       error("Downstream job for '${rubyVersion}' failed")
     }

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -5,9 +5,14 @@ import co.elastic.matrix.*
 import groovy.transform.Field
 
 /**
- This is required to store the results of the tests.
+ This is required know if there any failures when running the downstream jobs.
 */
 @Field def rubyTasksFailed = false
+
+/**
+ This is required to store the build status for the downstream jobs.
+*/
+@Field def rubyDownstreamJobs = [:]
 
 pipeline {
   agent { label 'linux && immutable' }
@@ -243,7 +248,7 @@ pipeline {
     }
     post {
       cleanup {
-        notifyBuildResult()
+        notifyBuildResult(downstreamJobs: rubyDownstreamJobs)
       }
     }
   }
@@ -286,18 +291,21 @@ def runBenchmark(version){
 }
 
 def runJob(rubyVersion){
+  def buildObject
   try {
-    build( job: "apm-agent-ruby/apm-agent-ruby-downstream/${env.BRANCH_NAME}",
-      parameters: [
-        string(name: 'RUBY_VERSION', value: "${rubyVersion}"),
-        string(name: 'BRANCH_SPECIFIER', value: "${env.GIT_BASE_COMMIT}")
-      ],
-      quietPeriod: 15
-    )
+    buildObject = build(job: "apm-agent-ruby/apm-agent-ruby-downstream/${env.BRANCH_NAME}",
+                        parameters: [
+                          string(name: 'RUBY_VERSION', value: "${rubyVersion}"),
+                          string(name: 'BRANCH_SPECIFIER', value: "${env.GIT_BASE_COMMIT}")
+                        ],
+                        quietPeriod: 15
+                      )
   } catch(e) {
     rubyTasksFailed = true
     warnError('Test Failures') {
       error("Downstream job for '${rubyVersion}' failed")
     }
+  } finally {
+    rubyDownstreamJobs["${rubyVersion}"] = buildObject
   }
 }

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -162,12 +162,18 @@ pipeline {
           }
         }
       }
-      stage('Populate Test failures') {
+      stage('Populate Downstream failures') {
         when {
           expression { return rubyTasksFailed }
         }
         steps {
-          error('There were some failures when running the "Test" stage')
+          script {
+            def message = 'Failures when running the "Test" stage'
+            if (notifyBuildResult.isAnyDownstreamJobFailedWithTimeout(rubyDownstreamJobs)) {
+              message += ' related to a timeout issue'
+            }
+            error(message)
+          }
         }
       }
       stage('Integration Tests') {

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -7,7 +7,7 @@ import groovy.transform.Field
 /**
  This is required to store the results of the tests.
 */
-@Field def rubyTasksFailed = false
+@Field def rubyTasksFailed = [:]
 
 pipeline {
   agent { label 'linux && immutable' }
@@ -159,10 +159,15 @@ pipeline {
       }
       stage('Populate Test failures') {
         when {
-          expression { return rubyTasksFailed }
+          expression { return !rubyTasksFailed.isEmpty() }
         }
         steps {
-          error('There were some failures when running the "Test" stage')
+          script {
+            if (rubyTasksFailed.find { k, v -> v.contains('timeout') }) {
+              currentBuild.description = 'Issue: timeout checkout in downstreams'
+            }
+          }
+          error("There were some failures when running the 'Test' stage. See ${rubyTasksFailed}")
         }
       }
       stage('Integration Tests') {
@@ -285,17 +290,19 @@ def runBenchmark(version){
   }
 }
 
-def runJob(rubyVersion){
+def runJob(rubyVersion) {
+  def downstreamBuild
   try {
-    build( job: "apm-agent-ruby/apm-agent-ruby-downstream/${env.BRANCH_NAME}",
-      parameters: [
-        string(name: 'RUBY_VERSION', value: "${rubyVersion}"),
-        string(name: 'BRANCH_SPECIFIER', value: "${env.GIT_BASE_COMMIT}")
-      ],
-      quietPeriod: 15
-    )
+    downstreamBuild = build(job: "apm-agent-ruby/apm-agent-ruby-downstream/${env.BRANCH_NAME}",
+                            parameters: [
+                              string(name: 'RUBY_VERSION', value: "${rubyVersion}"),
+                              string(name: 'BRANCH_SPECIFIER', value: "${env.GIT_BASE_COMMIT}")
+                            ],
+                            quietPeriod: 15
+                          )
   } catch(e) {
-    rubyTasksFailed = true
+    // This will help to report the status for the failure in the downstreams.
+    rubyTasksFailed["${rubyVersion}"] = downstreamBuild?.description?.trim() ? downstreamBuild?.description : 'failed'
     warnError('Test Failures') {
       error("Downstream job for '${rubyVersion}' failed")
     }

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -1,5 +1,5 @@
 #!/usr/bin/env groovy
-@Library('apm@current') _
+@Library('apm@7b341f35859bcefeead9a7f9646c638b1bc53bf0') _
 
 import co.elastic.matrix.*
 import groovy.transform.Field

--- a/.ci/prepare-git-context.sh
+++ b/.ci/prepare-git-context.sh
@@ -10,8 +10,8 @@ git config remote.origin.fetch '+refs/heads/*:refs/remotes/origin/*'
 # Force the git user details when pushing using the last commit details
 USER_MAIL=$(git log -1 --pretty=format:'%ae')
 USER_NAME=$(git log -1 --pretty=format:'%an')
-git config --global user.email "${USER_MAIL}"
-git config --global user.name "${USER_NAME}"
+git config user.email "${USER_MAIL}"
+git config user.name "${USER_NAME}"
 
 # Checkout the branch as it's detached based by default.
 # See https://issues.jenkins-ci.org/browse/JENKINS-33171


### PR DESCRIPTION
## What does this pull request do?

Notify to the `parentstream` the reason for the downstream failures when they are related to a timeout or a test failure in the downstreams.

The notification is reported in the build description.

## Why is it important?

Easy to see timeout issues in the parent jobs or test failures.

## UI

Build description points to the build failures related to the timeout issue:

![image](https://user-images.githubusercontent.com/2871786/72438734-5ee9df80-379d-11ea-8107-02c63357fd0f.png)

Error reported at the bottom points to the timeout issue only:

![image](https://user-images.githubusercontent.com/2871786/72438790-7e810800-379d-11ea-8819-08ea47d464b2.png)


## Follow-ups
- The description should be shown as HTML format if that's enabled by default. At the moment is plain based and therefore it's in a whole single line :(


