### PR TITLE
Remove Ruby 2.3 from test matrix

### DIFF
--- a/.ci/.jenkins_exclude.yml
+++ b/.ci/.jenkins_exclude.yml
@@ -18,8 +18,6 @@ exclude:
 
   - RUBY_VERSION: ruby:2.4
     FRAMEWORK: rails-6.0
-  - RUBY_VERSION: ruby:2.3
-    FRAMEWORK: rails-6.0
   - RUBY_VERSION: jruby:9.1
     FRAMEWORK: rails-6.0
   - RUBY_VERSION: docker.elastic.co/observability-ci/jruby:9.1-7-jdk
@@ -32,8 +30,6 @@ exclude:
     FRAMEWORK: rails-master
   - RUBY_VERSION: ruby:2.4
     FRAMEWORK: rails-master
-  - RUBY_VERSION: ruby:2.3
-    FRAMEWORK: rails-master
   - RUBY_VERSION: jruby:9.2
     FRAMEWORK: rails-master
   - RUBY_VERSION: jruby:9.1
@@ -52,8 +48,6 @@ exclude:
   - RUBY_VERSION: ruby:2.5
     FRAMEWORK: sinatra-master
   - RUBY_VERSION: ruby:2.4
-    FRAMEWORK: sinatra-master
-  - RUBY_VERSION: ruby:2.3
     FRAMEWORK: sinatra-master
   - RUBY_VERSION: jruby:9.2
     FRAMEWORK: sinatra-master
@@ -76,8 +70,6 @@ exclude:
     FRAMEWORK: grape-master
   - RUBY_VERSION: ruby:2.4
     FRAMEWORK: grape-master
-  - RUBY_VERSION: ruby:2.3
-    FRAMEWORK: grape-master
   - RUBY_VERSION: jruby:9.2
     FRAMEWORK: grape-master
   - RUBY_VERSION: jruby:9.1
@@ -93,17 +85,11 @@ exclude:
   - RUBY_VERSION: docker.elastic.co/observability-ci/jruby:9.1-7-jdk
     FRAMEWORK: grape-master
 
-  # Unsupported
-  - RUBY_VERSION: ruby:2.3
-    FRAMEWORK: grape-1.3
-
   - RUBY_VERSION: ruby:2.6
     FRAMEWORK: grape-1.3,sinatra-2.0,rails-6.0
   - RUBY_VERSION: ruby:2.5
     FRAMEWORK: grape-1.3,sinatra-2.0,rails-6.0
   - RUBY_VERSION: ruby:2.4
-    FRAMEWORK: grape-1.3,sinatra-2.0,rails-6.0
-  - RUBY_VERSION: ruby:2.3
     FRAMEWORK: grape-1.3,sinatra-2.0,rails-6.0
   - RUBY_VERSION: jruby:9.2
     FRAMEWORK: grape-1.3,sinatra-2.0,rails-6.0

--- a/.ci/.jenkins_ruby.yml
+++ b/.ci/.jenkins_ruby.yml
@@ -3,7 +3,6 @@ RUBY_VERSION:
   - ruby:2.6
   - ruby:2.5
   - ruby:2.4
-  - ruby:2.3
   - jruby:9.2
   - jruby:9.1
   - docker.elastic.co/observability-ci/jruby:9.2-13-jdk


### PR DESCRIPTION
Ruby 2.3 has reached its End Of Life.