### PR TITLE
Add sanitize_fields_names and soft deprecate custom_key_filters

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -43,6 +43,7 @@ endif::[]
 ===== Added
 
 - Pass along tracestate headers and add prefixless Traceparent header {pull}694[#694]
+- Add sanitize_field_names to replace custom_key_filters {pull}708[#708]
 
 [float]
 ===== Changed

--- a/docs/configuration.asciidoc
+++ b/docs/configuration.asciidoc
@@ -90,7 +90,7 @@ Some options can be set with `ENV` variables and all of them may be set in
 your source code.
 
 When setting values for lists using `ENV` variables, strings are split by comma
-eg `ELASTIC_APM_CUSTOM_KEY_FILTERS="a,b" # => [/a/, /b/]`.
+eg `ELASTIC_APM_SANITIZE_FIELD_NAMES="a,b" # => [/a/, /b/]`.
 
 [float]
 [[config-config-file]]
@@ -303,6 +303,8 @@ Use this option to add your own custom header keys to the list of filtered keys.
 When setting this option via `ENV`, use a comma separated string.
 Eg. `ELASTIC_APM_CUSTOM_KEY_FILTERS="a,b" # => [/a/, /b/]`
 
+NOTE: This option is being removed. See <<config-sanitize-field-names>> instead.
+
 [float]
 [[config-default-tags]]
 ==== `default_tags`
@@ -345,6 +347,7 @@ that are set will override `global_labels`.
 
 A comma-separated list of dotted metrics names that should not be sent to the APM Server.
 You can use `*` to match multiple metrics.
+Matching is case-insensitive.
 
 [float]
 [[config-disable-send]]
@@ -607,6 +610,24 @@ Options available are:
 There are also `ENV` version of these following the same pattern of putting `ELASTIC_APM_` in front.
 
 See https://github.com/httprb/http/wiki/Proxy-Support[Http.rb's docs].
+
+[float]
+[[config-sanitize-field-names]]
+==== `sanitize_field_names`
+
+[options="header"]
+|============
+| Environment                        | `Config` key           | Default | Example
+| `ELASTIC_APM_SANITIZE_FIELD_NAMES` | `sanitize_field_names` | `[]`    | `Auth*tion,abc*,*xyz`
+|============
+
+Sometimes it is necessary to sanitize the data sent to Elastic APM, e.g. remove sensitive data.
+
+Configure a list of wildcard patterns of field names which should be sanitized. These apply to HTTP headers and bodies (if you're capturing those.)
+
+Supports the wildcard `*`, which matches zero or more characters.
+Examples: `/foo/*/bar/*/baz*`, `*foo*`.
+Matching is case insensitive.
 
 [float]
 [[config-service-name]]

--- a/lib/elastic_apm/config.rb
+++ b/lib/elastic_apm/config.rb
@@ -32,7 +32,6 @@ module ElasticAPM
     option :current_user_id_method,            type: :string, default: 'id'
     option :current_user_username_method,      type: :string, default: 'username'
     option :custom_key_filters,                type: :list,   default: [],      converter: RegexpList.new
-    option :default_tags,                      type: :dict,   default: {}
     option :default_labels,                    type: :dict,   default: {}
     option :disable_metrics,                   type: :list,   default: [],      converter: WildcardPatternList.new
     option :disable_send,                      type: :bool,   default: false
@@ -157,22 +156,6 @@ module ElasticAPM
       metrics_interval > 0
     end
 
-    def custom_key_filters=(value)
-      warn '[DEPRECATED] The option custom_key_filters is being removed. ' \
-        'See sanitize_field_names for an alternative.'
-      set(:custom_key_filters, value)
-    end
-
-    def disabled_instrumentations
-      disable_instrumentations
-    end
-
-    def disabled_instrumentations=(value)
-      warn '[DEPRECATED] The option disabled_instrumentations has been ' \
-        'renamed to disable_instrumentations to align with other agents.'
-      self.disable_instrumentations = value
-    end
-
     def span_frames_min_duration?
       span_frames_min_duration != 0
     end
@@ -209,6 +192,33 @@ module ElasticAPM
 
     def inspect
       super.split.first + '>'
+    end
+
+    # Deprecations
+
+    def default_tags=(value)
+      warn '[DEPRECATED] The option default_tags has been renamed to ' \
+        'default_labels.'
+      self.default_labels = value
+    end
+
+    def custom_key_filters=(value)
+      unless value == self.class.schema[:custom_key_filters].default
+        warn '[DEPRECATED] The option custom_key_filters is being removed. ' \
+          'See sanitize_field_names for an alternative.'
+      end
+
+      set(:custom_key_filters, value)
+    end
+
+    def disabled_instrumentations
+      disable_instrumentations
+    end
+
+    def disabled_instrumentations=(value)
+      warn '[DEPRECATED] The option disabled_instrumentations has been ' \
+        'renamed to disable_instrumentations to align with other agents.'
+      self.disable_instrumentations = value
     end
 
     private

--- a/lib/elastic_apm/config.rb
+++ b/lib/elastic_apm/config.rb
@@ -58,6 +58,7 @@ module ElasticAPM
     option :proxy_password,                    type: :string
     option :proxy_port,                        type: :int
     option :proxy_username,                    type: :string
+    option :sanitize_field_names,              type: :list,   default: [],      converter: WildcardPatternList.new
     option :server_ca_cert,                    type: :string
     option :service_name,                      type: :string
     option :service_version,                   type: :string
@@ -154,6 +155,12 @@ module ElasticAPM
 
     def collect_metrics?
       metrics_interval > 0
+    end
+
+    def custom_key_filters=(value)
+      warn '[DEPRECATED] The option custom_key_filters is being removed. ' \
+        'See sanitize_field_names for an alternative.'
+      set(:custom_key_filters, value)
     end
 
     def disabled_instrumentations

--- a/lib/elastic_apm/config/wildcard_pattern_list.rb
+++ b/lib/elastic_apm/config/wildcard_pattern_list.rb
@@ -22,7 +22,7 @@ module ElasticAPM
               arr << (char == '*' ? '.*' : Regexp.escape(char))
             end
 
-          Regexp.new('\A' + parts.join + '\Z')
+          Regexp.new('\A' + parts.join + '\Z', Regexp::IGNORECASE)
         end
       end
 

--- a/lib/elastic_apm/config/wildcard_pattern_list.rb
+++ b/lib/elastic_apm/config/wildcard_pattern_list.rb
@@ -14,6 +14,8 @@ module ElasticAPM
           !!@pattern.match(other)
         end
 
+        alias :match :match?
+
         private
 
         def convert(str)

--- a/lib/elastic_apm/transport/filters/secrets_filter.rb
+++ b/lib/elastic_apm/transport/filters/secrets_filter.rb
@@ -25,7 +25,10 @@ module ElasticAPM
 
         def initialize(config)
           @config = config
-          @key_filters = KEY_FILTERS + config.custom_key_filters
+          @key_filters =
+            KEY_FILTERS +
+            config.custom_key_filters +
+            config.sanitize_field_names
         end
 
         def call(payload)
@@ -60,11 +63,11 @@ module ElasticAPM
         end
 
         def filter_key?(key)
-          @key_filters.any? { |regex| key.match regex }
+          @key_filters.any? { |regex| regex.match?(key) }
         end
 
         def filter_value?(value)
-          VALUE_FILTERS.any? { |regex| value.match regex }
+          VALUE_FILTERS.any? { |regex| regex.match?(value) }
         end
       end
     end

--- a/lib/elastic_apm/transport/filters/secrets_filter.rb
+++ b/lib/elastic_apm/transport/filters/secrets_filter.rb
@@ -67,7 +67,7 @@ module ElasticAPM
         end
 
         def filter_value?(value)
-          VALUE_FILTERS.any? { |regex| regex.match?(value) }
+          VALUE_FILTERS.any? { |regex| regex.match(value) }
         end
       end
     end

--- a/lib/elastic_apm/transport/filters/secrets_filter.rb
+++ b/lib/elastic_apm/transport/filters/secrets_filter.rb
@@ -63,7 +63,7 @@ module ElasticAPM
         end
 
         def filter_key?(key)
-          @key_filters.any? { |regex| regex.match?(key) }
+          @key_filters.any? { |regex| regex.match(key) }
         end
 
         def filter_value?(value)

--- a/spec/elastic_apm/config/wildcard_pattern_list_spec.rb
+++ b/spec/elastic_apm/config/wildcard_pattern_list_spec.rb
@@ -12,7 +12,8 @@ module ElasticAPM
         ['*d', 'abcd', true],
         ['ab*', 'abcd', true],
         ['a.cd', 'abcd', false],
-        ['a?cd', 'abcd', false]
+        ['a?cd', 'abcd', false],
+        ['AbC', 'abc', true]
       ].each do |(pattern, string, expectation)|
         context pattern do
           let(:pattern) { pattern }

--- a/spec/elastic_apm/config_spec.rb
+++ b/spec/elastic_apm/config_spec.rb
@@ -31,8 +31,6 @@ module ElasticAPM
     end
 
     it 'converts certain env values to Ruby types' do
-      allow_any_instance_of(Config).to receive(:warn)
-        .with(/default_tags=.*removed./)
       [
         # [ 'NAME', 'VALUE', 'EXPECTED' ]
         ['ELASTIC_APM_SOURCE_LINES_ERROR_APP_FRAMES', '666', 666],
@@ -45,12 +43,6 @@ module ElasticAPM
         ['ELASTIC_APM_VERIFY_SERVER_CERT', '0', false],
         ['ELASTIC_APM_VERIFY_SERVER_CERT', 'false', false],
         ['ELASTIC_APM_DISABLE_INSTRUMENTATIONS', 'json,http', %w[json http]],
-        ['ELASTIC_APM_CUSTOM_KEY_FILTERS', 'Auth,Other', [/Auth/, /Other/]],
-        [
-          'ELASTIC_APM_DEFAULT_TAGS',
-          'test=something something&other=ok',
-          { 'test' => 'something something', 'other' => 'ok' }
-        ],
         [
           'ELASTIC_APM_DEFAULT_LABELS',
           'wave=something erlking&brother=ok',
@@ -124,13 +116,6 @@ module ElasticAPM
       context 'without a unit' do
         subject { Config.new(api_request_size: '1') }
         its(:api_request_size) { should eq 1024 }
-      end
-    end
-
-    context 'custom_key_filters' do
-      it 'sets custom_key_filters to array of regexp' do
-        config = Config.new(custom_key_filters: [/Authorization/, 'String'])
-        expect(config.custom_key_filters).to eq [/Authorization/, /String/]
       end
     end
 
@@ -210,6 +195,17 @@ module ElasticAPM
     end
 
     context 'DEPRECATED' do
+      describe 'default_tags' do
+        subject { Config.new }
+
+        it 'logs a warning and redirects' do
+          expect(subject).to receive(:warn).with(/DEPRECATED/)
+          subject.default_tags = 'oh_no=its_gone'
+
+          expect(subject.default_labels).to eq('oh_no' => 'its_gone')
+        end
+      end
+
       describe 'disabled_instrumentations' do
         subject { Config.new }
 

--- a/spec/elastic_apm/config_spec.rb
+++ b/spec/elastic_apm/config_spec.rb
@@ -222,6 +222,17 @@ module ElasticAPM
             .to eq(subject.disable_instrumentations)
         end
       end
+
+      describe 'custom_key_filters' do
+        subject { Config.new }
+
+        it 'logs a warning' do
+          expect(subject).to receive(:warn).with(/DEPRECATED/)
+          subject.custom_key_filters = ['oh no']
+
+          expect(subject.custom_key_filters).to eq([/oh no/])
+        end
+      end
     end
   end
 end

--- a/spec/elastic_apm/transport/filters/secrets_filter_spec.rb
+++ b/spec/elastic_apm/transport/filters/secrets_filter_spec.rb
@@ -81,6 +81,28 @@ module ElasticAPM
             )
           end
         end
+
+        context 'with sanitize_field_names' do
+          let(:config) { Config.new(sanitize_field_names: 'Auth*ion') }
+
+          it 'removes Authorization header' do
+            payload = { transaction: { context: { request: { headers: {
+              Authorization: 'Bearer some',
+              Authentication: 'Polar Bearer some',
+              SomeHeader: 'some'
+            } } } } }
+
+            subject.call(payload)
+
+            headers = payload.dig(:transaction, :context, :request, :headers)
+
+            expect(headers).to match(
+              Authorization: '[FILTERED]',
+              Authentication: '[FILTERED]',
+              SomeHeader: 'some'
+            )
+          end
+        end
       end
     end
   end

--- a/spec/elastic_apm/transport/filters/secrets_filter_spec.rb
+++ b/spec/elastic_apm/transport/filters/secrets_filter_spec.rb
@@ -63,6 +63,11 @@ module ElasticAPM
         end
 
         context 'with custom_key_filters' do
+          before do
+            # silence deprecation warning
+            allow_any_instance_of(Config).to receive(:warn).with(/DEPRECATED/)
+          end
+
           let(:config) { Config.new(custom_key_filters: [/Authorization/]) }
 
           it 'removes Authorization header' do


### PR DESCRIPTION
Closes #659.

Adds a deprecation warning to the current `custom_key_filters` which has similar functionality.