### PR TITLE
Use config from the singleton agent instead of holding a reference

### DIFF
--- a/lib/elastic_apm.rb
+++ b/lib/elastic_apm.rb
@@ -31,6 +31,9 @@ require 'elastic_apm/grpc' if defined?(::GRPC)
 
 # ElasticAPM
 module ElasticAPM
+
+  class AgentRequired < RuntimeError; end
+
   class << self
     ### Life cycle
 
@@ -72,6 +75,8 @@ module ElasticAPM
     # @return [Config] The config of the running agent.
     # Returns nil if the agent is not running.
     def config
+      raise AgentRequired unless agent
+      raise RuntimeError, 'Config for agent is missing' unless Agent.config
       Agent.config
     end
 

--- a/lib/elastic_apm.rb
+++ b/lib/elastic_apm.rb
@@ -67,6 +67,14 @@ module ElasticAPM
       Agent.instance
     end
 
+    # Returns the config of the running agent.
+    #
+    # @return [Config] The config of the running agent.
+    # Returns nil if the agent is not running.
+    def config
+      Agent.config
+    end
+
     ### Metrics
 
     # Returns the currently active transaction (if any)

--- a/lib/elastic_apm/agent.rb
+++ b/lib/elastic_apm/agent.rb
@@ -69,14 +69,13 @@ module ElasticAPM
 
     def initialize(config)
       @stacktrace_builder = StacktraceBuilder.new(config)
-      @context_builder = ContextBuilder.new(config)
-      @error_builder = ErrorBuilder.new(self)
+      @context_builder = ContextBuilder.new
+      @error_builder = ErrorBuilder.new
 
       @central_config = CentralConfig.new(config)
       @transport = Transport::Base.new(config)
-      @metrics = Metrics.new(config) { |event| enqueue event }
+      @metrics = Metrics.new { |event| enqueue event }
       @instrumenter = Instrumenter.new(
-        config,
         metrics: metrics,
         stacktrace_builder: stacktrace_builder
       ) { |event| enqueue event }
@@ -156,7 +155,6 @@ module ElasticAPM
       instrumenter.start_transaction(
         name,
         type,
-        config: config,
         context: context,
         trace_context: trace_context
       )

--- a/lib/elastic_apm/agent.rb
+++ b/lib/elastic_apm/agent.rb
@@ -42,7 +42,11 @@ module ElasticAPM
           return
         end
 
-        @instance = new(config).start
+        # It's important that the @instance variable is set before calling #start.
+        # Objects rely on the config being available via ElasticAPM.agent.config
+        # while starting.
+        @instance = new(config)
+        @instance.start
       end
     end
 
@@ -57,6 +61,10 @@ module ElasticAPM
 
     def self.running?
       !!@instance
+    end
+
+    def self.config
+      @instance&.config
     end
 
     def initialize(config)

--- a/lib/elastic_apm/agent.rb
+++ b/lib/elastic_apm/agent.rb
@@ -42,9 +42,9 @@ module ElasticAPM
           return
         end
 
-        # It's important that the @instance variable is set before calling #start.
-        # Objects rely on the config being available via ElasticAPM.agent.config
-        # while starting.
+        # It's important that the @instance variable is set before
+        # calling #start. Objects rely on the config being available
+        # via ElasticAPM.agent.config while starting.
         @instance = new(config)
         @instance.start
       end

--- a/lib/elastic_apm/context_builder.rb
+++ b/lib/elastic_apm/context_builder.rb
@@ -6,12 +6,6 @@ module ElasticAPM
     MAX_BODY_LENGTH = 2048
     SKIPPED = '[SKIPPED]'
 
-    def initialize(config)
-      @config = config
-    end
-
-    attr_reader :config
-
     def build(rack_env:, for_type:)
       Context.new.tap do |context|
         apply_to_request(context, rack_env: rack_env, for_type: for_type)
@@ -90,6 +84,10 @@ module ElasticAPM
     def build_http_version(rack_env)
       return unless (http_version = rack_env['HTTP_VERSION'])
       http_version.gsub(%r{HTTP/}, '')
+    end
+
+    def config
+      ElasticAPM.config
     end
   end
 end

--- a/lib/elastic_apm/error_builder.rb
+++ b/lib/elastic_apm/error_builder.rb
@@ -3,16 +3,13 @@
 module ElasticAPM
   # @api private
   class ErrorBuilder
-    def initialize(agent)
-      @agent = agent
-    end
 
     def build_exception(exception, context: nil, handled: true)
       error = Error.new context: context || Context.new
       error.exception =
         Error::Exception.from_exception(exception, handled: handled)
 
-      Util.reverse_merge!(error.context.labels, @agent.config.default_labels)
+      Util.reverse_merge!(error.context.labels, config.default_labels)
 
       if exception.backtrace
         add_stacktrace error, :exception, exception.backtrace
@@ -40,7 +37,7 @@ module ElasticAPM
 
     def add_stacktrace(error, kind, backtrace)
       stacktrace =
-        @agent.stacktrace_builder.build(backtrace, type: :error)
+          ElasticAPM.agent.stacktrace_builder.build(backtrace, type: :error)
       return unless stacktrace
 
       case kind
@@ -68,6 +65,10 @@ module ElasticAPM
 
       Util.reverse_merge!(error.context.labels, transaction.context.labels)
       Util.reverse_merge!(error.context.custom, transaction.context.custom)
+    end
+
+    def config
+      ElasticAPM.config
     end
   end
 end

--- a/lib/elastic_apm/logging.rb
+++ b/lib/elastic_apm/logging.rb
@@ -36,8 +36,8 @@ module ElasticAPM
     private
 
     def log(lvl, msg, *args)
-      return unless (logger = @config&.logger)
-      return unless LEVELS[lvl] >= (@config&.log_level || 0)
+      return unless (logger = config&.logger)
+      return unless LEVELS[lvl] >= (config&.log_level || 0)
 
       formatted_msg = prepend_prefix(format(msg.to_s, *args))
 
@@ -48,6 +48,10 @@ module ElasticAPM
 
     def prepend_prefix(str)
       "#{PREFIX}#{str}"
+    end
+
+    def config
+      ElasticAPM.config
     end
   end
 end

--- a/lib/elastic_apm/metadata.rb
+++ b/lib/elastic_apm/metadata.rb
@@ -7,10 +7,13 @@ module ElasticAPM
       @service = ServiceInfo.new
       @process = ProcessInfo.new
       @system = SystemInfo.new
-      @labels = config.global_labels
     end
 
     attr_reader :service, :process, :system, :labels
+
+    def labels
+      @labels ||= config.global_labels
+    end
 
     private
 

--- a/lib/elastic_apm/metadata.rb
+++ b/lib/elastic_apm/metadata.rb
@@ -3,14 +3,20 @@
 module ElasticAPM
   # @api private
   class Metadata
-    def initialize(config)
-      @service = ServiceInfo.new(config)
-      @process = ProcessInfo.new(config)
-      @system = SystemInfo.new(config)
+    def initialize
+      @service = ServiceInfo.new
+      @process = ProcessInfo.new
+      @system = SystemInfo.new
       @labels = config.global_labels
     end
 
     attr_reader :service, :process, :system, :labels
+
+    private
+
+    def config
+      ElasticAPM.config
+    end
   end
 end
 

--- a/lib/elastic_apm/metadata/process_info.rb
+++ b/lib/elastic_apm/metadata/process_info.rb
@@ -4,9 +4,7 @@ module ElasticAPM
   class Metadata
     # @api private
     class ProcessInfo
-      def initialize(config)
-        @config = config
-
+      def initialize
         @argv = ARGV
         @pid = $PID || Process.pid
         @title = $PROGRAM_NAME

--- a/lib/elastic_apm/metadata/service_info.rb
+++ b/lib/elastic_apm/metadata/service_info.rb
@@ -13,27 +13,39 @@ module ElasticAPM
 
         attr_reader :name, :version
       end
+
+      class Framework
+        def name
+          @name ||= ElasticAPM.config.framework_name
+        end
+
+        def version
+          @version ||= ElasticAPM.config.framework_version
+        end
+      end
+
       class Agent < Versioned; end
-      class Framework < Versioned; end
       class Language < Versioned; end
       class Runtime < Versioned; end
       def initialize
-        @name = config.service_name
         @agent = Agent.new(name: 'ruby', version: VERSION)
-        @framework = Framework.new(
-          name: config.framework_name,
-          version: config.framework_version
-        )
+        @framework = Framework.new
         @language = Language.new(name: 'ruby', version: RUBY_VERSION)
         @runtime = lookup_runtime
-        @version = config.service_version || Util.git_sha
       end
 
-      attr_reader :name, :environment, :agent, :framework, :language, :runtime,
-        :version
+      attr_reader :environment, :agent, :framework, :language, :runtime
 
       def environment
         config.environment
+      end
+
+      def name
+        @name ||= config.service_name
+      end
+
+      def version
+        @version ||= config.service_version || Util.git_sha
       end
 
       private

--- a/lib/elastic_apm/metadata/service_info.rb
+++ b/lib/elastic_apm/metadata/service_info.rb
@@ -17,23 +17,24 @@ module ElasticAPM
       class Framework < Versioned; end
       class Language < Versioned; end
       class Runtime < Versioned; end
-      def initialize(config)
-        @config = config
-
-        @name = @config.service_name
-        @environment = @config.environment
+      def initialize
+        @name = config.service_name
         @agent = Agent.new(name: 'ruby', version: VERSION)
         @framework = Framework.new(
-          name: @config.framework_name,
-          version: @config.framework_version
+          name: config.framework_name,
+          version: config.framework_version
         )
         @language = Language.new(name: 'ruby', version: RUBY_VERSION)
         @runtime = lookup_runtime
-        @version = @config.service_version || Util.git_sha
+        @version = config.service_version || Util.git_sha
       end
 
       attr_reader :name, :environment, :agent, :framework, :language, :runtime,
         :version
+
+      def environment
+        config.environment
+      end
 
       private
 
@@ -50,6 +51,10 @@ module ElasticAPM
             version: JRUBY_VERSION || RUBY_ENGINE_VERSION
           )
         end
+      end
+
+      def config
+        ElasticAPM.config
       end
     end
   end

--- a/lib/elastic_apm/metadata/system_info.rb
+++ b/lib/elastic_apm/metadata/system_info.rb
@@ -4,10 +4,8 @@ module ElasticAPM
   class Metadata
     # @api private
     class SystemInfo
-      def initialize(config)
-        @config = config
-
-        @hostname = @config.hostname || `hostname`.chomp
+      def initialize
+        @hostname = config.hostname || `hostname`.chomp
         @architecture = gem_platform.cpu
         @platform = gem_platform.os
 
@@ -22,6 +20,10 @@ module ElasticAPM
 
       def gem_platform
         @gem_platform ||= Gem::Platform.local
+      end
+
+      def config
+        ElasticAPM.config
       end
     end
   end

--- a/lib/elastic_apm/metadata/system_info.rb
+++ b/lib/elastic_apm/metadata/system_info.rb
@@ -5,7 +5,6 @@ module ElasticAPM
     # @api private
     class SystemInfo
       def initialize
-        @hostname = config.hostname || `hostname`.chomp
         @architecture = gem_platform.cpu
         @platform = gem_platform.os
 
@@ -14,7 +13,11 @@ module ElasticAPM
         @kubernetes = container_info.kubernetes
       end
 
-      attr_reader :hostname, :architecture, :platform, :container, :kubernetes
+      attr_reader :architecture, :platform, :container, :kubernetes
+
+      def hostname
+        @hostname ||= config.hostname || `hostname`.chomp
+      end
 
       private
 

--- a/lib/elastic_apm/metrics.rb
+++ b/lib/elastic_apm/metrics.rb
@@ -21,7 +21,7 @@ module ElasticAPM
         @callback = block
       end
 
-      attr_reader :config, :sets, :callback
+      attr_reader :sets, :callback
       def start
         unless config.collect_metrics?
           debug 'Skipping metrics'
@@ -37,7 +37,7 @@ module ElasticAPM
           transaction: TransactionSet
         }.each_with_object({}) do |(key, kls), sets|
           debug "Adding metrics collector '#{kls}'"
-          sets[key] = kls.new(config)
+          sets[key] = kls.new
         end
 
         @timer_task = Concurrent::TimerTask.execute(

--- a/lib/elastic_apm/metrics.rb
+++ b/lib/elastic_apm/metrics.rb
@@ -3,8 +3,8 @@
 module ElasticAPM
   # @api private
   module Metrics
-    def self.new(config, &block)
-      Registry.new(config, &block)
+    def self.new(&block)
+      Registry.new(&block)
     end
 
     def self.platform
@@ -17,8 +17,7 @@ module ElasticAPM
 
       TIMEOUT_INTERVAL = 5 # seconds
 
-      def initialize(config, &block)
-        @config = config
+      def initialize(&block)
         @callback = block
       end
 
@@ -91,6 +90,10 @@ module ElasticAPM
           next unless samples
           arr.concat(samples)
         end
+      end
+
+      def config
+        ElasticAPM.config
       end
     end
   end

--- a/lib/elastic_apm/metrics/breakdown_set.rb
+++ b/lib/elastic_apm/metrics/breakdown_set.rb
@@ -4,7 +4,7 @@ module ElasticAPM
   module Metrics
     # @api private
     class BreakdownSet < SpanScopedSet
-      def initialize(config)
+      def initialize
         super
 
         disable! unless config.breakdown_metrics?

--- a/lib/elastic_apm/metrics/cpu_mem_set.rb
+++ b/lib/elastic_apm/metrics/cpu_mem_set.rb
@@ -42,14 +42,12 @@ module ElasticAPM
         )
       end
 
-      def initialize(config)
+      def initialize
         super
 
         @sampler = sampler_for_platform(Metrics.platform)
         read! # set @previous on boot
       end
-
-      attr_reader :config
 
       def collect
         read!

--- a/lib/elastic_apm/metrics/set.rb
+++ b/lib/elastic_apm/metrics/set.rb
@@ -11,8 +11,7 @@ module ElasticAPM
 
       DISTINCT_LABEL_LIMIT = 1000
 
-      def initialize(config)
-        @config = config
+      def initialize
         @metrics = {}
         @disabled = false
         @lock = Mutex.new
@@ -41,7 +40,7 @@ module ElasticAPM
       end
 
       def metric(kls, key, tags: nil, **args)
-        if @config.disable_metrics.any? { |p| p.match? key }
+        if config.disable_metrics.any? { |p| p.match? key }
           return NOOP
         end
 
@@ -100,6 +99,10 @@ module ElasticAPM
         tuple = tags.keys.zip(tags.values)
         tuple.flatten!
         tuple.unshift(key)
+      end
+
+      def config
+        ElasticAPM.config
       end
     end
   end

--- a/lib/elastic_apm/middleware.rb
+++ b/lib/elastic_apm/middleware.rb
@@ -65,9 +65,5 @@ module ElasticAPM
     def running?
       ElasticAPM.running?
     end
-
-    def config
-      @config ||= ElasticAPM.agent.config
-    end
   end
 end

--- a/lib/elastic_apm/normalizers.rb
+++ b/lib/elastic_apm/normalizers.rb
@@ -5,9 +5,6 @@ module ElasticAPM # :nodoc:
   module Normalizers
     # @api privagte
     class Normalizer
-      def initialize(config)
-        @config = config
-      end
 
       def self.register(name)
         Normalizers.register(name, self)
@@ -21,9 +18,9 @@ module ElasticAPM # :nodoc:
       @registered[name] = klass
     end
 
-    def self.build(config)
+    def self.build
       normalizers = @registered.each_with_object({}) do |(name, klass), built|
-        built[name] = klass.new(config)
+        built[name] = klass.new
       end
 
       Collection.new(normalizers)

--- a/lib/elastic_apm/normalizers/rails/action_view.rb
+++ b/lib/elastic_apm/normalizers/rails/action_view.rb
@@ -19,7 +19,7 @@ module ElasticAPM
         end
 
         def view_path(path)
-          root = @config.__view_paths.find { |vp| path.start_with?(vp) }
+          root = config.__view_paths.find { |vp| path.start_with?(vp) }
           return unless root
 
           strip_root(root, path)
@@ -35,6 +35,10 @@ module ElasticAPM
         def strip_root(root, path)
           start = root.length + 1
           path[start, path.length]
+        end
+
+        def config
+          ElasticAPM.config
         end
       end
 

--- a/lib/elastic_apm/subscriber.rb
+++ b/lib/elastic_apm/subscriber.rb
@@ -28,7 +28,7 @@ module ElasticAPM
 
     Notification = Struct.new(:id, :span)
     def start(name, id, payload)
-      return unless (transaction = @agent.current_transaction)
+      return unless (transaction = ElasticAPM.current_transaction)
 
       normalized = @normalizers.normalize(transaction, name, payload)
 
@@ -38,7 +38,7 @@ module ElasticAPM
         else
           name, type, subtype, action, context = normalized
 
-          @agent.start_span(
+          ElasticAPM.start_span(
             name,
             type,
             subtype: subtype,

--- a/lib/elastic_apm/transport/connection.rb
+++ b/lib/elastic_apm/transport/connection.rb
@@ -22,7 +22,7 @@ module ElasticAPM
         @config = config
         @metadata = JSON.fast_generate(
           Serializers::MetadataSerializer.new(config).build(
-            Metadata.new(config)
+            Metadata.new
           )
         )
         @url = config.server_url + '/intake/v2/events'

--- a/lib/elastic_apm/transport/headers.rb
+++ b/lib/elastic_apm/transport/headers.rb
@@ -49,7 +49,7 @@ module ElasticAPM
       private
 
       def build!(headers)
-        headers[:'User-Agent'] = UserAgent.new(@config).to_s
+        headers[:'User-Agent'] = UserAgent.new.to_s
 
         if (token = @config.secret_token)
           headers[:Authorization] = "Bearer #{token}"

--- a/lib/elastic_apm/transport/serializers.rb
+++ b/lib/elastic_apm/transport/serializers.rb
@@ -9,11 +9,6 @@ module ElasticAPM
 
       # @api private
       class Serializer
-        def initialize(config)
-          @config = config
-        end
-
-        attr_reader :config
 
         private
 
@@ -41,6 +36,10 @@ module ElasticAPM
               hash[k] = v.is_a?(String) ? keyword_field(v) : v
             end
           end
+        end
+
+        def config
+          ElasticAPM.config
         end
       end
 

--- a/lib/elastic_apm/transport/user_agent.rb
+++ b/lib/elastic_apm/transport/user_agent.rb
@@ -4,8 +4,8 @@ module ElasticAPM
   module Transport
     # @api private
     class UserAgent
-      def initialize(config)
-        @built = build(config)
+      def initialize
+        @built = build
       end
 
       def to_s
@@ -14,8 +14,8 @@ module ElasticAPM
 
       private
 
-      def build(config)
-        metadata = Metadata.new(config)
+      def build
+        metadata = Metadata.new
 
         [
           "elastic-apm-ruby/#{VERSION}",

--- a/spec/elastic_apm/context_builder_spec.rb
+++ b/spec/elastic_apm/context_builder_spec.rb
@@ -4,7 +4,8 @@ module ElasticAPM
   RSpec.describe ContextBuilder do
     describe '#build' do
       let(:config) { Config.new }
-      let(:subject) { described_class.new(config) }
+      let(:subject) { described_class.new }
+      before { allow(ElasticAPM).to receive(:config).and_return(config) }
 
       it 'enriches request' do
         env = Rack::MockRequest.env_for(

--- a/spec/elastic_apm/logging_spec.rb
+++ b/spec/elastic_apm/logging_spec.rb
@@ -10,6 +10,7 @@ module ElasticAPM
       def initialize(config)
         @config = config
       end
+      attr_reader :config
     end
 
     let(:config) do

--- a/spec/elastic_apm/metadata/process_info_spec.rb
+++ b/spec/elastic_apm/metadata/process_info_spec.rb
@@ -3,7 +3,8 @@
 module ElasticAPM
   RSpec.describe Metadata::ProcessInfo do
     describe '#initialize' do
-      subject { described_class.new(Config.new) }
+      subject { described_class.new }
+      before { allow(ElasticAPM).to receive(:config).and_return(Config.new) }
 
       it 'knows about the process' do
         expect(subject.argv).to be_a Array

--- a/spec/elastic_apm/metadata/service_info_spec.rb
+++ b/spec/elastic_apm/metadata/service_info_spec.rb
@@ -5,7 +5,8 @@ require 'spec_helper'
 module ElasticAPM
   RSpec.describe Metadata::ServiceInfo do
     describe '#initialize' do
-      subject { described_class.new(Config.new) }
+      subject { described_class.new }
+      before { allow(ElasticAPM).to receive(:config).and_return(Config.new) }
 
       it 'knows the runtime (mri)', unless: RSpec::Support::Ruby.jruby? do
         expect(subject.runtime.name).to eq 'ruby'

--- a/spec/elastic_apm/metadata/system_info_spec.rb
+++ b/spec/elastic_apm/metadata/system_info_spec.rb
@@ -3,7 +3,8 @@
 module ElasticAPM
   RSpec.describe Metadata::SystemInfo do
     describe '#initialize' do
-      subject { described_class.new(Config.new) }
+      subject { described_class.new }
+      before { allow(ElasticAPM).to receive(:config).and_return(Config.new) }
 
       it 'has values' do
         %i[hostname architecture platform].each do |key|

--- a/spec/elastic_apm/metadata_spec.rb
+++ b/spec/elastic_apm/metadata_spec.rb
@@ -5,7 +5,8 @@ require 'spec_helper'
 module ElasticAPM
   RSpec.describe Metadata do
     let(:config) { Config.new(global_labels: { apples: 'oranges' }) }
-    subject { described_class.new(config) }
+    before { allow(ElasticAPM).to receive(:config).and_return(config) }
+    subject { described_class.new }
 
     describe '#labels' do
       it 'accesses the config\'s labels' do

--- a/spec/elastic_apm/metrics/cpu_mem_set_spec.rb
+++ b/spec/elastic_apm/metrics/cpu_mem_set_spec.rb
@@ -4,7 +4,8 @@ module ElasticAPM
   module Metrics
     RSpec.describe CpuMemSet do
       let(:config) { Config.new }
-      subject { described_class.new config }
+      subject { described_class.new }
+      before { allow(ElasticAPM).to receive(:config).and_return(config) }
 
       context 'Linux' do
         before { allow(Metrics).to receive(:platform) { :linux } }

--- a/spec/elastic_apm/metrics/set_spec.rb
+++ b/spec/elastic_apm/metrics/set_spec.rb
@@ -15,6 +15,10 @@ module ElasticAPM
       end
 
       describe 'metrics' do
+        before do
+          allow(ElasticAPM).to receive(:config).and_return(config)
+        end
+
         it 'can have metrics' do
           subject.gauge('gauge').value = 0
           subject.counter('counter').value = 0

--- a/spec/elastic_apm/metrics/set_spec.rb
+++ b/spec/elastic_apm/metrics/set_spec.rb
@@ -2,9 +2,11 @@
 
 module ElasticAPM
   module Metrics
-    RSpec.describe Set do
+    RSpec.describe Set, :intercept do
       let(:config) { Config.new }
-      subject { described_class.new config }
+      subject { described_class.new }
+      before { ElasticAPM.start(config) }
+      after { ElasticAPM.stop }
 
       describe 'disabled?' do
         it 'can be disabled' do
@@ -15,9 +17,6 @@ module ElasticAPM
       end
 
       describe 'metrics' do
-        before do
-          allow(ElasticAPM).to receive(:config).and_return(config)
-        end
 
         it 'can have metrics' do
           subject.gauge('gauge').value = 0

--- a/spec/elastic_apm/metrics/span_scoped_set_spec.rb
+++ b/spec/elastic_apm/metrics/span_scoped_set_spec.rb
@@ -4,7 +4,9 @@ module ElasticAPM
   module Metrics
     RSpec.shared_examples(:span_scope_set) do
       let(:config) { Config.new }
-      subject { described_class.new config }
+      subject { described_class.new }
+      before { ElasticAPM.start(config) }
+      after { ElasticAPM.stop }
 
       describe 'collect' do
         it 'moves transaction info from tags to props' do
@@ -27,11 +29,11 @@ module ElasticAPM
       end
     end
 
-    RSpec.describe TransactionSet do
+    RSpec.describe TransactionSet, :intercept do
       it_behaves_like :span_scope_set
     end
 
-    RSpec.describe BreakdownSet do
+    RSpec.describe BreakdownSet, :intercept do
       it_behaves_like :span_scope_set
     end
   end

--- a/spec/elastic_apm/metrics/vm_set_spec.rb
+++ b/spec/elastic_apm/metrics/vm_set_spec.rb
@@ -2,10 +2,11 @@
 
 module ElasticAPM
   module Metrics
-    RSpec.describe VMSet do
+    RSpec.describe VMSet, :intercept do
       let(:config) { Config.new }
-
-      subject { described_class.new config }
+      subject { described_class.new  }
+      before { ElasticAPM.start(config) }
+      after { ElasticAPM.stop }
 
       describe 'collect' do
         context 'when disabled' do

--- a/spec/elastic_apm/metrics_spec.rb
+++ b/spec/elastic_apm/metrics_spec.rb
@@ -6,7 +6,8 @@ module ElasticAPM
   RSpec.describe Metrics do
     let(:config) { Config.new }
     let(:callback) { ->(_) {} }
-    subject { described_class.new(config, &callback) }
+    subject { described_class.new(&callback) }
+    before { allow(ElasticAPM).to receive(:config).and_return(config) }
 
     describe 'life cycle' do
       describe '#start' do
@@ -77,10 +78,10 @@ module ElasticAPM
     end
 
     context 'thread safety stress test', :mock_intake do
+      let(:config) { Config.new(metrics_interval: '100ms') }
       it 'handles multiple threads reporting and collecting at the same time' do
-        config = Config.new(metrics_interval: '100ms')
         queue = Queue.new
-        metrics = Metrics.new(config) { queue.push metricset }
+        metrics = Metrics.new { queue.push metricset }
         thread_count = 1_000
 
         names = Array.new(5).map do

--- a/spec/elastic_apm/normalizers/action_controller_spec.rb
+++ b/spec/elastic_apm/normalizers/action_controller_spec.rb
@@ -8,7 +8,7 @@ module ElasticAPM
     module ActionController
       RSpec.describe ProcessActionNormalizer do
         it 'registers for name' do
-          normalizers = Normalizers.build(nil)
+          normalizers = Normalizers.build
           subject = normalizers.for('process_action.action_controller')
 
           expect(subject).to be_a ProcessActionNormalizer
@@ -17,7 +17,7 @@ module ElasticAPM
         describe '#normalize' do
           it 'sets transaction name from payload' do
             instrumenter = double(Instrumenter)
-            subject = ProcessActionNormalizer.new nil
+            subject = ProcessActionNormalizer.new
             transaction = Transaction.new instrumenter,
               'Rack', config: Config.new
 

--- a/spec/elastic_apm/normalizers/action_view_spec.rb
+++ b/spec/elastic_apm/normalizers/action_view_spec.rb
@@ -7,11 +7,16 @@ module ElasticAPM
   module Normalizers
     RSpec.describe ActionView do
       let(:normalizers) do
-        config = Config.new.tap do |c|
+        Normalizers.build
+      end
+      
+      let(:config) do
+        Config.new.tap do |c|
           c.__view_paths = ['/var/www/app/views']
         end
-        Normalizers.build(config)
       end
+      
+      before { allow(ElasticAPM).to receive(:config).and_return(config) }
 
       shared_examples_for :action_view_normalizer do |key|
         describe '#normalize' do

--- a/spec/elastic_apm/normalizers/active_record_spec.rb
+++ b/spec/elastic_apm/normalizers/active_record_spec.rb
@@ -8,7 +8,7 @@ module ElasticAPM
     module ActiveRecord
       RSpec.describe SqlNormalizer do
         it 'registers for name' do
-          normalizers = Normalizers.build nil
+          normalizers = Normalizers.build
           subject = normalizers.for('sql.active_record')
           expect(subject).to be_a SqlNormalizer
         end
@@ -24,7 +24,7 @@ module ElasticAPM
             allow(::ActiveRecord::Base)
               .to receive(:connection_config) { { adapter: 'MySQL' } }
 
-            subject = SqlNormalizer.new nil
+            subject = SqlNormalizer.new
 
             _, _, subtype, =
               subject.normalize(nil, nil, sql: 'DROP * FROM users')
@@ -35,7 +35,7 @@ module ElasticAPM
 
         describe '#normalize' do
           let(:key) { 'sql.active_record' }
-          subject { SqlNormalizer.new nil }
+          subject { SqlNormalizer.new }
 
           def normalize_payload(payload)
             subject.normalize(nil, 'sql.active_record', payload)

--- a/spec/elastic_apm/normalizers_spec.rb
+++ b/spec/elastic_apm/normalizers_spec.rb
@@ -19,7 +19,7 @@ if enable
             register 'something'
           end
 
-          built = Normalizers.build nil
+          built = Normalizers.build
           expect(built.for('something')).to be_a TestNormalizer
           expect(built.keys).to include 'something'
         end

--- a/spec/elastic_apm/transport/connection/proxy_pipe_spec.rb
+++ b/spec/elastic_apm/transport/connection/proxy_pipe_spec.rb
@@ -3,6 +3,8 @@
 module ElasticAPM
   module Transport
     RSpec.describe Connection::ProxyPipe do
+      before { allow(ElasticAPM).to receive(:config).and_return(Config.new) }
+
       describe '.pipe' do
         it 'returns a reader and a writer' do
           begin

--- a/spec/elastic_apm/transport/connection_spec.rb
+++ b/spec/elastic_apm/transport/connection_spec.rb
@@ -212,6 +212,10 @@ module ElasticAPM
           Config.new(server_url: 'https://self-signed.badssl.com')
         end
 
+        before do
+          allow(ElasticAPM).to receive(:config).and_return(config)
+        end
+
         it 'is enabled by default' do
           expect(config.logger)
             .to receive(:error)

--- a/spec/elastic_apm/transport/connection_spec.rb
+++ b/spec/elastic_apm/transport/connection_spec.rb
@@ -6,7 +6,8 @@ module ElasticAPM
   module Transport
     RSpec.describe Connection do
       let(:config) { Config.new(http_compression: false) }
-      subject { described_class.new(config) }
+      subject { described_class.new }
+      before { allow(ElasticAPM).to receive(:config).and_return(config) }
 
       after { WebMock.reset! }
 
@@ -164,8 +165,8 @@ module ElasticAPM
         context 'and gzip off' do
           let(:config) { Config.new(http_compression: false) }
           let(:metadata) do
-            Serializers::MetadataSerializer.new(config).build(
-              Metadata.new(config)
+            Serializers::MetadataSerializer.new.build(
+              Metadata.new
             )
           end
 

--- a/spec/elastic_apm/transport/serializers/error_serializer_spec.rb
+++ b/spec/elastic_apm/transport/serializers/error_serializer_spec.rb
@@ -5,12 +5,14 @@ require 'spec_helper'
 module ElasticAPM
   module Transport
     module Serializers
-      RSpec.describe ErrorSerializer do
+      RSpec.describe ErrorSerializer, :intercept do
         let(:config) { Config.new }
         let(:agent) { Agent.new(config) }
-        let(:builder) { ErrorBuilder.new(agent) }
+        let(:builder) { ErrorBuilder.new }
+        before { ElasticAPM.start }
+        after { ElasticAPM.stop }
 
-        subject { described_class.new(config) }
+        subject { described_class.new }
 
         context 'with an exception', :mock_time do
           it 'matches format' do
@@ -118,7 +120,7 @@ module ElasticAPM
               error = with_agent do
                 ElasticAPM.with_transaction do
                   ErrorBuilder
-                    .new(ElasticAPM.agent)
+                    .new
                     .build_exception(actual_exception)
                 end
               end

--- a/spec/elastic_apm/transport/worker_spec.rb
+++ b/spec/elastic_apm/transport/worker_spec.rb
@@ -89,20 +89,20 @@ module ElasticAPM
       end
 
       describe '#process' do
-        it 'rescues exceptions' do
-          event = Transaction.new(
-            "What's in a name ⁉️",
-            (+'👏').force_encoding('ascii-8bit'),
-            config: config
-          )
+        it 'rescues exceptions', :mock_intake do
+          with_agent(config: config) do
+            event = Transaction.new(
+              "What's in a name ⁉️",
+              (+'👏').force_encoding('ascii-8bit'),
+              config: config
+            )
 
-          expect(config.logger).to receive(:error).twice.and_call_original
+            expect(ElasticAPM.config.logger).to receive(:error).twice.and_call_original
 
-          expect do
-            subject.process event
-          end.to_not raise_error
-
-          subject.connection.flush
+            expect do
+              subject.process event
+            end.to_not raise_error
+          end
         end
       end
     end

--- a/spec/elastic_apm_spec.rb
+++ b/spec/elastic_apm_spec.rb
@@ -328,5 +328,11 @@ RSpec.describe ElasticAPM do
 
       expect(ran).to be true
     end
+
+    describe '.config' do
+      it 'returns nil' do
+        expect(ElasticAPM.config).to be nil
+      end
+    end
   end
 end

--- a/spec/elastic_apm_spec.rb
+++ b/spec/elastic_apm_spec.rb
@@ -47,10 +47,18 @@ RSpec.describe ElasticAPM do
   context 'when running', :mock_intake do
     before do
       MockIntake.instance.stub!
-      ElasticAPM.start
+      ElasticAPM.start(config)
     end
 
+    let(:config) { ElasticAPM::Config.new }
+
     let(:agent) { ElasticAPM.agent }
+
+    describe '.config' do
+      it 'returns the agent config' do
+        expect(ElasticAPM.config).to be(config)
+      end
+    end
 
     describe '.log_ids' do
       context 'with no current_transaction' do

--- a/spec/support/with_agent.rb
+++ b/spec/support/with_agent.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module WithAgent
-  def with_agent(klass: ElasticAPM, args: [], config: config, **config_hash)
+  def with_agent(klass: ElasticAPM, args: [], config: nil, **config_hash)
     unless @mock_intake || @intercepted
       raise 'Using with_agent but neither MockIntake nor Intercepted'
     end

--- a/spec/support/with_agent.rb
+++ b/spec/support/with_agent.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module WithAgent
-  def with_agent(klass: ElasticAPM, args: [], **config)
+  def with_agent(klass: ElasticAPM, args: [], config: config, **config_hash)
     unless @mock_intake || @intercepted
       raise 'Using with_agent but neither MockIntake nor Intercepted'
     end
@@ -11,7 +11,11 @@ module WithAgent
         :get, %r{^http://localhost:8200/config/v1/agents/?$}
       ).to_return(body: '{}')
 
-    klass.start(*args, **config)
+    if config_hash
+      klass.start(*args, **config_hash)
+    else
+      klass.start(*args, config)
+    end
     yield
   ensure
     ElasticAPM.stop


### PR DESCRIPTION
This sets up the codebase to allow all/any options to be dynamically changed.

Closes #725 