### PR TITLE
adding missing command `install` for gem installation

### DIFF
--- a/docs/getting-started-rails.asciidoc
+++ b/docs/getting-started-rails.asciidoc
@@ -14,7 +14,7 @@ Add the gem to your `Gemfile`:
 
 [source,ruby]
 ----
-gem 'elastic-apm'
+gem install 'elastic-apm'
 ----
 
 Create a file `config/elastic_apm.yml`:


### PR DESCRIPTION
## What does this pull request do?

Fixing `elastic-apm` installation guide to add missing command `install`

<!--
Use this space to describe what the proposed code _does_, ie. what precisely will be done differently from this change.
-->

## Why is it important?

It will be not working when following the guide 

<!--
Optionally provide an explanation of why this is important.
-->
