### PR TITLE
Rename and deprecate disableD_instrumentations

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -35,6 +35,15 @@ endif::[]
 [[release-notes-3.x]]
 === Ruby Agent version 3.x
 
+[float]
+[[unreleased]]
+==== Unreleased
+
+[float]
+===== Changed
+
+- Rename disabled_instrumentations to disable_instrumentations {pull}695[#695]
+
 [[release-notes-3.4.0]]
 ==== 3.4.0 (2020-01-10)
 

--- a/docs/configuration.asciidoc
+++ b/docs/configuration.asciidoc
@@ -351,12 +351,12 @@ Disables the agent's startup message announcing itself.
 
 [float]
 [[config-disabled-instrumentations]]
-==== `disabled_instrumentations`
+==== `disable_instrumentations`
 
 [options="header"]
 |============
-| Environment                             | `Config` key                | Default
-| `ELASTIC_APM_DISABLED_INSTRUMENTATIONS` | `disabled_instrumentations` | `['json']`
+| Environment                            | `Config` key               | Default
+| `ELASTIC_APM_DISABLE_INSTRUMENTATIONS` | `disable_instrumentations` | `['json']`
 |============
 
 Elastic APM automatically instruments select third party libraries.

--- a/lib/elastic_apm/config.rb
+++ b/lib/elastic_apm/config.rb
@@ -37,7 +37,7 @@ module ElasticAPM
     option :disable_metrics,                   type: :list,   default: [],      converter: WildcardPatternList.new
     option :disable_send,                      type: :bool,   default: false
     option :disable_start_message,             type: :bool,   default: false
-    option :disabled_instrumentations,         type: :list,   default: %w[json]
+    option :disable_instrumentations,          type: :list,   default: %w[json]
     option :disabled_spies,                    type: :list,   default: []
     option :environment,                       type: :string, default: ENV['RAILS_ENV'] || ENV['RACK_ENV']
     option :framework_name,                    type: :string
@@ -129,7 +129,7 @@ module ElasticAPM
     end
 
     def enabled_instrumentations
-      available_instrumentations - disabled_instrumentations
+      available_instrumentations - disable_instrumentations
     end
 
     def method_missing(name, *args)
@@ -154,6 +154,16 @@ module ElasticAPM
 
     def collect_metrics?
       metrics_interval > 0
+    end
+
+    def disabled_instrumentations
+      disable_instrumentations
+    end
+
+    def disabled_instrumentations=(value)
+      warn '[DEPRECATED] The option disabled_instrumentations has been ' \
+        'renamed to disable_instrumentations to align with other agents.'
+      self.disable_instrumentations = value
     end
 
     def span_frames_min_duration?

--- a/spec/elastic_apm/config_spec.rb
+++ b/spec/elastic_apm/config_spec.rb
@@ -44,7 +44,7 @@ module ElasticAPM
         ['ELASTIC_APM_VERIFY_SERVER_CERT', 'true', true],
         ['ELASTIC_APM_VERIFY_SERVER_CERT', '0', false],
         ['ELASTIC_APM_VERIFY_SERVER_CERT', 'false', false],
-        ['ELASTIC_APM_DISABLED_INSTRUMENTATIONS', 'json,http', %w[json http]],
+        ['ELASTIC_APM_DISABLE_INSTRUMENTATIONS', 'json,http', %w[json http]],
         ['ELASTIC_APM_CUSTOM_KEY_FILTERS', 'Auth,Other', [/Auth/, /Other/]],
         [
           'ELASTIC_APM_DEFAULT_TAGS',
@@ -157,7 +157,7 @@ module ElasticAPM
     it 'has spies and may disable them' do
       expect(Config.new.available_instrumentations).to_not be_empty
 
-      config = Config.new disabled_instrumentations: ['json']
+      config = Config.new disable_instrumentations: ['json']
       expect(config.enabled_instrumentations).to_not include('json')
     end
 
@@ -205,6 +205,21 @@ module ElasticAPM
           expect_any_instance_of(Config)
             .to receive(:warn).with(/Unknown option/)
           Config.new(config_file: 'spec/fixtures/unknown_option.yml')
+        end
+      end
+    end
+
+    context 'DEPRECATED' do
+      describe 'disabled_instrumentations' do
+        subject { Config.new }
+
+        it 'logs a warning and redirects' do
+          expect(subject).to receive(:warn).with(/DEPRECATED/)
+          subject.disabled_instrumentations = ['oh no']
+
+          expect(subject.disable_instrumentations).to eq(['oh no'])
+          expect(subject.disabled_instrumentations)
+            .to eq(subject.disable_instrumentations)
         end
       end
     end

--- a/spec/integration/json_spy_spec.rb
+++ b/spec/integration/json_spy_spec.rb
@@ -4,7 +4,7 @@ module ElasticAPM
   RSpec.describe 'Spy: JSON', :intercept do
     before do
       intercept!
-      ElasticAPM.start disabled_instrumentations: []
+      ElasticAPM.start disable_instrumentations: []
     end
 
     after do


### PR DESCRIPTION
Closes #658.

At first I added the deprecation warning to the reader method too, but figured one warning on app boot was enough.