### PR TITLE
[docs] Attribute bug fix

### DIFF
--- a/docs/supported-technologies.asciidoc
+++ b/docs/supported-technologies.asciidoc
@@ -85,4 +85,4 @@ We automatically instrument background processing using:
 - DelayedJob
 - Sidekiq
 - Shoryuken
-- Sneakers (v2.12.0+) (Experimental, see {pull}676[#676])
+- Sneakers (v2.12.0+) (Experimental, see https://github.com/elastic/apm-agent-ruby/pull/676[#676])


### PR DESCRIPTION
Noticed a small bug in the docs. The `{pull}` attribute only works in the release notes, so this was showing up in the supported tech section:
<img width="470" alt="Screen Shot 2020-02-14 at 11 07 19 AM" src="https://user-images.githubusercontent.com/5618806/74560031-907bd500-4f1a-11ea-9e94-8ca7847fa368.png">
