### PR TITLE
Destination address port

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -43,6 +43,7 @@ endif::[]
 ===== Added
 
 - Support for gRPC using the `grpc` gem (Experimental) {pull}669[#669]
+- Add `span.context.destination.address` and `span.context.destination.port` when available. {pull}722[#722]
 
 [[release-notes-3.5.0]]
 ==== 3.5.0 (2020-02-12)

--- a/lib/elastic_apm/grpc.rb
+++ b/lib/elastic_apm/grpc.rb
@@ -18,10 +18,13 @@ module ElasticAPM
         peer = call.instance_variable_get(:@wrapped)&.peer
         context =
           if peer
+            split_peer = URI.split(peer)
             destination = ElasticAPM::Span::Context::Destination.new(
               type: TYPE,
               name: SUBTYPE,
-              resource: peer
+              resource: peer,
+              address: split_peer[0],
+              port: split_peer[6]
             )
             ElasticAPM::Span::Context.new(destination: destination)
           end

--- a/lib/elastic_apm/grpc.rb
+++ b/lib/elastic_apm/grpc.rb
@@ -15,29 +15,32 @@ module ElasticAPM
           trace_context.apply_headers { |k, v| metadata[k.downcase] = v }
         end
 
-        peer = call.instance_variable_get(:@wrapped)&.peer
-        context =
-          if peer
-            split_peer = URI.split(peer)
-            destination = ElasticAPM::Span::Context::Destination.new(
-              type: TYPE,
-              name: SUBTYPE,
-              resource: peer,
-              address: split_peer[0],
-              port: split_peer[6]
-            )
-            ElasticAPM::Span::Context.new(destination: destination)
-          end
-
         ElasticAPM.with_span(
           method, TYPE,
           subtype: SUBTYPE,
-          context: context
+          context: span_context(call)
         ) do
           yield
         end
       end
       # rubocop:enable Lint/UnusedMethodArgument
+
+      private
+
+      def span_context(call)
+        peer = call.instance_variable_get(:@wrapped)&.peer
+        return unless peer
+
+        split_peer = URI.split(peer)
+        destination = ElasticAPM::Span::Context::Destination.new(
+          type: TYPE,
+          name: SUBTYPE,
+          resource: peer,
+          address: split_peer[0],
+          port: split_peer[6]
+        )
+        ElasticAPM::Span::Context.new(destination: destination)
+      end
     end
 
     # @api private

--- a/lib/elastic_apm/span/context/destination.rb
+++ b/lib/elastic_apm/span/context/destination.rb
@@ -5,21 +5,37 @@ module ElasticAPM
     class Context
       # @api private
       class Destination
-        def initialize(name: nil, resource: nil, type: nil)
+        def initialize(
+          name: nil,
+          resource: nil,
+          type: nil,
+          address: nil,
+          port: nil
+        )
           @name = name
           @resource = resource
           @type = type
+          @address = address
+          @port = port
         end
 
-        attr_reader :name, :resource, :type
+        attr_reader(
+          :name,
+          :resource,
+          :type,
+          :address,
+          :port
+        )
 
-        def self.from_uri(uri_or_str, type: 'external')
+        def self.from_uri(uri_or_str, type: 'external', port: nil)
           uri = normalize(uri_or_str)
 
           new(
             name: only_scheme_and_host(uri),
             resource: "#{uri.host}:#{uri.port}",
-            type: type
+            type: type,
+            address: uri.hostname,
+            port: port || uri.port
           )
         end
 

--- a/lib/elastic_apm/transport/serializers/span_serializer.rb
+++ b/lib/elastic_apm/transport/serializers/span_serializer.rb
@@ -78,7 +78,10 @@ module ElasticAPM
                 resource: keyword_field(destination.resource),
                 type: keyword_field(destination.type)
               }
-            }
+            }.tap do |dest|
+              dest[:address] = keyword_field(destination.address)
+              dest[:port] = keyword_field(destination.port.to_s)
+            end
           end
         end
 

--- a/lib/elastic_apm/transport/serializers/span_serializer.rb
+++ b/lib/elastic_apm/transport/serializers/span_serializer.rb
@@ -80,7 +80,7 @@ module ElasticAPM
               }
             }.tap do |dest|
               dest[:address] = keyword_field(destination.address)
-              dest[:port] = keyword_field(destination.port.to_s)
+              dest[:port] = destination.port
             end
           end
         end

--- a/lib/elastic_apm/transport/serializers/span_serializer.rb
+++ b/lib/elastic_apm/transport/serializers/span_serializer.rb
@@ -77,11 +77,10 @@ module ElasticAPM
                 name: keyword_field(destination.name),
                 resource: keyword_field(destination.resource),
                 type: keyword_field(destination.type)
-              }
-            }.tap do |dest|
-              dest[:address] = keyword_field(destination.address)
-              dest[:port] = destination.port
-            end
+              },
+              address: keyword_field(destination.address),
+              port: destination.port
+            }
           end
         end
 

--- a/spec/elastic_apm/grpc_spec.rb
+++ b/spec/elastic_apm/grpc_spec.rb
@@ -46,6 +46,8 @@ if !defined?(JRUBY_VERSION) && RUBY_VERSION < '2.7'
           expect(span.context.destination.type).to eq('external')
           expect(span.context.destination.name).to eq('grpc')
           expect(span.context.destination.resource).to eq('localhost:50051')
+          expect(span.context.destination.address).to eq('localhost')
+          expect(span.context.destination.port).to eq('50051')
 
           server.stop
           thread.kill

--- a/spec/elastic_apm/grpc_spec.rb
+++ b/spec/elastic_apm/grpc_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 if !defined?(JRUBY_VERSION) && RUBY_VERSION < '2.7'
-require 'grpc'
+  require 'grpc'
   module ElasticAPM
     RSpec.describe GRPC, :intercept do
       class GreeterServer < Helloworld::Greeter::Service
@@ -43,6 +43,9 @@ require 'grpc'
           expect(span.name).to eq('/helloworld.Greeter/SayHello')
           expect(span.type).to eq('external')
           expect(span.subtype).to eq('grpc')
+          expect(span.context.destination.type).to eq('external')
+          expect(span.context.destination.name).to eq('grpc')
+          expect(span.context.destination.resource).to eq('localhost:50051')
 
           server.stop
           thread.kill

--- a/spec/elastic_apm/grpc_spec.rb
+++ b/spec/elastic_apm/grpc_spec.rb
@@ -2,6 +2,7 @@
 
 if !defined?(JRUBY_VERSION) && RUBY_VERSION < '2.7'
   require 'grpc'
+  
   module ElasticAPM
     RSpec.describe GRPC, :intercept do
       class GreeterServer < Helloworld::Greeter::Service

--- a/spec/elastic_apm/span/context/destination_spec.rb
+++ b/spec/elastic_apm/span/context/destination_spec.rb
@@ -12,17 +12,23 @@ module ElasticAPM
           its(:name) { is_expected.to eq 'http://example.com' }
           its(:resource) { is_expected.to eq 'example.com:80' }
           its(:type) { is_expected.to eq 'external' }
+          its(:address) { is_expected.to eq 'example.com' }
+          its(:port) { is_expected.to eq 80 }
 
           context 'https' do
             let(:uri) { URI('https://example.com/path?a=1') }
             its(:name) { is_expected.to eq 'https://example.com' }
             its(:resource) { is_expected.to eq 'example.com:443' }
+            its(:address) { is_expected.to eq 'example.com' }
+            its(:port) { is_expected.to eq 443 }
           end
 
           context 'non-default port' do
             let(:uri) { URI('http://example.com:8080/path?a=1') }
             its(:name) { is_expected.to eq 'http://example.com:8080' }
             its(:resource) { is_expected.to eq 'example.com:8080' }
+            its(:address) { is_expected.to eq 'example.com' }
+            its(:port) { is_expected.to eq 8080 }
           end
 
           context 'when given a string' do
@@ -31,6 +37,18 @@ module ElasticAPM
             its(:name) { is_expected.to eq 'http://example.com' }
             its(:resource) { is_expected.to eq 'example.com:80' }
             its(:type) { is_expected.to eq 'external' }
+            its(:address) { is_expected.to eq 'example.com' }
+            its(:port) { is_expected.to eq 80 }
+          end
+
+          context 'IPv6' do
+            let(:uri) { 'http://[::1]:8080/' }
+
+            its(:name) { is_expected.to eq 'http://[::1]:8080' }
+            its(:resource) { is_expected.to eq '[::1]:8080' }
+            its(:type) { is_expected.to eq 'external' }
+            its(:address) { is_expected.to eq '::1' }
+            its(:port) { is_expected.to eq 8080 }
           end
         end
       end

--- a/spec/elastic_apm/spies/faraday_spec.rb
+++ b/spec/elastic_apm/spies/faraday_spec.rb
@@ -60,6 +60,8 @@ module ElasticAPM
       expect(destination.name).to match('http://example.com')
       expect(destination.resource).to match('example.com:80')
       expect(destination.type).to match('external')
+      expect(destination.address).to match('example.com')
+      expect(destination.port).to match(80)
     end
 
     it 'spans http calls with prefix' do

--- a/spec/elastic_apm/spies/http_spec.rb
+++ b/spec/elastic_apm/spies/http_spec.rb
@@ -53,6 +53,8 @@ module ElasticAPM
       expect(destination.name).to match('http://example.com')
       expect(destination.resource).to match('example.com:80')
       expect(destination.type).to match('external')
+      expect(destination.address).to match('example.com')
+      expect(destination.port).to match(80)
     end
 
     it 'adds destination information with IPv6' do

--- a/spec/elastic_apm/spies/net_http_spec.rb
+++ b/spec/elastic_apm/spies/net_http_spec.rb
@@ -158,6 +158,26 @@ module ElasticAPM
         expect(span.context.destination.resource).to eq 'example.com:1234'
         expect(span.context.destination.type).to eq 'external'
       end
+
+      it 'adds IPv6 info to span context' do
+        WebMock.stub_request(:get, %r{http://\[::1\]:8080/.*})
+
+        with_agent(central_config: false) do
+          ElasticAPM.with_transaction 'Net::HTTP test IPv6' do
+            Net::HTTP.start('[::1]', 8080) do |http|
+              http.get '/some/path?a=1'
+            end
+          end
+        end
+
+        span, = @intercepted.spans
+
+        expect(span.context.destination.name).to eq 'http://[::1]:8080'
+        expect(span.context.destination.resource).to eq '[::1]:8080'
+        expect(span.context.destination.type).to eq 'external'
+        expect(span.context.destination.address).to eq '::1'
+        expect(span.context.destination.port).to eq 8080
+      end
     end
 
     it 'handles IPv6 addresses' do

--- a/spec/elastic_apm/spies/net_http_spec.rb
+++ b/spec/elastic_apm/spies/net_http_spec.rb
@@ -157,6 +157,8 @@ module ElasticAPM
         expect(span.context.destination.name).to eq 'http://example.com:1234'
         expect(span.context.destination.resource).to eq 'example.com:1234'
         expect(span.context.destination.type).to eq 'external'
+        expect(span.context.destination.address).to eq 'example.com'
+        expect(span.context.destination.port).to eq 1234
       end
 
       it 'adds IPv6 info to span context' do

--- a/spec/elastic_apm/transport/serializers/span_serializer_spec.rb
+++ b/spec/elastic_apm/transport/serializers/span_serializer_spec.rb
@@ -143,7 +143,7 @@ module ElasticAPM
                     type: 'c'
                   },
                   address: 'd',
-                  port: '8080'
+                  port: 8080
                 }
               )
             end

--- a/spec/elastic_apm/transport/serializers/span_serializer_spec.rb
+++ b/spec/elastic_apm/transport/serializers/span_serializer_spec.rb
@@ -123,15 +123,23 @@ module ElasticAPM
                 parent: transaction,
                 trace_context: trace_context,
                 context: Span::Context.new(
-                  destination: { name: 'a', resource: 'b', type: 'c' }
+                  destination: {
+                    name: 'a',
+                    resource: 'b',
+                    type: 'c',
+                    address: 'd',
+                    port: 8080
+                  }
                 )
               )
 
               result = subject.build(span)
 
-              expect(result.dig(:span, :context, :destination)).to match(
-                service: { name: 'a', resource: 'b', type: 'c' }
-              )
+              expect(result.dig(:span, :context, :destination)).to match({
+                service: { name: 'a', resource: 'b', type: 'c' },
+                address: 'd',
+                port: '8080'
+              })
             end
           end
 

--- a/spec/elastic_apm/transport/serializers/span_serializer_spec.rb
+++ b/spec/elastic_apm/transport/serializers/span_serializer_spec.rb
@@ -135,11 +135,17 @@ module ElasticAPM
 
               result = subject.build(span)
 
-              expect(result.dig(:span, :context, :destination)).to match({
-                service: { name: 'a', resource: 'b', type: 'c' },
-                address: 'd',
-                port: '8080'
-              })
+              expect(result.dig(:span, :context, :destination)).to match(
+                {
+                  service: {
+                    name: 'a',
+                    resource: 'b',
+                    type: 'c'
+                  },
+                  address: 'd',
+                  port: '8080'
+                }
+              )
             end
           end
 


### PR DESCRIPTION
This PR adds `span.context.destination.address` and `span.context.destination.port` when they are available. The spies for which it was possible to get this info were:
- `Faraday`
- `NetHTTP`
- `HTTP`

The following don't expose this info in the spied-on method:
- `Mongo`
- `Sequel`
- `ActiveRecord`
- `Elasticsearch`

I've also updated the `SpanSerializer` to add these new fields.

**Note there is no test for IPv6 for Faraday because the `get` method fails when an IPv6 uri is provided. See [this](https://github.com/lostisland/faraday/issues/589) issue.

Closes #720 