### PR TITLE
Compare metricset counts only to number of successful requests

### DIFF
--- a/spec/integration/rails_metrics_stress_spec.rb
+++ b/spec/integration/rails_metrics_stress_spec.rb
@@ -77,9 +77,8 @@ if enabled
         Thread.new do
           env = Rack::MockRequest.env_for(paths.sample)
           status, = Rails.application.call(env)
-          expect(status).to be 200
-          expect(env)
-          count.increment
+          count.increment if status == 200
+          count
         end
       end.each(&:join)
 

--- a/spec/integration/rails_metrics_stress_spec.rb
+++ b/spec/integration/rails_metrics_stress_spec.rb
@@ -77,14 +77,16 @@ if enabled
         Thread.new do
           env = Rack::MockRequest.env_for(paths.sample)
           status, = Rails.application.call(env)
+          # The request is occasionally unsuccessful so we want to only
+          # compare the metricset counts to the number of successful
+          # requests.
           count.increment if status == 200
-          count
         end
       end.each(&:join)
 
       sleep 2 # wait for metrics to collect
       expect(EventCollector.metricsets_summary.values).to eq(
-        Array.new(5).map { request_count }
+        Array.new(5).map { count.value }
       )
     end
   end


### PR DESCRIPTION
A really small change to the rails metrics stress test to compare the expected metricsets counts to the number of successful requests.
This would avoid test failures like this that are not indicative of an agent issue: https://apm-ci.elastic.co/blue/organizations/jenkins/apm-agent-ruby%2Fapm-agent-ruby-downstream/detail/master/2933/pipeline

I also removed the expectation on the request status and `env` variable, as those don't tell us anything about the agent functionality.