### PR TITLE
Handle case when headers are nil in response

### DIFF
--- a/lib/elastic_apm/context/response.rb
+++ b/lib/elastic_apm/context/response.rb
@@ -21,7 +21,7 @@ module ElasticAPM
       attr_reader :headers
 
       def headers=(headers)
-        @headers = headers.each_with_object({}) do |(k, v), hsh|
+        @headers = headers&.each_with_object({}) do |(k, v), hsh|
           hsh[k] = v.to_s
         end
       end

--- a/spec/elastic_apm/context/response_spec.rb
+++ b/spec/elastic_apm/context/response_spec.rb
@@ -2,21 +2,34 @@
 
 module ElasticAPM
   RSpec.describe Context::Response do
-    it 'converts header values to string' do
-      resp = described_class.new(
+    let(:response) do
+      described_class.new(
         nil,
-        headers: {
-          a: 1,
-          b: '2',
-          c: [1, 2, 3]
-        }
+        headers: headers
       )
+    end
 
-      expect(resp.headers).to match(
+    let(:headers) do
+      {
+        a: 1,
+        b: '2',
+        c: [1, 2, 3]
+      }
+    end
+
+    it 'converts header values to string' do
+      expect(response.headers).to match(
         a: '1',
         b: '2',
         c: '[1, 2, 3]'
       )
+    end
+
+    context 'when headers are nil' do
+      let(:headers) { nil }
+      it 'sets headers to nil' do
+        expect(response.headers).to eq(nil)
+      end
     end
   end
 end


### PR DESCRIPTION
We got this error in a test:

```ruby
undefined method `each_with_object' for nil:NilClass
["./lib/elastic_apm/context/response.rb:24:in `headers='",...
```

So we must check if `headers` is `nil` before processing them.