### PR TITLE
add missing command install

### DIFF
--- a/docs/getting-started-rack.asciidoc
+++ b/docs/getting-started-rack.asciidoc
@@ -11,7 +11,7 @@ Add the gem to your `Gemfile`:
 
 [source,ruby]
 ----
-gem 'elastic-apm'
+gem install 'elastic-apm'
 ----
 
 Create a file `config/elastic_apm.yml`:


### PR DESCRIPTION

## What does this pull request do?

Fixing `elastic-apm` installation guide to add missing command install

## Why is it important?

The user will be not available to install `elastic-apm` with following this guide