### PR TITLE
ci(jenkins): load utils function with the retry and fix update-branch

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -238,10 +238,10 @@ pipeline {
           steps {
             deleteDir()
             // Let's wait for the Gem to be available
-            retry(10) {
-              sleep 10
-              sh "curl --silent --show-error --fail -I https://rubygems.org/gems/elastic-apm/versions/${env.VERSION}"
-            }
+            sh label: 'Wait for gem', script: """#!/usr/bin/env bash
+              source /usr/local/bin/bash_standard_lib.sh
+              (retry 10 curl --silent --show-error --fail -I https://rubygems.org/gems/elastic-apm/versions/${env.VERSION})
+            """
             dir("${OPBEANS_REPO}"){
               git credentialsId: 'f6c7695a-671e-4f4f-a331-acdce44ff9ba',
                   url: "git@github.com:elastic/${OPBEANS_REPO}.git"

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -238,7 +238,10 @@ pipeline {
           steps {
             deleteDir()
             // Let's wait for the Gem to be available
-            sh "(retry 10 curl --silent --show-error --fail -I https://rubygems.org/gems/elastic-apm/versions/${env.VERSION})"
+            retry(10) {
+              sleep 10
+              sh "curl --silent --show-error --fail -I https://rubygems.org/gems/elastic-apm/versions/${env.VERSION}"
+            }
             dir("${OPBEANS_REPO}"){
               git credentialsId: 'f6c7695a-671e-4f4f-a331-acdce44ff9ba',
                   url: "git@github.com:elastic/${OPBEANS_REPO}.git"

--- a/Rakefile
+++ b/Rakefile
@@ -7,7 +7,7 @@ Update `3.x` branch to be at released commit and push it to GitHub.
 """
 namespace :release do
   task :update_branch do
-    `echo hi && false && git checkout 3.x &&
+    `git checkout 3.x &&
     git rebase master &&
     git push origin 3.x &&
     git checkout master`


### PR DESCRIPTION
## What does this pull request do?

- Fixes the required utils file to be loaded.
- Remove leftovers for the syncup branches when a release happens.

## Why is it important?

Retry is not a built-in function.
