### PR TITLE
Use the new SQL parser as default

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -45,6 +45,11 @@ endif::[]
 - Support for gRPC using the `grpc` gem (Experimental) {pull}669[#669]
 - Add `span.context.destination.address` and `span.context.destination.port` when available. {pull}722[#722]
 
+[float]
+===== Changed
+
+- The new SQL parser is used by default {pull}730[#730]
+
 [[release-notes-3.5.0]]
 ==== 3.5.0 (2020-02-12)
 

--- a/docs/configuration.asciidoc
+++ b/docs/configuration.asciidoc
@@ -765,20 +765,14 @@ context information, tags, or spans.
 
 [float]
 [[config-use-experimental-sql-parser]]
-==== `use_experimental_sql_parser`
+==== `use_legacy_sql_parser`
 |============
-| Environment                               | `Config` key                  | Default
-| `ELASTIC_APM_USE_EXPERIMENTAL_SQL_PARSER` | `use_experimental_sql_parser` | `false`
+| Environment                         | `Config` key            | Default
+| `ELASTIC_APM_USE_LEGACY_SQL_PARSER` | `use_legacy_sql_parser` | `false`
 |============
 
-Use a newer, more precise but still experimental approach to generating summaries of
-your app's SQL statements.
-Without this, your SQL statements will still be summarized albeit less accurately.
-
-The summaries become the spans' names -- what it says in the waterfall view in Kibana.
-
-NOTE: This should work just fine but is still deamed experimental. That means it is
-subject to change. Please let us know if you come across any issues.
+Use the older, less precise approach to generating summaries of your app's SQL statements.
+Try this if you're experiencing trouble using the new default.
 
 [float]
 [[config-verify-server-cert]]

--- a/lib/elastic_apm/config.rb
+++ b/lib/elastic_apm/config.rb
@@ -70,7 +70,7 @@ module ElasticAPM
     option :transaction_max_spans,             type: :int,    default: 500
     option :transaction_sample_rate,           type: :float,  default: 1.0
     option :use_elastic_traceparent_header,    type: :bool,   default: true
-    option :use_experimental_sql_parser,       type: :bool,   default: false
+    option :use_legacy_sql_parser,             type: :bool,   default: false
     option :verify_server_cert,                type: :bool,   default: true
 
     # rubocop:enable Metrics/LineLength, Layout/ExtraSpacing
@@ -219,6 +219,11 @@ module ElasticAPM
       warn '[DEPRECATED] The option disabled_instrumentations has been ' \
         'renamed to disable_instrumentations to align with other agents.'
       self.disable_instrumentations = value
+    end
+
+    def use_experimental_sql_parser=(value)
+      warn '[DEPRECATED] The new SQL parser is now the default. To use the old one, '
+        'use use_legacy_sql_parser and please report why you wish to do so.'
     end
 
     private

--- a/lib/elastic_apm/sql.rb
+++ b/lib/elastic_apm/sql.rb
@@ -7,12 +7,12 @@ module ElasticAPM
     # both implementations ~mikker
     def self.summarizer
       @summarizer ||=
-        if ElasticAPM.agent&.config&.use_experimental_sql_parser
-          require 'elastic_apm/sql/signature'
-          Sql::Signature::Summarizer.new
-        else
+        if ElasticAPM.agent&.config&.use_legacy_sql_parser
           require 'elastic_apm/sql_summarizer'
           SqlSummarizer.new
+        else
+          require 'elastic_apm/sql/signature'
+          Sql::Signature::Summarizer.new
         end
     end
   end

--- a/spec/elastic_apm/config_spec.rb
+++ b/spec/elastic_apm/config_spec.rb
@@ -229,6 +229,15 @@ module ElasticAPM
           expect(subject.custom_key_filters).to eq([/oh no/])
         end
       end
+
+      describe 'use_legacy_sql_parser' do
+        subject { Config.new }
+
+        it 'logs a warning' do
+          expect(subject).to receive(:warn).with(/DEPRECATED/)
+          subject.use_experimental_sql_parser = true
+        end
+      end
     end
   end
 end

--- a/spec/elastic_apm/spies/sequel_spec.rb
+++ b/spec/elastic_apm/spies/sequel_spec.rb
@@ -20,7 +20,7 @@ module ElasticAPM
 
       db[:users].count # warm up
 
-      with_agent(use_experimental_sql_parser: true) do
+      with_agent do
         ElasticAPM.with_transaction 'Sequel test' do
           db[:users].count
         end


### PR DESCRIPTION
This PR switches the default SQL parser to the new one.

The old one is still provided so users can easily switch if they encounter any problems.

In a few months we'll remove the old approach completely.