### PR TITLE
JRuby docker images

### DIFF
--- a/.ci/docker/jruby/11-jdk/Dockerfile
+++ b/.ci/docker/jruby/11-jdk/Dockerfile
@@ -1,0 +1,40 @@
+FROM openjdk:11-jdk
+
+RUN apt-get update \
+    && apt-get install -y libc6-dev --no-install-recommends \
+    && rm -rf /var/lib/apt/lists/*
+
+ENV JRUBY_VERSION 9.2.10.0
+ENV JRUBY_SHA256 9199707712c683c525252ccb1de5cb8e75f53b790c5b57a18f6367039ec79553
+
+RUN mkdir -p /opt/jruby \
+    && curl -fSL https://repo1.maven.org/maven2/org/jruby/jruby-dist/${JRUBY_VERSION}/jruby-dist-${JRUBY_VERSION}-bin.tar.gz -o /tmp/jruby.tar.gz \
+    && echo "$JRUBY_SHA256 */tmp/jruby.tar.gz" | sha256sum -c - \
+    && tar -zx --strip-components=1 -f /tmp/jruby.tar.gz -C /opt/jruby \
+    && update-alternatives --install /usr/local/bin/ruby ruby /opt/jruby/bin/jruby 1
+
+# set the jruby binaries in the path
+ENV PATH /opt/jruby/bin:$PATH
+
+# skip installing gem documentation
+RUN mkdir -p /opt/jruby/etc \
+    && { \
+        echo 'install: --no-document'; \
+        echo 'update: --no-document'; \
+    } >> /opt/jruby/etc/gemrc
+
+# install bundler, gem requires bash to work
+RUN gem install bundler rake net-telnet xmlrpc tzinfo-data
+
+# install things globally, for great justice
+# and don't create ".bundle" in all our apps
+ENV GEM_HOME /usr/local/bundle
+ENV BUNDLE_PATH="$GEM_HOME" \
+    BUNDLE_BIN="$GEM_HOME/bin" \
+    BUNDLE_SILENCE_ROOT_WARNING=1 \
+    BUNDLE_APP_CONFIG="$GEM_HOME"
+ENV PATH $BUNDLE_BIN:$PATH
+RUN mkdir -p "$GEM_HOME" "$BUNDLE_BIN" \
+    && chmod 777 "$GEM_HOME" "$BUNDLE_BIN"
+
+CMD [ "irb" ]

--- a/.ci/docker/jruby/12-jdk/Dockerfile
+++ b/.ci/docker/jruby/12-jdk/Dockerfile
@@ -1,0 +1,40 @@
+FROM adoptopenjdk:12-jdk-openj9
+
+RUN apt-get update \
+    && apt-get install -y libc6-dev git tcc netbase --no-install-recommends \
+    && rm -rf /var/lib/apt/lists/*
+
+ENV JRUBY_VERSION 9.2.10.0
+ENV JRUBY_SHA256 9199707712c683c525252ccb1de5cb8e75f53b790c5b57a18f6367039ec79553
+
+RUN mkdir -p /opt/jruby \
+    && curl -fSL https://repo1.maven.org/maven2/org/jruby/jruby-dist/${JRUBY_VERSION}/jruby-dist-${JRUBY_VERSION}-bin.tar.gz -o /tmp/jruby.tar.gz \
+    && echo "$JRUBY_SHA256 */tmp/jruby.tar.gz" | sha256sum -c - \
+    && tar -zx --strip-components=1 -f /tmp/jruby.tar.gz -C /opt/jruby \
+    && update-alternatives --install /usr/local/bin/ruby ruby /opt/jruby/bin/jruby 1
+
+# set the jruby binaries in the path
+ENV PATH /opt/jruby/bin:$PATH
+
+# skip installing gem documentation
+RUN mkdir -p /opt/jruby/etc \
+    && { \
+        echo 'install: --no-document'; \
+        echo 'update: --no-document'; \
+    } >> /opt/jruby/etc/gemrc
+
+# install bundler, gem requires bash to work
+RUN gem install bundler rake net-telnet xmlrpc tzinfo-data
+
+# install things globally, for great justice
+# and don't create ".bundle" in all our apps
+ENV GEM_HOME /usr/local/bundle
+ENV BUNDLE_PATH="$GEM_HOME" \
+    BUNDLE_BIN="$GEM_HOME/bin" \
+    BUNDLE_SILENCE_ROOT_WARNING=1 \
+    BUNDLE_APP_CONFIG="$GEM_HOME"
+ENV PATH $BUNDLE_BIN:$PATH
+RUN mkdir -p "$GEM_HOME" "$BUNDLE_BIN" \
+    && chmod 777 "$GEM_HOME" "$BUNDLE_BIN"
+
+CMD [ "irb" ]

--- a/.ci/docker/jruby/13-jdk/Dockerfile
+++ b/.ci/docker/jruby/13-jdk/Dockerfile
@@ -1,0 +1,40 @@
+FROM openjdk:13-jdk-slim
+
+RUN apt-get update \
+    && apt-get install -y libc6-dev git tcc curl netbase --no-install-recommends \
+    && rm -rf /var/lib/apt/lists/*
+
+ENV JRUBY_VERSION 9.2.10.0
+ENV JRUBY_SHA256 9199707712c683c525252ccb1de5cb8e75f53b790c5b57a18f6367039ec79553
+
+RUN mkdir -p /opt/jruby \
+    && curl -fSL https://repo1.maven.org/maven2/org/jruby/jruby-dist/${JRUBY_VERSION}/jruby-dist-${JRUBY_VERSION}-bin.tar.gz -o /tmp/jruby.tar.gz \
+    && echo "$JRUBY_SHA256 */tmp/jruby.tar.gz" | sha256sum -c - \
+    && tar -zx --strip-components=1 -f /tmp/jruby.tar.gz -C /opt/jruby \
+    && update-alternatives --install /usr/local/bin/ruby ruby /opt/jruby/bin/jruby 1
+
+# set the jruby binaries in the path
+ENV PATH /opt/jruby/bin:$PATH
+
+# skip installing gem documentation
+RUN mkdir -p /opt/jruby/etc \
+    && { \
+        echo 'install: --no-document'; \
+        echo 'update: --no-document'; \
+    } >> /opt/jruby/etc/gemrc
+
+# install bundler, gem requires bash to work
+RUN gem install bundler rake net-telnet xmlrpc tzinfo-data
+
+# install things globally, for great justice
+# and don't create ".bundle" in all our apps
+ENV GEM_HOME /usr/local/bundle
+ENV BUNDLE_PATH="$GEM_HOME" \
+    BUNDLE_BIN="$GEM_HOME/bin" \
+    BUNDLE_SILENCE_ROOT_WARNING=1 \
+    BUNDLE_APP_CONFIG="$GEM_HOME"
+ENV PATH $BUNDLE_BIN:$PATH
+RUN mkdir -p "$GEM_HOME" "$BUNDLE_BIN" \
+    && chmod 777 "$GEM_HOME" "$BUNDLE_BIN"
+
+CMD [ "irb" ]

--- a/.ci/docker/jruby/7-jdk/Dockerfile
+++ b/.ci/docker/jruby/7-jdk/Dockerfile
@@ -1,0 +1,40 @@
+FROM openjdk:7-jdk
+
+RUN apt-get update \
+    && apt-get install -y libc6-dev --no-install-recommends \
+    && rm -rf /var/lib/apt/lists/*
+
+ENV JRUBY_VERSION 9.1.17.0
+ENV JRUBY_SHA256 6a22f7bf8fef1a52530a9c9781a9d374ad07bbbef0d3d8e2af0ff5cbead0dfd5
+
+RUN mkdir -p /opt/jruby \
+    && curl -fSL https://repo1.maven.org/maven2/org/jruby/jruby-dist/${JRUBY_VERSION}/jruby-dist-${JRUBY_VERSION}-bin.tar.gz -o /tmp/jruby.tar.gz \
+    && echo "$JRUBY_SHA256 */tmp/jruby.tar.gz" | sha256sum -c - \
+    && tar -zx --strip-components=1 -f /tmp/jruby.tar.gz -C /opt/jruby \
+    && update-alternatives --install /usr/local/bin/ruby ruby /opt/jruby/bin/jruby 1
+
+# set the jruby binaries in the path
+ENV PATH /opt/jruby/bin:$PATH
+
+# skip installing gem documentation
+RUN mkdir -p /opt/jruby/etc \
+    && { \
+        echo 'install: --no-document'; \
+        echo 'update: --no-document'; \
+    } >> /opt/jruby/etc/gemrc
+
+# install bundler, gem requires bash to work
+RUN gem install bundler rake net-telnet xmlrpc tzinfo-data
+
+# install things globally, for great justice
+# and don't create ".bundle" in all our apps
+ENV GEM_HOME /usr/local/bundle
+ENV BUNDLE_PATH="$GEM_HOME" \
+    BUNDLE_BIN="$GEM_HOME/bin" \
+    BUNDLE_SILENCE_ROOT_WARNING=1 \
+    BUNDLE_APP_CONFIG="$GEM_HOME"
+ENV PATH $BUNDLE_BIN:$PATH
+RUN mkdir -p "$GEM_HOME" "$BUNDLE_BIN" \
+    && chmod 777 "$GEM_HOME" "$BUNDLE_BIN"
+
+CMD [ "irb" ]

--- a/.ci/docker/jruby/8-jdk/Dockerfile
+++ b/.ci/docker/jruby/8-jdk/Dockerfile
@@ -1,0 +1,40 @@
+FROM openjdk:8-jdk
+
+RUN apt-get update \
+    && apt-get install -y libc6-dev --no-install-recommends \
+    && rm -rf /var/lib/apt/lists/*
+
+ENV JRUBY_VERSION 9.2.10.0
+ENV JRUBY_SHA256 9199707712c683c525252ccb1de5cb8e75f53b790c5b57a18f6367039ec79553
+
+RUN mkdir -p /opt/jruby \
+    && curl -fSL https://repo1.maven.org/maven2/org/jruby/jruby-dist/${JRUBY_VERSION}/jruby-dist-${JRUBY_VERSION}-bin.tar.gz -o /tmp/jruby.tar.gz \
+    && echo "$JRUBY_SHA256 */tmp/jruby.tar.gz" | sha256sum -c - \
+    && tar -zx --strip-components=1 -f /tmp/jruby.tar.gz -C /opt/jruby \
+    && update-alternatives --install /usr/local/bin/ruby ruby /opt/jruby/bin/jruby 1
+
+# set the jruby binaries in the path
+ENV PATH /opt/jruby/bin:$PATH
+
+# skip installing gem documentation
+RUN mkdir -p /opt/jruby/etc \
+    && { \
+        echo 'install: --no-document'; \
+        echo 'update: --no-document'; \
+    } >> /opt/jruby/etc/gemrc
+
+# install bundler, gem requires bash to work
+RUN gem install bundler rake net-telnet xmlrpc tzinfo-data
+
+# install things globally, for great justice
+# and don't create ".bundle" in all our apps
+ENV GEM_HOME /usr/local/bundle
+ENV BUNDLE_PATH="$GEM_HOME" \
+    BUNDLE_BIN="$GEM_HOME/bin" \
+    BUNDLE_SILENCE_ROOT_WARNING=1 \
+    BUNDLE_APP_CONFIG="$GEM_HOME"
+ENV PATH $BUNDLE_BIN:$PATH
+RUN mkdir -p "$GEM_HOME" "$BUNDLE_BIN" \
+    && chmod 777 "$GEM_HOME" "$BUNDLE_BIN"
+
+CMD [ "irb" ]

--- a/.ci/docker/jruby/README.md
+++ b/.ci/docker/jruby/README.md
@@ -1,0 +1,31 @@
+# JRuby docker images
+
+Builds jruby docker images.
+
+## Build
+
+To build the images run
+
+```bash
+  ./run.sh --action build
+```
+
+You can set your own docker registry with the flag `--registry x.y.z/org`
+
+You can exclude what images can be built with the flag `--exclude jdk-7`
+
+## Test
+
+To test the images run
+
+```bash
+  ./run.sh --action test
+```
+
+## Push
+
+To push the images run
+
+```bash
+  ./run.sh --action push
+```

--- a/.ci/docker/jruby/run.sh
+++ b/.ci/docker/jruby/run.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+
+while (( "$#" )); do
+  case "$1" in
+    -r|--registry)
+      REGISTRY=$2
+      shift 2
+      ;;
+    -e|--exclude)
+      EXCLUDE=$2
+      shift 2
+      ;;
+    -a|--action)
+      ACTION=$2
+      shift 2
+      ;;
+    --) # end argument parsing
+      shift
+      break
+      ;;
+    -*|--*=) # unsupported flags
+      echo "Error: Unsupported flag $1" >&2
+      exit 1
+      ;;
+    *) # preserve positional arguments
+      shift
+      ;;
+  esac
+done
+
+
+if [ -n "$EXCLUDE" ] ; then
+  search=$(find . -path ./$EXCLUDE -prune -o -name 'Dockerfile' -print)
+else
+  search=$(find . -name 'Dockerfile' -print)
+fi
+
+function report {
+  if [ $1 -eq 0 ] ; then
+    printf '\tImage %-60s %-10s\n' "${2}" "GENERATED"
+  else
+    printf '\tImage %-60s %-10s\n' "${2}" "FAILED"
+  fi
+}
+
+echo "${ACTION} docker images"
+for i in ${search}; do
+  jdk_image=$(basename `dirname "$i"`)
+  jdk_version=$(echo "$jdk_image" | cut -d'-' -f1)
+  jruby=$(grep "JRUBY_VERSION" $i | cut -d" " -f 3)
+  if [ "${jdk_image}" == "onbuild" ] ; then
+    short=$(grep "FROM" "$i" | cut -d":" -f 2 | cut -d'-' -f1)
+    jdk_version=
+  else
+    short=$(echo "$jruby" | cut -d'.' -f1-2)
+  fi
+
+  if [ -n "${REGISTRY}" ] ; then
+    name="${REGISTRY}/jruby:${short}-${jdk_image}"
+  else
+    name="jruby:${short}-${jdk_image}"
+  fi
+
+  if [ "${ACTION}" == "build" ] ; then
+    docker build --tag "${name}" -< $i >> output.log 2>&1
+    report $? "${name}"
+  elif [ "${ACTION}" == "push" ] ; then
+    docker push "${name}" >> output.log 2>&1
+    report $? "${name}"
+  else
+    ./test.sh "${name}" $jdk_version
+  fi
+done

--- a/.ci/docker/jruby/test.sh
+++ b/.ci/docker/jruby/test.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+image=${1?image is required}
+version=${2}
+
+printf '\tTest %-30s %s\n' ${image}
+
+if [ -n "$version" ] ; then
+  test_name="Test java -version '$version'"
+  docker run -t --rm $image java -version | grep -q "openjdk version \"$version\|1.$version" && printf '\t\t%-40s %s\n' "${test_name}" "PASSED" || printf '\t\t%-40s %s\n' "${test_name}" "FAILED"
+fi
+
+test_name="Test Hello World"
+docker run -t --rm $image jruby -e "puts 'Hello World" | grep -q 'Hello World' && printf '\t\t%-40s %s\n' "${test_name}" "PASSED" || printf '\t\t%-40s %s\n' "${test_name}" "FAILED"

--- a/.gitignore
+++ b/.gitignore
@@ -22,4 +22,6 @@ vendor/
 log/
 
 benchmark-*.error
-benchmark-*.raw.ci/docker/jruby/output.log
+benchmark-*.raw
+
+.ci/docker/jruby/output.log

--- a/.gitignore
+++ b/.gitignore
@@ -22,4 +22,4 @@ vendor/
 log/
 
 benchmark-*.error
-benchmark-*.raw
+benchmark-*.raw.ci/docker/jruby/output.log


### PR DESCRIPTION
## What does this pull request do?

Move the docker image definition for the JRuby ones within this repo rather than in https://github.com/elastic/docker-jruby.

Bump JRUBY_VERSION 9.2.10.0

## Why is it important?

One single point of source

## Checklist

- [x] I have signed the [Contributor License Agreement](https://www.elastic.co/contributor-agreement/). 
- [x] My code follows the style guidelines of this project (See `.rubocop.yml`)
- [x] I have rebased my changes on top of the latest master branch
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have made corresponding changes to the documentation

## Related issues

Closes #609

## How to test this

```
$ export TAG_CACHE=docker.elastic.co/observability-ci

$ ./run.sh --action build --registry ${TAG_CACHE}
build docker images
	Image docker.elastic.co/observability-ci/jruby:9.1-7-jdk           GENERATED 
	Image docker.elastic.co/observability-ci/jruby:9.2-11-jdk          GENERATED 
	Image docker.elastic.co/observability-ci/jruby:9.2-12-jdk          GENERATED 
	Image docker.elastic.co/observability-ci/jruby:9.2-13-jdk          GENERATED 
	Image docker.elastic.co/observability-ci/jruby:9.2-8-jdk           GENERATED 

$ ./run.sh --action test --registry ${TAG_CACHE}
test docker images
	Test docker.elastic.co/observability-ci/jruby:9.1-7-jdk 
		Test java -version '7'                   PASSED
		Test Hello World                         PASSED
	Test docker.elastic.co/observability-ci/jruby:9.2-11-jdk 
		Test java -version '11'                  PASSED
		Test Hello World                         PASSED
	Test docker.elastic.co/observability-ci/jruby:9.2-12-jdk 
		Test java -version '12'                  PASSED
		Test Hello World                         PASSED
	Test docker.elastic.co/observability-ci/jruby:9.2-13-jdk 
		Test java -version '13'                  PASSED
		Test Hello World                         PASSED
	Test docker.elastic.co/observability-ci/jruby:9.2-8-jdk 
		Test java -version '8'                   PASSED
		Test Hello World                         PASSED

$ ./run.sh --action push --registry ${TAG_CACHE}
push docker images
	Image docker.elastic.co/observability-ci/jruby:9.1-7-jdk           GENERATED 
	Image docker.elastic.co/observability-ci/jruby:9.2-11-jdk          GENERATED 
	Image docker.elastic.co/observability-ci/jruby:9.2-12-jdk          GENERATED 
	Image docker.elastic.co/observability-ci/jruby:9.2-13-jdk          GENERATED 
	Image docker.elastic.co/observability-ci/jruby:9.2-8-jdk           GENERATED 

```
