### PR TITLE
ci(jenkins): run opbeans validation per PR

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -184,14 +184,12 @@ pipeline {
           }
         }
         steps {
-          log(level: 'INFO', text: 'Launching Async ITs')
           build(job: env.ITS_PIPELINE, propagate: false, wait: false,
                 parameters: [string(name: 'AGENT_INTEGRATION_TEST', value: 'Ruby'),
-                             string(name: 'BUILD_OPTS', value: "--ruby-agent-version ${env.GIT_BASE_COMMIT} --ruby-agent-version-state ${env.GIT_BUILD_CAUSE} --ruby-agent-repo ${env.CHANGE_FORK?.trim() ?: 'elastic'}/${env.REPO}"),
+                             string(name: 'BUILD_OPTS', value: "--ruby-agent-version ${env.GIT_BASE_COMMIT} --ruby-agent-version-state ${env.GIT_BUILD_CAUSE} --ruby-agent-repo ${env.CHANGE_FORK?.trim() ?: 'elastic'}/${env.REPO} --opbeans-ruby-agent-branch ${env.GIT_BASE_COMMIT}"),
                              string(name: 'GITHUB_CHECK_NAME', value: env.GITHUB_CHECK_ITS_NAME),
                              string(name: 'GITHUB_CHECK_REPO', value: env.REPO),
-                             string(name: 'GITHUB_CHECK_SHA1', value: env.GIT_BASE_COMMIT)]
-          )
+                             string(name: 'GITHUB_CHECK_SHA1', value: env.GIT_BASE_COMMIT)])
           githubNotify(context: "${env.GITHUB_CHECK_ITS_NAME}", description: "${env.GITHUB_CHECK_ITS_NAME} ...", status: 'PENDING', targetUrl: "${env.JENKINS_URL}search/?q=${env.ITS_PIPELINE.replaceAll('/','+')}")
         }
       }

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -26,7 +26,7 @@ pipeline {
     DOCKER_REGISTRY = 'docker.elastic.co'
     DOCKER_SECRET = 'secret/apm-team/ci/docker-registry/prod'
     GITHUB_CHECK_ITS_NAME = 'Integration Tests'
-    ITS_PIPELINE = 'apm-integration-tests-selector-mbp/master'
+    ITS_PIPELINE = 'apm-integration-tests-selector-mbp/PR-763'
     RELEASE_SECRET = 'secret/apm-team/ci/apm-agent-ruby-rubygems-release'
     OPBEANS_REPO = 'opbeans-ruby'
     REFERENCE_REPO = '/var/lib/jenkins/.git-references/apm-agent-ruby.git'

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -26,7 +26,7 @@ pipeline {
     DOCKER_REGISTRY = 'docker.elastic.co'
     DOCKER_SECRET = 'secret/apm-team/ci/docker-registry/prod'
     GITHUB_CHECK_ITS_NAME = 'Integration Tests'
-    ITS_PIPELINE = 'apm-integration-tests-selector-mbp/PR-763'
+    ITS_PIPELINE = 'apm-integration-tests-selector-mbp/master'
     RELEASE_SECRET = 'secret/apm-team/ci/apm-agent-ruby-rubygems-release'
     OPBEANS_REPO = 'opbeans-ruby'
     REFERENCE_REPO = '/var/lib/jenkins/.git-references/apm-agent-ruby.git'


### PR DESCRIPTION
### What does this PR do?

Pass the build flag to the apm-integration-testing validation.

Depends on https://github.com/elastic/apm-integration-testing/pull/763

### Screenshots

This pipeline will trigger another downstream job that will evaluate the `apm-integration-testing` for the given agent version and also the opbeans app.

The look and feel can be seen below:

![image](https://user-images.githubusercontent.com/2871786/74846732-e7bde300-5328-11ea-827a-87d9e990d382.png)
