### PR TITLE
[benchmark] some fixes in the CI

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -280,7 +280,7 @@ def runBenchmark(version){
             dockerLogin(secret: "${DOCKER_SECRET}", registry: "${DOCKER_REGISTRY}")
           }
           try{
-            sh "./spec/scripts/benchmarks.sh ${version}"
+            sh """./spec/scripts/benchmarks.sh "${version}" "${REFERENCE_REPO}" """
           } catch(e){
             throw e
           } finally {

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -86,47 +86,6 @@ pipeline {
         }
       }
     }
-    stage('Benchmarks') {
-      options { skipDefaultCheckout() }
-      stages {
-        stage('Clean Workspace') {
-          agent { label 'metal' }
-          steps {
-            echo "Cleaning Workspace"
-          }
-          post {
-            always {
-              cleanWs()
-            }
-          }
-        }
-        /**
-          Run the benchmarks and store the results on ES.
-          The result JSON files are also archive into Jenkins.
-        */
-        stage('Run Benchmarks') {
-          steps {
-            withGithubNotify(context: 'Run Benchmarks') {
-              deleteDir()
-              unstash 'source'
-              dir("${BASE_DIR}"){
-                script {
-                  def versions = readYaml(file: ".ci/.jenkins_ruby.yml")
-                  def benchmarkTask = [:]
-                  // TODO: benchmark for the jruby:9.2 and similar versions got some issues with
-                  //       NoMethodError: undefined method `[]' for nil:NilClass
-                  //      <main> at bench/report.rb:48
-                  versions['RUBY_VERSION'].findAll { !it.contains('9.2') }.each{ v ->
-                    benchmarkTask[v] = runBenchmark(v)
-                  }
-                  parallel(benchmarkTask)
-                }
-              }
-            }
-          }
-        }
-      }
-    }
     /**
     Execute unit tests.
     */
@@ -145,6 +104,60 @@ pipeline {
                 testTasks[rubyVersion] = { runJob(rubyVersion, i++) }
               }
               parallel(testTasks)
+              }
+            }
+          }
+        }
+      }
+      stage('Benchmarks') {
+        options { skipDefaultCheckout() }
+        when {
+          beforeAgent true
+          allOf {
+            anyOf {
+              branch 'master'
+              branch "\\d+\\.\\d+"
+              branch "v\\d?"
+              tag "v\\d+\\.\\d+\\.\\d+*"
+              expression { return params.Run_As_Master_Branch }
+            }
+            expression { return params.bench_ci }
+          }
+        }
+        stages {
+          stage('Clean Workspace') {
+            agent { label 'metal' }
+            steps {
+              echo "Cleaning Workspace"
+            }
+            post {
+              always {
+                cleanWs()
+              }
+            }
+          }
+          /**
+            Run the benchmarks and store the results on ES.
+            The result JSON files are also archive into Jenkins.
+          */
+          stage('Run Benchmarks') {
+            steps {
+              withGithubNotify(context: 'Run Benchmarks') {
+                deleteDir()
+                unstash 'source'
+                dir("${BASE_DIR}"){
+                  script {
+                    def versions = readYaml(file: ".ci/.jenkins_ruby.yml")
+                    def benchmarkTask = [:]
+                    // TODO: benchmark for the jruby:9.2 and similar versions got some issues with
+                    //       NoMethodError: undefined method `[]' for nil:NilClass
+                    //      <main> at bench/report.rb:48
+                    versions['RUBY_VERSION'].findAll { !it.contains('9.2') }.each{ v ->
+                      benchmarkTask[v] = runBenchmark(v)
+                    }
+                    parallel(benchmarkTask)
+                  }
+                }
               }
             }
           }
@@ -275,6 +288,8 @@ def runBenchmark(version){
               allowEmptyArchive: true,
               artifacts: "**/benchmark-${transformedVersion}.raw,**/benchmark-${transformedVersion}.error",
               onlyIfSuccessful: false)
+            sendBenchmarks(file: "benchmark-${transformedVersion}.bulk",
+              index: "benchmark-ruby", archive: true)
           }
         }
       }

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -86,6 +86,47 @@ pipeline {
         }
       }
     }
+    stage('Benchmarks') {
+      options { skipDefaultCheckout() }
+      stages {
+        stage('Clean Workspace') {
+          agent { label 'metal' }
+          steps {
+            echo "Cleaning Workspace"
+          }
+          post {
+            always {
+              cleanWs()
+            }
+          }
+        }
+        /**
+          Run the benchmarks and store the results on ES.
+          The result JSON files are also archive into Jenkins.
+        */
+        stage('Run Benchmarks') {
+          steps {
+            withGithubNotify(context: 'Run Benchmarks') {
+              deleteDir()
+              unstash 'source'
+              dir("${BASE_DIR}"){
+                script {
+                  def versions = readYaml(file: ".ci/.jenkins_ruby.yml")
+                  def benchmarkTask = [:]
+                  // TODO: benchmark for the jruby:9.2 and similar versions got some issues with
+                  //       NoMethodError: undefined method `[]' for nil:NilClass
+                  //      <main> at bench/report.rb:48
+                  versions['RUBY_VERSION'].findAll { !it.contains('9.2') }.each{ v ->
+                    benchmarkTask[v] = runBenchmark(v)
+                  }
+                  parallel(benchmarkTask)
+                }
+              }
+            }
+          }
+        }
+      }
+    }
     /**
     Execute unit tests.
     */
@@ -104,60 +145,6 @@ pipeline {
                 testTasks[rubyVersion] = { runJob(rubyVersion, i++) }
               }
               parallel(testTasks)
-              }
-            }
-          }
-        }
-      }
-      stage('Benchmarks') {
-        options { skipDefaultCheckout() }
-        when {
-          beforeAgent true
-          allOf {
-            anyOf {
-              branch 'master'
-              branch "\\d+\\.\\d+"
-              branch "v\\d?"
-              tag "v\\d+\\.\\d+\\.\\d+*"
-              expression { return params.Run_As_Master_Branch }
-            }
-            expression { return params.bench_ci }
-          }
-        }
-        stages {
-          stage('Clean Workspace') {
-            agent { label 'metal' }
-            steps {
-              echo "Cleaning Workspace"
-            }
-            post {
-              always {
-                cleanWs()
-              }
-            }
-          }
-          /**
-            Run the benchmarks and store the results on ES.
-            The result JSON files are also archive into Jenkins.
-          */
-          stage('Run Benchmarks') {
-            steps {
-              withGithubNotify(context: 'Run Benchmarks') {
-                deleteDir()
-                unstash 'source'
-                dir("${BASE_DIR}"){
-                  script {
-                    def versions = readYaml(file: ".ci/.jenkins_ruby.yml")
-                    def benchmarkTask = [:]
-                    // TODO: benchmark for the jruby:9.2 and similar versions got some issues with
-                    //       NoMethodError: undefined method `[]' for nil:NilClass
-                    //      <main> at bench/report.rb:48
-                    versions['RUBY_VERSION'].findAll { !it.contains('9.2') }.each{ v ->
-                      benchmarkTask[v] = runBenchmark(v)
-                    }
-                    parallel(benchmarkTask)
-                  }
-                }
               }
             }
           }
@@ -288,8 +275,6 @@ def runBenchmark(version){
               allowEmptyArchive: true,
               artifacts: "**/benchmark-${transformedVersion}.raw,**/benchmark-${transformedVersion}.error",
               onlyIfSuccessful: false)
-            sendBenchmarks(file: "benchmark-${transformedVersion}.bulk",
-              index: "benchmark-ruby", archive: true)
           }
         }
       }

--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,6 @@ vendor/
 
 .idea/
 log/
+
+benchmark-*.error
+benchmark-*.raw

--- a/spec/scripts/benchmarks.sh
+++ b/spec/scripts/benchmarks.sh
@@ -5,15 +5,17 @@
 #
 # Usage: ./spec/scripts/benchmarks.sh jruby:9.1
 #
-set -exuo pipefail
+set -exo pipefail
 
-if [ $# -lt 1 ]; then
-  echo "Arguments missing"
-  exit 2
-fi
-
-RUBY_IMAGE=${1}
+RUBY_IMAGE=${1:?"missing RUBY IMAGE"}
 VERSION=$(echo "${RUBY_IMAGE}" | cut -d":" -f2)
+REFERENCE_REPO=${2}
+
+if [ -z "${REFERENCE_REPO}" ] ; then
+  REFERENCE_REPO_FLAG=""
+else
+  REFERENCE_REPO_FLAG="-v ${REFERENCE_REPO}:${REFERENCE_REPO}"
+fi
 
 ## Transform the versions like:
 ##  - docker.elastic.co/observability-ci/jruby:9.2-12-jdk to jruby-9.2-12-jdk
@@ -36,6 +38,7 @@ RUBY_VERSION=${VERSION} docker-compose run \
   -e LOCAL_USER_ID=$UID \
   -v "$local_vendor_path:$container_vendor_path" \
   -v "$(dirname "$(pwd)"):/app" \
+  ${REFERENCE_REPO_FLAG} \
   --rm ruby_rspec \
   /bin/bash -c "set -x
     cp -rf ${container_vendor_path} /tmp/.vendor

--- a/spec/scripts/benchmarks.sh
+++ b/spec/scripts/benchmarks.sh
@@ -30,7 +30,7 @@ cd spec
 docker build --pull --force-rm --build-arg "RUBY_IMAGE=${RUBY_IMAGE}" -t "apm-agent-ruby:${VERSION}" .
 RUBY_VERSION=${VERSION} docker-compose run \
   --user $UID \
-  -e HOME=/app \
+  -e HOME=/tmp \
   -e FRAMEWORK=rails \
   -w /app \
   -e LOCAL_USER_ID=$UID \
@@ -38,9 +38,10 @@ RUBY_VERSION=${VERSION} docker-compose run \
   -v "$(dirname "$(pwd)"):/app" \
   --rm ruby_rspec \
   /bin/bash -c "set -x
+    cp -rf ${container_vendor_path} /tmp/.vendor
     gem update --system
     gem install bundler
-    bundle config set path ${container_vendor_path}
+    bundle config set path '/tmp/.vendor'
     bundle install
     bench/benchmark.rb 2> benchmark-${TRANSFORMED_VERSION}.error > benchmark-${TRANSFORMED_VERSION}.raw
     bench/report.rb < benchmark-${TRANSFORMED_VERSION}.raw > benchmark-${TRANSFORMED_VERSION}.bulk"

--- a/spec/scripts/benchmarks.sh
+++ b/spec/scripts/benchmarks.sh
@@ -44,7 +44,7 @@ RUBY_VERSION=${VERSION} docker-compose run \
     cp -rf ${container_vendor_path} /tmp/.vendor
     gem update --system
     gem install bundler
-    bundle config set path '/tmp/.vendor'
+    bundle config --global set path '/tmp/.vendor'
     bundle install
     bench/benchmark.rb 2> benchmark-${TRANSFORMED_VERSION}.error > benchmark-${TRANSFORMED_VERSION}.raw
     bench/report.rb < benchmark-${TRANSFORMED_VERSION}.raw > benchmark-${TRANSFORMED_VERSION}.bulk"

--- a/spec/scripts/benchmarks.sh
+++ b/spec/scripts/benchmarks.sh
@@ -40,7 +40,8 @@ RUBY_VERSION=${VERSION} docker-compose run \
   /bin/bash -c "set -x
     gem update --system
     gem install bundler
-    bundle install --path $container_vendor_path
+    bundle config set path ${container_vendor_path}
+    bundle install
     bench/benchmark.rb 2> benchmark-${TRANSFORMED_VERSION}.error > benchmark-${TRANSFORMED_VERSION}.raw
     bench/report.rb < benchmark-${TRANSFORMED_VERSION}.raw > benchmark-${TRANSFORMED_VERSION}.bulk"
 


### PR DESCRIPTION
## What does this pull request do?

Fixes:
- Git reference repo access from the docker containers when running in the CI pipeline bypassing the git reference repo to the docker-compose.
- Deprecate when using the `--path` flag by using `bundle config set path`
- Write access to the /app/.bundle folder by copying the cached folder in another location and setting the HOME path in the docker container.

## Why is it important?

Benchmarking stage is broken at the moment.

## Related issues

closes #691

## Tests

![image](https://user-images.githubusercontent.com/2871786/72723821-954aa480-3b79-11ea-8556-cf00a271f5a1.png)
