### PR TITLE
ci(jenkins): decouple post-release steps in the rake release step

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -213,20 +213,20 @@ pipeline {
             }
           }
         }
-        stage('Syncup') {
+        stage('Update Branch') {
           steps {
             deleteDir()
             unstash 'source'
             prepareRelease(){
-              catchError(buildResult: 'SUCCESS', message: 'Syncup branches failed', stageResult: 'UNSTABLE') {
-                sh 'rake syncup'
+              catchError(buildResult: 'SUCCESS', message: 'Update branch task failed', stageResult: 'UNSTABLE') {
+                sh 'rake release:update_branch'
               }
             }
           }
           post {
             unsuccessful {
               emailext subject: "[${env.REPO}] Syncup post-release stage failed.", to: "${NOTIFY_TO}",
-                        body: "Please go to ${env.BUILD_URL} to review the logs. Most likely you need to syncup the branches manually."
+                        body: "Please go to ${env.BUILD_URL} to review the logs. Most likely you need to update the branch manually."
             }
           }
         }

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -206,27 +206,27 @@ pipeline {
         stages {
           stage('Release') {
             steps {
-              withGithubNotify(context: 'Release') {
-                deleteDir()
-                unstash 'source'
-                script {
-                  dir(BASE_DIR){
-                    docker.image("${env.RUBY_DOCKER_TAG}").inside('-v ${REFERENCE_REPO}:${REFERENCE_REPO} -v /etc/passwd:/etc/passwd -v ${HOME}/.ssh:${HOME}/.ssh') {
-                      withEnv(["HOME=${env.WORKSPACE}/${env.BASE_DIR ?: ''}"]) {
-                        rubygemsLogin.withApi(secret: "${env.RELEASE_SECRET}") {
-                          sshagent(['f6c7695a-671e-4f4f-a331-acdce44ff9ba']) {
-                            sh '.ci/prepare-git-context.sh'
-                            sh 'gem install rake yard rspec'
-                            sh 'rake release'
-                            catchError(buildResult: 'SUCCESS', message: 'Syncup branches failed', stageResult: 'UNSTABLE') {
-                              sh 'rake syncup'
-                            }
-                          }
-                        }
-                      }
-                    }
-                  }
+              deleteDir()
+              unstash 'source'
+              prepareRelease(){
+                sh 'rake release'
+              }
+            }
+          }
+          stage('Syncup') {
+            steps {
+              deleteDir()
+              unstash 'source'
+              prepareRelease(){
+                catchError(buildResult: 'SUCCESS', message: 'Syncup branches failed', stageResult: 'UNSTABLE') {
+                  sh 'rake syncup'
                 }
+              }
+            }
+            post {
+              unsuccessful {
+                emailext subject: "[${env.REPO}] Syncup post-release stage failed.", to: "${NOTIFY_TO}",
+                         body: "Please go to ${env.BUILD_URL} to review the logs. Most likely you need to syncup the branches manually."
               }
             }
           }
@@ -316,5 +316,21 @@ def runJob(String rubyVersion, int sleep = 1){
     }
   } finally {
     rubyDownstreamJobs["${rubyVersion}"] = buildObject
+  }
+}
+
+def prepareRelease(Closure body){
+  dir("${env.BASE_DIR}"){
+    docker.image("${env.RUBY_DOCKER_TAG}").inside('-v ${REFERENCE_REPO}:${REFERENCE_REPO} -v /etc/passwd:/etc/passwd -v ${HOME}/.ssh:${HOME}/.ssh') {
+      withEnv(["HOME=${env.WORKSPACE}/${env.BASE_DIR ?: ''}"]) {
+        rubygemsLogin.withApi(secret: "${env.RELEASE_SECRET}") {
+          sshagent(['f6c7695a-671e-4f4f-a331-acdce44ff9ba']) {
+            sh '.ci/prepare-git-context.sh'
+            sh 'gem install rake yard rspec'
+            body()
+          }
+        }
+      }
+    }
   }
 }

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -218,6 +218,9 @@ pipeline {
                             sh '.ci/prepare-git-context.sh'
                             sh 'gem install rake yard rspec'
                             sh 'rake release'
+                            catchError(buildResult: 'SUCCESS', message: 'Syncup branches failed', stageResult: 'UNSTABLE') {
+                              sh 'rake syncup'
+                            }
                           }
                         }
                       }

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -48,4 +48,5 @@ To release a new version:
     1. Tag the current commit as new version.
     2. Push the tag to GitHub.
     3. Build the gem and upload to Rubygems (local user needs to be signed in and authorized.)
-    4. Update `2.x` branch to be at released commit and push it to GitHub.
+1. Run `rake syncup`. This will...
+    1. Update `3.x` branch to be at released commit and push it to GitHub.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -48,5 +48,5 @@ To release a new version:
     1. Tag the current commit as new version.
     2. Push the tag to GitHub.
     3. Build the gem and upload to Rubygems (local user needs to be signed in and authorized.)
-1. Run `rake syncup`. This will...
+1. Run `rake release:update_branch`. This will...
     1. Update `3.x` branch to be at released commit and push it to GitHub.

--- a/Rakefile
+++ b/Rakefile
@@ -2,7 +2,10 @@
 
 require 'bundler/gem_tasks'
 
-Rake::Task[:release].enhance do
+desc """Post release action:
+Update `3.x` branch to be at released commit and push it to GitHub.
+"""
+task :syncup => :environment do
   `git checkout 3.x &&
   git rebase master &&
   git push origin 3.x &&

--- a/Rakefile
+++ b/Rakefile
@@ -5,11 +5,13 @@ require 'bundler/gem_tasks'
 desc """Post release action:
 Update `3.x` branch to be at released commit and push it to GitHub.
 """
-task :syncup => :environment do
-  `git checkout 3.x &&
-  git rebase master &&
-  git push origin 3.x &&
-  git checkout master`
+namespace :release do
+  task :update_branch do
+    `echo hi && false && git checkout 3.x &&
+    git rebase master &&
+    git push origin 3.x &&
+    git checkout master`
+  end
 end
 
 require 'rspec/core/rake_task'


### PR DESCRIPTION
## What does this pull request do?

- Update docs
- Create rake task to syncup the branches when a release happens
- Notify if the post-release step failed and keep moving forward. 
- Send an email if the syncup failed.

 
## Why is it important?

Avoid fail fast when the syncup between merges failed, this will help to release the new version of the opbeans.

## Related issues

Closes https://github.com/elastic/apm-agent-ruby/issues/714