### PR TITLE
ci(jenkins): wait for the Gem to be available when a release happens

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -232,14 +232,17 @@ pipeline {
           stage('Opbeans') {
             environment {
               REPO_NAME = "${OPBEANS_REPO}"
+              VERSION = "${env.BRANCH_NAME.replaceAll('^v', '')}"
             }
             steps {
               deleteDir()
+              // Let's wait for the Gem to be available
+              sh "(retry 10 curl --silent --show-error --fail -I https://rubygems.org/gems/elastic-apm/versions/${env.VERSION})"
               dir("${OPBEANS_REPO}"){
                 git credentialsId: 'f6c7695a-671e-4f4f-a331-acdce44ff9ba',
                     url: "git@github.com:elastic/${OPBEANS_REPO}.git"
                 // It's required to transform the tag value to the gem version
-                sh script: ".ci/bump-version.sh ${env.BRANCH_NAME.replaceAll('^v', '')}", label: 'Bump version'
+                sh script: ".ci/bump-version.sh ${env.VERSION}", label: 'Bump version'
                 // The opbeans pipeline will trigger a release for the master branch
                 gitPush()
                 // The opbeans pipeline will trigger a release for the release tag


### PR DESCRIPTION
## What does this pull request do?

Wait up to 17 minutes approx once the release happens.

## Why is it important?

The opbeans bump version might take a bit to be available, therefore the version that it's used doesn't match with the version that it was just released.

```
[2020-02-12T11:35:19.793Z] + git diff --name-only '-Selastic-apm (3.5.0)'
[2020-02-12T11:35:19.793Z] + grep Gemfile.lock
[2020-02-12T11:35:19.793Z] + found=0
[2020-02-12T11:35:19.793Z] + '[' 0 -eq 0 ']'
[2020-02-12T11:35:19.793Z] + echo 'ERROR: Agent version was not updated. See the below diff detail output:'
[2020-02-12T11:35:19.793Z] ERROR: Agent version was not updated. See the below diff detail output:
[2020-02-12T11:35:19.793Z] + git diff --unified=0 Gemfile.lock
[2020-02-12T11:35:19.793Z] diff --git a/Gemfile.lock b/Gemfile.lock
[2020-02-12T11:35:19.793Z] index b1cd5fb..3c43450 100644
[2020-02-12T11:35:19.793Z] --- a/Gemfile.lock
[2020-02-12T11:35:19.793Z] +++ b/Gemfile.lock
...
[2020-02-12T11:35:19.793Z] @@ -55 +55 @@ GEM
[2020-02-12T11:35:19.793Z] -    elastic-apm (3.3.0)
[2020-02-12T11:35:19.793Z] +    elastic-apm (3.4.0)

```

See [build](https://apm-ci.elastic.co/blue/organizations/jenkins/apm-agent-ruby%2Fapm-agent-ruby-mbp/detail/v3.5.0/1/pipeline/291#step-304-log-187)


For instance, if the release was not yet available then:

```
(retry 10 curl --silent --show-error --fail -I https://rubygems.org/gems/elastic-apm/versions/3.6.0)
curl: (22) The requested URL returned error: 404 Not Found
Retry 1/10 exited 22, retrying in 1 seconds...
curl: (22) The requested URL returned error: 404 Not Found
Retry 2/10 exited 22, retrying in 2 seconds...
curl: (22) The requested URL returned error: 404 Not Found
Retry 3/10 exited 22, retrying in 4 seconds...
curl: (22) The requested URL returned error: 404 Not Found
Retry 4/10 exited 22, retrying in 8 seconds...
curl: (22) The requested URL returned error: 404 Not Found
Retry 5/10 exited 22, retrying in 16 seconds...
curl: (22) The requested URL returned error: 404 Not Found
Retry 6/10 exited 22, retrying in 32 seconds...
curl: (22) The requested URL returned error: 404 Not Found
Retry 7/10 exited 22, retrying in 64 seconds...
curl: (22) The requested URL returned error: 404 Not Found
Retry 8/10 exited 22, retrying in 128 seconds...

```

Otherwise:

```
(retry 10 curl --silent --show-error --fail -I https://rubygems.org/gems/elastic-apm/versions/3.5.0)
HTTP/1.1 200 OK
Content-Type: text/html; charset=utf-8
X-Frame-Options: SAMEORIGIN
X-XSS-Protection: 1; mode=block
X-Content-Type-Options: nosniff
X-Download-Options: noopen
X-Permitted-Cross-Domain-Policies: none
Referrer-Policy: strict-origin-when-cross-origin
Cache-Control: max-age=0, private, must-revalidate
Content-Security-Policy: default-src 'self'; font-src 'self' https://fonts.gstatic.com; img-src 'self' https://secure.gaug.es https://gravatar.com https://secure.gravatar.com https://*.fastly-insights.com; object-src 'none'; script-src 'self' https://secure.gaug.es https://www.fastly-insights.com; style-src 'self' https://fonts.googleapis.com; connect-src 'self' https://s3-us-west-2.amazonaws.com/rubygems-dumps/ https://*.fastly-insights.com https://api.github.com
Set-Cookie: _rubygems_session=qlzqOMQlM8ARvYPgyXTgBNW4eKWj0rDry540%2FbgThtvmr%2BfJSDj4pyBlCPfLwlKIo9%2Fsmd3QJd0DGAo9is6%2FkdVooiGpZyTQQ3w2dCn9HE2EcZRd2lsGF9JEsCWR9kH5LvbMdd4Zfr12S69z8FM%3D--5frlwE0w9%2BPIfquc--ZRP4BpMHq7whkLAmzPcRZA%3D%3D; path=/; secure; HttpOnly
X-Request-Id: 7e6c2233-cc3f-4a0f-a739-cf072945086a
X-Runtime: 0.041953
Strict-Transport-Security: max-age=120
X-Backend: F_Rails 54.186.104.15:443
Accept-Ranges: bytes
Age: 0
Transfer-Encoding: chunked
Accept-Ranges: bytes
Date: Wed, 12 Feb 2020 12:13:09 GMT
Via: 1.1 varnish
Age: 0
Connection: keep-alive
X-Served-By: cache-lon4276-LON
X-Cache: MISS
X-Cache-Hits: 0
X-Timer: S1581509589.332115,VS0,VE317
Vary: Accept-Encoding,Fastly-SSL
ETag: "51382a511265e58ed61974eef3ee9732"
Server: RubyGems.org
```


## Checklist

- [x] I have signed the [Contributor License Agreement](https://www.elastic.co/contributor-agreement/). 
- [x] My code follows the style guidelines of this project (See `.rubocop.yml`)
- [x] I have rebased my changes on top of the latest master branch

## Related issues