### PR TITLE
(🚧) Spec suite spring cleaning

### DIFF
--- a/lib/elastic_apm/transport/connection.rb
+++ b/lib/elastic_apm/transport/connection.rb
@@ -30,6 +30,7 @@ module ElasticAPM
       end
 
       attr_reader :http
+
       def write(str)
         return false if @config.disable_send
 

--- a/lib/elastic_apm/transport/serializers.rb
+++ b/lib/elastic_apm/transport/serializers.rb
@@ -55,6 +55,7 @@ module ElasticAPM
         end
 
         attr_reader :transaction, :span, :error, :metadata, :metricset
+
         def serialize(resource)
           case resource
           when Transaction

--- a/lib/elastic_apm/transport/worker.rb
+++ b/lib/elastic_apm/transport/worker.rb
@@ -36,6 +36,7 @@ module ElasticAPM
       end
 
       attr_reader :queue, :filters, :name, :connection, :serializers
+
       def work_forever
         while (msg = queue.pop)
           case msg

--- a/spec/elastic_apm/central_config_spec.rb
+++ b/spec/elastic_apm/central_config_spec.rb
@@ -2,8 +2,6 @@
 
 module ElasticAPM
   RSpec.describe CentralConfig do
-    after { WebMock.reset! }
-
     let(:config) { Config.new service_name: 'MyApp' }
     subject { described_class.new(config) }
 

--- a/spec/elastic_apm/spies/elasticsearch_spec.rb
+++ b/spec/elastic_apm/spies/elasticsearch_spec.rb
@@ -4,8 +4,6 @@ require 'elasticsearch'
 
 module ElasticAPM
   RSpec.describe 'Spy: Elasticsearch' do
-    after { WebMock.reset! }
-
     it 'spans requests', :intercept do
       WebMock.stub_request(:get, %r{http://localhost:9200/.*})
 

--- a/spec/elastic_apm/spies/faraday_spec.rb
+++ b/spec/elastic_apm/spies/faraday_spec.rb
@@ -4,8 +4,6 @@ require 'faraday'
 
 module ElasticAPM
   RSpec.describe 'Spy: Faraday', :intercept do
-    after { WebMock.reset! }
-
     let(:client) do
       Faraday.new(url: 'http://example.com')
     end

--- a/spec/elastic_apm/spies/http_spec.rb
+++ b/spec/elastic_apm/spies/http_spec.rb
@@ -4,8 +4,6 @@ require 'http'
 
 module ElasticAPM
   RSpec.describe 'Spy: HTTP.rb', :intercept do
-    after { WebMock.reset! }
-
     it 'spans http calls' do
       WebMock.stub_request(:get, %r{http://example.com/.*})
 

--- a/spec/elastic_apm/spies/net_http_spec.rb
+++ b/spec/elastic_apm/spies/net_http_spec.rb
@@ -4,8 +4,6 @@ require 'net/http'
 
 module ElasticAPM
   RSpec.describe 'Spy: NetHTTP', :intercept do
-    after { WebMock.reset! }
-
     it 'spans http calls' do
       WebMock.stub_request(:get, %r{http://example.com/.*})
 
@@ -137,7 +135,6 @@ module ElasticAPM
       expect(span.action).to eq 'POST'
 
       ElasticAPM.stop
-      WebMock.reset!
     end
 
     describe 'destination info' do

--- a/spec/elastic_apm/transport/connection/http_spec.rb
+++ b/spec/elastic_apm/transport/connection/http_spec.rb
@@ -5,8 +5,6 @@ require 'elastic_apm/transport/connection'
 module ElasticAPM
   module Transport
     RSpec.describe Connection::Http do
-      after { WebMock.reset! }
-
       let(:config) { Config.new(http_compression: false) }
 
       let(:metadata) do

--- a/spec/elastic_apm/transport/connection_spec.rb
+++ b/spec/elastic_apm/transport/connection_spec.rb
@@ -8,8 +8,6 @@ module ElasticAPM
       let(:config) { Config.new(http_compression: false) }
       subject { described_class.new(config) }
 
-      after { WebMock.reset! }
-
       describe '#initialize' do
         it 'is has no active connection' do
           expect(subject.http).to be nil

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -124,8 +124,4 @@ RSpec.shared_context 'stubbed_central_config' do
       :get, %r{^http://localhost:8200/config/v1/agents/?$}
     ).to_return(body: '{}')
   end
-
-  after(:all) do
-    WebMock.reset!
-  end
 end

--- a/spec/support/webmock.rb
+++ b/spec/support/webmock.rb
@@ -1,15 +1,6 @@
 # frozen_string_literal: true
 
 require 'webmock'
-require 'webmock/rspec/matchers'
+require 'webmock/rspec'
 
 WebMock.hide_stubbing_instructions!
-
-# We want everything from webmock/rspec except resetting after each example
-RSpec.configure do |config|
-  config.include WebMock::API
-  config.include WebMock::Matchers
-
-  config.before(:suite) { WebMock.enable! }
-  config.after(:suite) { WebMock.disable! }
-end


### PR DESCRIPTION
Re: #612

- [x] No manual WebMock resetting
- [ ] Logging#error raises in test (unless expected)
- [ ] Move wait_for to MockIntake.wait_for
- [ ] Stripped down defaults for with_agent
- [ ] Rails.application.config.deep_merge!(DEFAULT_RAILS_TEST_OPTIONS)
	- [ ] WithAgent::DEFAULT_TEST_OPTIONS maybe?
- [ ] Omit `-r spec_helper` in `.rspec`. Only require in the specs that need it.
        - Evaluate whether we want to rename the current `spec_helper` to `agent_helper` or something similar and have a **minimal** `spec_helper` (setting up load path, requiring `rspec/its`, bare minimum)
- [ ] Add `require: nil` to everything in `Gemfile`