### PR TITLE
Handle case when Bundler is defined but there's no Gemfile

### DIFF
--- a/lib/elastic_apm/stacktrace_builder.rb
+++ b/lib/elastic_apm/stacktrace_builder.rb
@@ -12,8 +12,12 @@ module ElasticAPM
     RUBY_VERS_REGEX = %r{ruby(/gems)?[-/](\d+\.)+\d}.freeze
     JRUBY_ORG_REGEX = %r{org/jruby}.freeze
 
-    GEMS_PATH = (defined?(Bundler) && Bundler.default_bundle_dir) ?
-                  Bundler.bundle_path.to_s : Gem.dir
+    GEMS_PATH =
+      if defined?(Bundler) && Bundler.default_bundle_dir
+        Bundler.bundle_path.to_s
+      else
+        Gem.dir
+      end
 
     def initialize(config)
       @config = config

--- a/lib/elastic_apm/stacktrace_builder.rb
+++ b/lib/elastic_apm/stacktrace_builder.rb
@@ -12,7 +12,8 @@ module ElasticAPM
     RUBY_VERS_REGEX = %r{ruby(/gems)?[-/](\d+\.)+\d}.freeze
     JRUBY_ORG_REGEX = %r{org/jruby}.freeze
 
-    GEMS_PATH = defined?(Bundler) ? Bundler.bundle_path.to_s : Gem.dir
+    GEMS_PATH = (defined?(Bundler) && Bundler.default_bundle_dir) ?
+                  Bundler.bundle_path.to_s : Gem.dir
 
     def initialize(config)
       @config = config


### PR DESCRIPTION
I noticed this minor issue when testing Resque with the agent. Bundler was defined but my resque example directory didn't contain a Gemfile. I thus got this error when `Bundler.bundle_path` was called.

`Bundler::GemfileNotFound: Could not locate Gemfile`

This change checks if `Bundler.default_bundle_dir` is defined before calling `Bundler.bundle_path`.