### PR TITLE
Upgrade Grape version in test matrix

### DIFF
--- a/.ci/.jenkins_exclude.yml
+++ b/.ci/.jenkins_exclude.yml
@@ -94,24 +94,24 @@ exclude:
     FRAMEWORK: grape-master
 
   - RUBY_VERSION: ruby:2.6
-    FRAMEWORK: grape-1.2,sinatra-2.0,rails-6.0
+    FRAMEWORK: grape-1.3,sinatra-2.0,rails-6.0
   - RUBY_VERSION: ruby:2.5
-    FRAMEWORK: grape-1.2,sinatra-2.0,rails-6.0
+    FRAMEWORK: grape-1.3,sinatra-2.0,rails-6.0
   - RUBY_VERSION: ruby:2.4
-    FRAMEWORK: grape-1.2,sinatra-2.0,rails-6.0
+    FRAMEWORK: grape-1.3,sinatra-2.0,rails-6.0
   - RUBY_VERSION: ruby:2.3
-    FRAMEWORK: grape-1.2,sinatra-2.0,rails-6.0
+    FRAMEWORK: grape-1.3,sinatra-2.0,rails-6.0
   - RUBY_VERSION: jruby:9.2
-    FRAMEWORK: grape-1.2,sinatra-2.0,rails-6.0
+    FRAMEWORK: grape-1.3,sinatra-2.0,rails-6.0
   - RUBY_VERSION: jruby:9.1
-    FRAMEWORK: grape-1.2,sinatra-2.0,rails-6.0
+    FRAMEWORK: grape-1.3,sinatra-2.0,rails-6.0
   - RUBY_VERSION: docker.elastic.co/observability-ci/jruby:9.2-13-jdk
-    FRAMEWORK: grape-1.2,sinatra-2.0,rails-6.0
+    FRAMEWORK: grape-1.3,sinatra-2.0,rails-6.0
   - RUBY_VERSION: docker.elastic.co/observability-ci/jruby:9.2-12-jdk
-    FRAMEWORK: grape-1.2,sinatra-2.0,rails-6.0
+    FRAMEWORK: grape-1.3,sinatra-2.0,rails-6.0
   - RUBY_VERSION: docker.elastic.co/observability-ci/jruby:9.2-11-jdk
-    FRAMEWORK: grape-1.2,sinatra-2.0,rails-6.0
+    FRAMEWORK: grape-1.3,sinatra-2.0,rails-6.0
   - RUBY_VERSION: docker.elastic.co/observability-ci/jruby:9.2-8-jdk
-    FRAMEWORK: grape-1.2,sinatra-2.0,rails-6.0
+    FRAMEWORK: grape-1.3,sinatra-2.0,rails-6.0
   - RUBY_VERSION: docker.elastic.co/observability-ci/jruby:9.1-7-jdk
-    FRAMEWORK: grape-1.2,sinatra-2.0,rails-6.0
+    FRAMEWORK: grape-1.3,sinatra-2.0,rails-6.0

--- a/.ci/.jenkins_exclude.yml
+++ b/.ci/.jenkins_exclude.yml
@@ -93,6 +93,10 @@ exclude:
   - RUBY_VERSION: docker.elastic.co/observability-ci/jruby:9.1-7-jdk
     FRAMEWORK: grape-master
 
+  # Unsupported
+  - RUBY_VERSION: ruby:2.3
+    FRAMEWORK: grape-1.3
+
   - RUBY_VERSION: ruby:2.6
     FRAMEWORK: grape-1.3,sinatra-2.0,rails-6.0
   - RUBY_VERSION: ruby:2.5

--- a/.ci/.jenkins_framework.yml
+++ b/.ci/.jenkins_framework.yml
@@ -8,6 +8,6 @@ FRAMEWORK:
   - sinatra-2.0
   - sinatra-1.4
 
-  - grape-1.2
+  - grape-1.3
 
-  - grape-1.2,sinatra-2.0,rails-6.0
+  - grape-1.3,sinatra-2.0,rails-6.0


### PR DESCRIPTION
Grape 1.3.0 was recently released: https://github.com/ruby-grape/grape/blob/master/CHANGELOG.md#130-20200111