### PR TITLE
Enable docker image cache in the CI workers

### DIFF
--- a/.ci/packer_cache.sh
+++ b/.ci/packer_cache.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+source /usr/local/bin/bash_standard_lib.sh
+
+grep "-" .ci/.jenkins_ruby.yml | cut -d'-' -f2- | \
+while read -r version;
+do
+    (retry 2 ./spec/scripts/docker_build.sh "${version}") || echo "Error building ${version} Docker image, we continue"
+done

--- a/spec/scripts/docker_build.sh
+++ b/spec/scripts/docker_build.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+set -ex
+
+RUBY_IMAGE=${1}
+VERSION=$(echo "${RUBY_IMAGE}" | cut -d":" -f2)
+
+cd spec
+docker build --build-arg "RUBY_IMAGE=${RUBY_IMAGE}" -t "apm-agent-ruby:${VERSION}" .

--- a/spec/scripts/spec.sh
+++ b/spec/scripts/spec.sh
@@ -33,7 +33,7 @@ if [[ $RUBY_IMAGE == *"jruby"* ]]; then
   JRUBY_OPTS="--debug"
 fi
 
-docker build --pull --build-arg "RUBY_IMAGE=${RUBY_IMAGE}" -t "apm-agent-ruby:${VERSION}" .
+docker build --build-arg "RUBY_IMAGE=${RUBY_IMAGE}" -t "apm-agent-ruby:${VERSION}" .
 RUBY_VERSION=${VERSION} docker-compose run \
   -e FRAMEWORK="${FRAMEWORK}" \
   -e INCLUDE_SCHEMA_SPECS=1 \


### PR DESCRIPTION
## What does this pull request do?

Build docker images and cache them in the CI workers using the `.ci/.jenkins_ruby.yml` as the reference to the docker images to be built

## Why is it important?

Speed up the CI overall execution time

## Related issues
closes #ISSUE

## How to test this

```bash
hub checkout pr 697
sh -x .ci/packer_cache.sh
```
_NOTE_: `/usr/local/bin/bash_standard_lib.sh` is required to exist. That particular requirement is already in place for the CI workers.


## Question
- Using a docker volume when running the docker compose could help with the caching? Or that's something already solved when building the docker image?