### PR TITLE
Adding missing links

### DIFF
--- a/docs/set-up.asciidoc
+++ b/docs/set-up.asciidoc
@@ -9,8 +9,11 @@ endif::[]
 
 To get you off the ground, we’ve prepared guides for setting up the Agent with different frameworks:
 
+ * <<getting-started-rails,Rails>>
+ * <<getting-started-rack,Rack>>
+
+For custom instrumentation, see the <<api>>.
+
 include::./getting-started-rails.asciidoc[]
 
 include::./getting-started-rack.asciidoc[]
-
-For custom instrumentation, see the <<api>>.


### PR DESCRIPTION
## What does this pull request do?

The sub-links and API reference link is not visible. 
Align with the same page on Python Agent doc [here]( https://www.elastic.co/guide/en/apm/agent/python/current/set-up.html).

## Why is it important?

It will make the User find each subpage more easily and provide the same UX with other lang agent reference guide.
