### PR TITLE
Minimize the amount of Ruby 2.3 test branches

### DIFF
--- a/.ci/.jenkins_exclude.yml
+++ b/.ci/.jenkins_exclude.yml
@@ -1,4 +1,27 @@
 exclude:
+  # Ruby 2.3
+  # Only includes rails-5.2, sinatra-2.0
+  - RUBY_VERSION: ruby:2.3
+    FRAMEWORK: rails-6.0
+  - RUBY_VERSION: ruby:2.3
+    FRAMEWORK: rails-5.1
+  - RUBY_VERSION: ruby:2.3
+    FRAMEWORK: rails-5.0
+  - RUBY_VERSION: ruby:2.3
+    FRAMEWORK: rails-4.2
+  - RUBY_VERSION: ruby:2.3
+    FRAMEWORK: sinatra-1.4
+  - RUBY_VERSION: ruby:2.3
+    FRAMEWORK: grape-1.3
+  - RUBY_VERSION: ruby:2.3
+    FRAMEWORK: grape-1.3,sinatra-2.0,rails-6.0
+  - RUBY_VERSION: ruby:2.3
+    FRAMEWORK: rails-master
+  - RUBY_VERSION: ruby:2.3
+    FRAMEWORK: sinatra-master
+  - RUBY_VERSION: ruby:2.3
+    FRAMEWORK: grape-master
+
   - RUBY_VERSION: ruby:2.7
     FRAMEWORK: rails-4.2
   - RUBY_VERSION: jruby:9.2
@@ -18,8 +41,6 @@ exclude:
 
   - RUBY_VERSION: ruby:2.4
     FRAMEWORK: rails-6.0
-  - RUBY_VERSION: ruby:2.3
-    FRAMEWORK: rails-6.0
   - RUBY_VERSION: jruby:9.1
     FRAMEWORK: rails-6.0
   - RUBY_VERSION: docker.elastic.co/observability-ci/jruby:9.1-7-jdk
@@ -32,8 +53,6 @@ exclude:
     FRAMEWORK: rails-master
   - RUBY_VERSION: ruby:2.4
     FRAMEWORK: rails-master
-  - RUBY_VERSION: ruby:2.3
-    FRAMEWORK: rails-master
   - RUBY_VERSION: jruby:9.2
     FRAMEWORK: rails-master
   - RUBY_VERSION: jruby:9.1
@@ -52,8 +71,6 @@ exclude:
   - RUBY_VERSION: ruby:2.5
     FRAMEWORK: sinatra-master
   - RUBY_VERSION: ruby:2.4
-    FRAMEWORK: sinatra-master
-  - RUBY_VERSION: ruby:2.3
     FRAMEWORK: sinatra-master
   - RUBY_VERSION: jruby:9.2
     FRAMEWORK: sinatra-master
@@ -75,8 +92,6 @@ exclude:
   - RUBY_VERSION: ruby:2.5
     FRAMEWORK: grape-master
   - RUBY_VERSION: ruby:2.4
-    FRAMEWORK: grape-master
-  - RUBY_VERSION: ruby:2.3
     FRAMEWORK: grape-master
   - RUBY_VERSION: jruby:9.2
     FRAMEWORK: grape-master
@@ -94,7 +109,9 @@ exclude:
     FRAMEWORK: grape-master
 
   # Unsupported
-  - RUBY_VERSION: ruby:2.3
+  - RUBY_VERSION: jruby:9.1
+    FRAMEWORK: grape-1.3
+  - RUBY_VERSION: docker.elastic.co/observability-ci/jruby:9.1-7-jdk
     FRAMEWORK: grape-1.3
 
   - RUBY_VERSION: ruby:2.6
@@ -102,8 +119,6 @@ exclude:
   - RUBY_VERSION: ruby:2.5
     FRAMEWORK: grape-1.3,sinatra-2.0,rails-6.0
   - RUBY_VERSION: ruby:2.4
-    FRAMEWORK: grape-1.3,sinatra-2.0,rails-6.0
-  - RUBY_VERSION: ruby:2.3
     FRAMEWORK: grape-1.3,sinatra-2.0,rails-6.0
   - RUBY_VERSION: jruby:9.2
     FRAMEWORK: grape-1.3,sinatra-2.0,rails-6.0


### PR DESCRIPTION
Ruby 2.3 has reached EOL, so we're minimizing the count of framework combinations under test. Support will officially be dropped in next major release.