### PR TITLE
[docs] Fix typo

### DIFF
--- a/docs/api.asciidoc
+++ b/docs/api.asciidoc
@@ -425,7 +425,7 @@ end
 
 [float]
 [[api-transaction-sampled_]]
-==== Sampled?
+==== `#sampled?`
 
 Whether the transaction is _sampled_ eg. it includes stacktraces for its spans.
 

--- a/docs/api.asciidoc
+++ b/docs/api.asciidoc
@@ -425,13 +425,13 @@ end
 
 [float]
 [[api-transaction-sampled_]]
-==== #sampled?
+==== Sampled?
 
 Whether the transaction is _sampled_ eg. it includes stacktraces for its spans.
 
 [float]
 [[api-transaction-ensure_parent_id]]
-==== #ensure_parent_id
+==== `ensure_parent_id`
 
 If the transaction does not have a parent-ID yet, calling this method generates
 a new ID, sets it as the parent-ID of this transaction, and returns it as a

--- a/docs/api.asciidoc
+++ b/docs/api.asciidoc
@@ -431,7 +431,7 @@ Whether the transaction is _sampled_ eg. it includes stacktraces for its spans.
 
 [float]
 [[api-transaction-ensure_parent_id]]
-==== `ensure_parent_id`
+==== `#ensure_parent_id`
 
 If the transaction does not have a parent-ID yet, calling this method generates
 a new ID, sets it as the parent-ID of this transaction, and returns it as a


### PR DESCRIPTION
## What does this pull request do?

This fixes a couple typos in `api.asciidoc`.

## Why is it important?

<!--
Optionally provide an explanation of why this is important.
-->

## Checklist
~~- [ ] I have signed the [Contributor License Agreement](https://www.elastic.co/contributor-agreement/).~~
~~- [ ] My code follows the style guidelines of this project (See `.rubocop.yml`)~~
~~- [ ] I have rebased my changes on top of the latest master branch~~
~~- [ ] I have added tests that prove my fix is effective or that my feature works~~
~~- [ ] New and existing [**unit** tests](https://github.com/elastic/apm-agent-ruby/blob/master/CONTRIBUTING.md#testing) pass locally with my changes~~
~~- [ ] I have made corresponding changes to the documentation~~
~~- [ ] I have updated [CHANGELOG.asciidoc](CHANGELOG.asciidoc)~~
~~- [ ] I have updated [supported-technologies.asciidoc](docs/supported-technologies.asciidoc)~~
~~- [ ] Added an API method or config option? Document in which version this will be introduced~~

## Related issues

