### PR TITLE
ci(jenkins): even load distribution for the timeouts

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -94,8 +94,9 @@ pipeline {
             script {
               def ruby = readYaml(file: '.ci/.jenkins_ruby.yml')
               def testTasks = [:]
+              def i = 0
               ruby['RUBY_VERSION'].each{ rubyVersion ->
-                testTasks[rubyVersion] = { runJob(rubyVersion) }
+                testTasks[rubyVersion] = { runJob(rubyVersion, i++) }
               }
               parallel(testTasks)
               }
@@ -285,14 +286,15 @@ def runBenchmark(version){
   }
 }
 
-def runJob(rubyVersion){
+def runJob(String rubyVersion, int sleep = 1){
   try {
+    def quiet = (sleep * randomNumber(min: 1, max: 5)) + 5
     build( job: "apm-agent-ruby/apm-agent-ruby-downstream/${env.BRANCH_NAME}",
       parameters: [
         string(name: 'RUBY_VERSION', value: "${rubyVersion}"),
         string(name: 'BRANCH_SPECIFIER', value: "${env.GIT_BASE_COMMIT}")
       ],
-      quietPeriod: 15
+      quietPeriod: quiet
     )
   } catch(e) {
     rubyTasksFailed = true

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -288,7 +288,7 @@ def runBenchmark(version){
 
 def runJob(String rubyVersion, int sleep = 1){
   try {
-    def quiet = (sleep * randomNumber(min: 1, max: 5)) + 5
+    def quiet = (sleep * randomNumber(min: 2, max: 6)) + 5
     build( job: "apm-agent-ruby/apm-agent-ruby-downstream/${env.BRANCH_NAME}",
       parameters: [
         string(name: 'RUBY_VERSION', value: "${rubyVersion}"),


### PR DESCRIPTION
## What does this pull request do?

Run downstream jobs with some random sleep.

## Why is it important?

Let's see if this particular change reduces the issues with the tiemout when there are a bunch of builds asking for git checkouts

## Related issues
closes #ISSUE