### PR TITLE
Enable docker image cache in the CI workers

### DIFF
--- a/.ci/packer_cache.sh
+++ b/.ci/packer_cache.sh
@@ -2,10 +2,11 @@
 
 source /usr/local/bin/bash_standard_lib.sh
 
-grep "-" .ci/.jenkins_ruby.yml | cut -d'-' -f2- | \
+grep "-" .ci/.jenkins_ruby.yml | grep -v 'observability-ci' | cut -d'-' -f2- | \
 while read -r version;
 do
-    imageName="apm-agent-ruby:${version}"
+    transformedVersion=$(echo "${version}" | cut -d":" -f2)
+    imageName="apm-agent-ruby:${transformedVersion}"
     registryImageName="docker.elastic.co/observability-ci/${imageName}"
     (retry 2 docker pull "${registryImageName}")
     docker tag "${registryImageName}" "${imageName}"

--- a/.ci/packer_cache.sh
+++ b/.ci/packer_cache.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+source /usr/local/bin/bash_standard_lib.sh
+
+grep "-" .ci/.jenkins_ruby.yml | cut -d'-' -f2- | \
+while read -r version;
+do
+    (retry 2 ./spec/scripts/docker_build.sh "${version}") || echo "Error building ${version} Docker image, we continue"
+done

--- a/.ci/packer_cache.sh
+++ b/.ci/packer_cache.sh
@@ -5,5 +5,8 @@ source /usr/local/bin/bash_standard_lib.sh
 grep "-" .ci/.jenkins_ruby.yml | cut -d'-' -f2- | \
 while read -r version;
 do
-    (retry 2 ./spec/scripts/docker_build.sh "${version}") || echo "Error building ${version} Docker image, we continue"
+    imageName="apm-agent-ruby:${version}"
+    registryImageName="docker.elastic.co/observability-ci/${imageName}"
+    (retry 2 docker pull "${registryImageName}")
+    docker tag "${registryImageName}" "${imageName}"
 done

--- a/.ci/packer_cache.sh
+++ b/.ci/packer_cache.sh
@@ -5,9 +5,10 @@ source /usr/local/bin/bash_standard_lib.sh
 grep "-" .ci/.jenkins_ruby.yml | grep -v 'observability-ci' | cut -d'-' -f2- | \
 while read -r version;
 do
+    transformedName=${version/:/-}
     transformedVersion=$(echo "${version}" | cut -d":" -f2)
-    imageName="apm-agent-ruby:${transformedVersion}"
-    registryImageName="docker.elastic.co/observability-ci/${imageName}"
+    imageName="apm-agent-ruby"
+    registryImageName="docker.elastic.co/observability-ci/${imageName}:${transformedName}"
     (retry 2 docker pull "${registryImageName}")
-    docker tag "${registryImageName}" "${imageName}"
+    docker tag "${registryImageName}" "${imageName}:${transformedVersion}"
 done

--- a/spec/scripts/docker_build.sh
+++ b/spec/scripts/docker_build.sh
@@ -1,9 +1,0 @@
-#!/usr/bin/env bash
-
-set -ex
-
-RUBY_IMAGE=${1}
-VERSION=$(echo "${RUBY_IMAGE}" | cut -d":" -f2)
-
-cd spec
-docker build --build-arg "RUBY_IMAGE=${RUBY_IMAGE}" -t "apm-agent-ruby:${VERSION}" .

--- a/spec/scripts/docker_build.sh
+++ b/spec/scripts/docker_build.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+set -ex
+
+RUBY_IMAGE=${1}
+VERSION=$(echo "${RUBY_IMAGE}" | cut -d":" -f2)
+
+cd spec
+docker build --build-arg "RUBY_IMAGE=${RUBY_IMAGE}" -t "apm-agent-ruby:${VERSION}" .

--- a/spec/scripts/spec.sh
+++ b/spec/scripts/spec.sh
@@ -33,7 +33,7 @@ if [[ $RUBY_IMAGE == *"jruby"* ]]; then
   JRUBY_OPTS="--debug"
 fi
 
-docker build --pull --build-arg "RUBY_IMAGE=${RUBY_IMAGE}" -t "apm-agent-ruby:${VERSION}" .
+docker build --build-arg "RUBY_IMAGE=${RUBY_IMAGE}" -t "apm-agent-ruby:${VERSION}" .
 RUBY_VERSION=${VERSION} docker-compose run \
   -e FRAMEWORK="${FRAMEWORK}" \
   -e INCLUDE_SCHEMA_SPECS=1 \


### PR DESCRIPTION
## What does this pull request do?

Use the just built docker images from [pipeline](https://apm-ci.elastic.co/job/apm-shared/job/apm-docker-images-pipeline/) that are already available in the internal docker registry and retag them to use them in the CI pipeline.

## Why is it important?

Speed up the CI overall execution time

## How to test this

```bash
hub checkout pr 698
sh -x .ci/packer_cache.sh
```
_NOTE_: `/usr/local/bin/bash_standard_lib.sh` is required to exist. That particular requirement is already in place for the CI workers.


## Issues

superseed #697


## Test cases

```
14:36:20  + docker build -t docker.elastic.co/observability-ci/apm-agent-ruby:ruby-2.5 --build-arg RUBY_IMAGE=ruby:2.5 .
14:36:20  Step 1/8 : ARG RUBY_IMAGE
14:36:20  Step 2/8 : FROM ${RUBY_IMAGE}
14:36:20   ---> e216e233b258
14:36:20  Step 3/8 : ENV CI "1"
14:36:20   ---> Using cache
14:36:20   ---> 89266d98cff1
14:36:20  Step 4/8 : ENV INCLUDE_COVERAGE "1"
14:36:20   ---> Using cache
14:36:20   ---> dc014316b67a
14:36:20  Step 5/8 : ENV DEBIAN_FRONTEND=noninteractive
14:36:20   ---> Using cache
14:36:20   ---> 690730f634d8
14:36:20  Step 6/8 : RUN [ apt-get ]     && ( apt-get update -qq         && apt-get install -qq -y build-essential libpq-dev git tzdata)     || true
14:36:20   ---> Using cache
14:36:20   ---> 00f568aab11d
14:36:20  Step 7/8 : RUN [ yum ]     && ( yum update -y -q         && yum install -y git )     || true
14:36:20   ---> Using cache
14:36:20   ---> b6739f431af3
14:36:20  Step 8/8 : WORKDIR /app
14:36:20   ---> Using cache
14:36:20   ---> 977afcc4bbfb
14:36:20  Successfully built 977afcc4bbfb
14:36:20  Successfully tagged docker.elastic.co/observability-ci/apm-agent-ruby:ruby-2.5

```

![image](https://user-images.githubusercontent.com/2871786/73184690-c6e0e400-4114-11ea-9cdf-8643e1c9cd3c.png)
