### PR TITLE
Move framework specific requires to spies

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -59,7 +59,7 @@ end
 frameworks_versions.each do |framework, version|
   case version
   when 'master'
-    gem framework, github: GITHUB_REPOS.fetch[framework]
+    gem framework, github: GITHUB_REPOS.fetch(framework)
   when /.+/
     gem framework, "~> #{version}.0"
   else

--- a/lib/elastic_apm/spies/grape.rb
+++ b/lib/elastic_apm/spies/grape.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module ElasticAPM
+  # @api private
+  module Spies
+    # @api private
+    class GrapeSpy
+      def install
+        require 'elastic_apm/grape'
+      end
+    end
+
+    register 'Grape', 'grape', GrapeSpy.new
+  end
+end

--- a/lib/elastic_apm/spies/sinatra.rb
+++ b/lib/elastic_apm/spies/sinatra.rb
@@ -6,6 +6,8 @@ module ElasticAPM
     # @api private
     class SinatraSpy
       def install
+        require 'elastic_apm/sinatra'
+
         ::Sinatra::Base.class_eval do
           alias dispatch_without_apm! dispatch!
           alias compile_template_without_apm compile_template

--- a/spec/entrypoint.sh
+++ b/spec/entrypoint.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -x
 
-bundle check || (rm Gemfile.lock && bundle)
+bundle check || (rm -f Gemfile.lock && bundle)
 
 # If first arg is a spec path, run spec(s)
 if [[ $1 == spec/* ]]; then


### PR DESCRIPTION
Our current solution depends on the `elastic-apm` gem to be loaded _after_ Grape or Sinatra.

This PR uses the already present mechanism of hooking into require to make sure to load regardless of gem order.