### PR TITLE
Allow some config options to be dynamic

### DIFF
--- a/lib/elastic_apm.rb
+++ b/lib/elastic_apm.rb
@@ -32,6 +32,8 @@ require 'elastic_apm/grpc' if defined?(::GRPC)
 # ElasticAPM
 module ElasticAPM
   class << self
+    class AgentRequired < RuntimeError; end
+
     ### Life cycle
 
     # Starts the ElasticAPM Agent
@@ -65,6 +67,16 @@ module ElasticAPM
     # @return [Agent] Currently running [Agent] if any
     def agent
       Agent.instance
+    end
+
+    # Returns the config of the running agent.
+    #
+    # @return [Config] The config of the running agent.
+    # Returns nil if the agent is not running.
+    def config
+      raise AgentRequired unless agent
+      raise RuntimeError, 'Config for agent is missing' unless Agent.config
+      Agent.config
     end
 
     ### Metrics

--- a/lib/elastic_apm/agent.rb
+++ b/lib/elastic_apm/agent.rb
@@ -42,7 +42,11 @@ module ElasticAPM
           return
         end
 
-        @instance = new(config).start
+        # It's important that the @instance variable is set before
+        # calling #start. Objects rely on the config being available
+        # via ElasticAPM.agent.config while starting.
+        @instance = new(config)
+        @instance.start
       end
     end
 
@@ -59,9 +63,13 @@ module ElasticAPM
       !!@instance
     end
 
+    def self.config
+      @instance&.config
+    end
+
     def initialize(config)
       @stacktrace_builder = StacktraceBuilder.new(config)
-      @context_builder = ContextBuilder.new(config)
+      @context_builder = ContextBuilder.new
       @error_builder = ErrorBuilder.new(self)
 
       @central_config = CentralConfig.new(config)

--- a/lib/elastic_apm/agent.rb
+++ b/lib/elastic_apm/agent.rb
@@ -76,7 +76,6 @@ module ElasticAPM
       @transport = Transport::Base.new(config)
       @metrics = Metrics.new(config) { |event| enqueue event }
       @instrumenter = Instrumenter.new(
-        config,
         metrics: metrics,
         stacktrace_builder: stacktrace_builder
       ) { |event| enqueue event }

--- a/lib/elastic_apm/agent.rb
+++ b/lib/elastic_apm/agent.rb
@@ -70,7 +70,10 @@ module ElasticAPM
     def initialize(config)
       @stacktrace_builder = StacktraceBuilder.new(config)
       @context_builder = ContextBuilder.new
-      @error_builder = ErrorBuilder.new(default_labels: config.default_labels)
+      @error_builder = ErrorBuilder.new(
+        config,
+        stacktrace_builder: @stacktrace_builder
+      )
 
       @central_config = CentralConfig.new(config)
       @transport = Transport::Base.new(config)

--- a/lib/elastic_apm/agent.rb
+++ b/lib/elastic_apm/agent.rb
@@ -70,7 +70,7 @@ module ElasticAPM
     def initialize(config)
       @stacktrace_builder = StacktraceBuilder.new(config)
       @context_builder = ContextBuilder.new
-      @error_builder = ErrorBuilder.new(self)
+      @error_builder = ErrorBuilder.new(default_labels: config.default_labels)
 
       @central_config = CentralConfig.new(config)
       @transport = Transport::Base.new(config)

--- a/lib/elastic_apm/context_builder.rb
+++ b/lib/elastic_apm/context_builder.rb
@@ -6,12 +6,6 @@ module ElasticAPM
     MAX_BODY_LENGTH = 2048
     SKIPPED = '[SKIPPED]'
 
-    def initialize(config)
-      @config = config
-    end
-
-    attr_reader :config
-
     def build(rack_env:, for_type:)
       Context.new.tap do |context|
         apply_to_request(context, rack_env: rack_env, for_type: for_type)
@@ -43,7 +37,7 @@ module ElasticAPM
     end
 
     def should_capture_body?(for_type)
-      option = config.capture_body
+      option = config.capture_body?
 
       return true if option == 'all'
       return true if option == 'transactions' && for_type == :transaction
@@ -90,6 +84,10 @@ module ElasticAPM
     def build_http_version(rack_env)
       return unless (http_version = rack_env['HTTP_VERSION'])
       http_version.gsub(%r{HTTP/}, '')
+    end
+
+    def config
+      ElasticAPM.config
     end
   end
 end

--- a/lib/elastic_apm/error_builder.rb
+++ b/lib/elastic_apm/error_builder.rb
@@ -3,8 +3,9 @@
 module ElasticAPM
   # @api private
   class ErrorBuilder
-    def initialize(default_labels: nil)
-      @default_labels = default_labels
+    def initialize(config, stacktrace_builder:)
+      @default_labels = config.default_labels
+      @stacktrace_builder = stacktrace_builder
     end
 
     def build_exception(exception, context: nil, handled: true)
@@ -40,7 +41,7 @@ module ElasticAPM
 
     def add_stacktrace(error, kind, backtrace)
       stacktrace =
-        ElasticAPM.agent.stacktrace_builder.build(backtrace, type: :error)
+        @stacktrace_builder.build(backtrace, type: :error)
       return unless stacktrace
 
       case kind

--- a/lib/elastic_apm/error_builder.rb
+++ b/lib/elastic_apm/error_builder.rb
@@ -3,8 +3,8 @@
 module ElasticAPM
   # @api private
   class ErrorBuilder
-    def initialize(agent)
-      @agent = agent
+    def initialize(default_labels: nil)
+      @default_labels = default_labels
     end
 
     def build_exception(exception, context: nil, handled: true)
@@ -12,7 +12,7 @@ module ElasticAPM
       error.exception =
         Error::Exception.from_exception(exception, handled: handled)
 
-      Util.reverse_merge!(error.context.labels, @agent.config.default_labels)
+      Util.reverse_merge!(error.context.labels, @default_labels)
 
       if exception.backtrace
         add_stacktrace error, :exception, exception.backtrace
@@ -40,7 +40,7 @@ module ElasticAPM
 
     def add_stacktrace(error, kind, backtrace)
       stacktrace =
-        @agent.stacktrace_builder.build(backtrace, type: :error)
+        ElasticAPM.agent.stacktrace_builder.build(backtrace, type: :error)
       return unless stacktrace
 
       case kind

--- a/lib/elastic_apm/instrumenter.rb
+++ b/lib/elastic_apm/instrumenter.rb
@@ -39,8 +39,7 @@ module ElasticAPM
       end
     end
 
-    def initialize(config, metrics:, stacktrace_builder:, &enqueue)
-      @config = config
+    def initialize(metrics:, stacktrace_builder:, &enqueue)
       @stacktrace_builder = stacktrace_builder
       @enqueue = enqueue
       @metrics = metrics

--- a/lib/elastic_apm/logging.rb
+++ b/lib/elastic_apm/logging.rb
@@ -36,8 +36,8 @@ module ElasticAPM
     private
 
     def log(lvl, msg, *args)
-      return unless (logger = @config&.logger)
-      return unless LEVELS[lvl] >= (@config&.log_level || 0)
+      return unless (logger = config&.logger)
+      return unless LEVELS[lvl] >= (config&.log_level || 0)
 
       formatted_msg = prepend_prefix(format(msg.to_s, *args))
 
@@ -48,6 +48,10 @@ module ElasticAPM
 
     def prepend_prefix(str)
       "#{PREFIX}#{str}"
+    end
+
+    def config
+      ElasticAPM.config
     end
   end
 end

--- a/lib/elastic_apm/metadata.rb
+++ b/lib/elastic_apm/metadata.rb
@@ -4,9 +4,14 @@ module ElasticAPM
   # @api private
   class Metadata
     def initialize(config)
-      @service = ServiceInfo.new(config)
-      @process = ProcessInfo.new(config)
-      @system = SystemInfo.new(config)
+      @service = ServiceInfo.new(
+        service_name: config.service_name,
+        framework_name: config.framework_name,
+        framework_version: config.framework_version,
+        service_version: config.service_version
+      )
+      @process = ProcessInfo.new
+      @system = SystemInfo.new(hostname: config.hostname)
       @labels = config.global_labels
     end
 

--- a/lib/elastic_apm/metadata/process_info.rb
+++ b/lib/elastic_apm/metadata/process_info.rb
@@ -4,9 +4,7 @@ module ElasticAPM
   class Metadata
     # @api private
     class ProcessInfo
-      def initialize(config)
-        @config = config
-
+      def initialize
         @argv = ARGV
         @pid = $PID || Process.pid
         @title = $PROGRAM_NAME

--- a/lib/elastic_apm/metadata/service_info.rb
+++ b/lib/elastic_apm/metadata/service_info.rb
@@ -17,23 +17,31 @@ module ElasticAPM
       class Framework < Versioned; end
       class Language < Versioned; end
       class Runtime < Versioned; end
-      def initialize(config)
-        @config = config
-
-        @name = @config.service_name
-        @environment = @config.environment
+      def initialize(
+        service_name:,
+        framework_name:,
+        framework_version:,
+        service_version:
+      )
+        @name = service_name
         @agent = Agent.new(name: 'ruby', version: VERSION)
         @framework = Framework.new(
-          name: @config.framework_name,
-          version: @config.framework_version
+          name: framework_name,
+          version: framework_version
         )
         @language = Language.new(name: 'ruby', version: RUBY_VERSION)
         @runtime = lookup_runtime
-        @version = @config.service_version || Util.git_sha
+        @version = service_version || Util.git_sha
       end
 
-      attr_reader :name, :environment, :agent, :framework, :language, :runtime,
+      attr_reader :name, :agent, :framework, :language, :runtime,
         :version
+
+      def environment
+        # This value can be changed in the remote config so we
+        # get it via ElasticAPM
+        ElasticAPM.config.environment
+      end
 
       private
 

--- a/lib/elastic_apm/metadata/system_info.rb
+++ b/lib/elastic_apm/metadata/system_info.rb
@@ -4,10 +4,8 @@ module ElasticAPM
   class Metadata
     # @api private
     class SystemInfo
-      def initialize(config)
-        @config = config
-
-        @hostname = @config.hostname || `hostname`.chomp
+      def initialize(hostname:)
+        @hostname = hostname || `hostname`.chomp
         @architecture = gem_platform.cpu
         @platform = gem_platform.os
 

--- a/lib/elastic_apm/metrics/cpu_mem_set.rb
+++ b/lib/elastic_apm/metrics/cpu_mem_set.rb
@@ -49,8 +49,6 @@ module ElasticAPM
         read! # set @previous on boot
       end
 
-      attr_reader :config
-
       def collect
         read!
         super

--- a/lib/elastic_apm/metrics/set.rb
+++ b/lib/elastic_apm/metrics/set.rb
@@ -12,7 +12,7 @@ module ElasticAPM
       DISTINCT_LABEL_LIMIT = 1000
 
       def initialize(config)
-        @config = config
+        @disable_metrics = config.disable_metrics
         @metrics = {}
         @disabled = false
         @lock = Mutex.new
@@ -41,7 +41,7 @@ module ElasticAPM
       end
 
       def metric(kls, key, tags: nil, **args)
-        if @config.disable_metrics.any? { |p| p.match? key }
+        if @disable_metrics.any? { |p| p.match? key }
           return NOOP
         end
 

--- a/lib/elastic_apm/span.rb
+++ b/lib/elastic_apm/span.rb
@@ -120,7 +120,7 @@ module ElasticAPM
 
     def long_enough_for_stacktrace?
       min_duration =
-        @stacktrace_builder.config.span_frames_min_duration_us
+        ElasticAPM.config.span_frames_min_duration_us
 
       return true if min_duration < 0
       return false if min_duration == 0

--- a/lib/elastic_apm/subscriber.rb
+++ b/lib/elastic_apm/subscriber.rb
@@ -38,7 +38,9 @@ module ElasticAPM
         else
           name, type, subtype, action, context = normalized
 
-          ElasticAPM.start_span(
+          # We call #start_span on the agent, otherwise original_backtrace
+          # will be set on the span.
+          ElasticAPM.agent.start_span(
             name,
             type,
             subtype: subtype,

--- a/lib/elastic_apm/transport/base.rb
+++ b/lib/elastic_apm/transport/base.rb
@@ -25,7 +25,7 @@ module ElasticAPM
         @config = config
         @queue = SizedQueue.new(config.api_buffer_size)
 
-        @serializers = Serializers.new(config)
+        @serializers = Serializers.new
         @filters = Filters.new(config)
 
         @stopped = Concurrent::AtomicBoolean.new

--- a/lib/elastic_apm/transport/connection.rb
+++ b/lib/elastic_apm/transport/connection.rb
@@ -19,7 +19,6 @@ module ElasticAPM
       # requests have to be synchronized.
 
       def initialize(config)
-        @config = config
         @metadata = JSON.fast_generate(
           Serializers::MetadataSerializer.new.build(
             Metadata.new(config)
@@ -31,7 +30,7 @@ module ElasticAPM
 
       attr_reader :http
       def write(str)
-        return false if @config.disable_send
+        return false if config.disable_send
 
         begin
           bytes_written = 0
@@ -43,7 +42,7 @@ module ElasticAPM
             bytes_written = http.write(str)
           end
 
-          flush(:api_request_size) if bytes_written >= @config.api_request_size
+          flush(:api_request_size) if bytes_written >= config.api_request_size
         rescue IOError => e
           error('Connection error: %s', e.inspect)
           flush(:ioerror)
@@ -74,10 +73,10 @@ module ElasticAPM
       private
 
       def connect
-        schedule_closing if @config.api_request_time
+        schedule_closing if config.api_request_time
 
         @http =
-          Http.open(@config, @url).tap do |http|
+          Http.open(config, @url).tap do |http|
             http.write(@metadata)
           end
       end
@@ -86,9 +85,13 @@ module ElasticAPM
       def schedule_closing
         @close_task&.cancel
         @close_task =
-          Concurrent::ScheduledTask.execute(@config.api_request_time) do
+          Concurrent::ScheduledTask.execute(config.api_request_time) do
             flush(:timeout)
           end
+      end
+
+      def config
+        ElasticAPM.config
       end
     end
   end

--- a/lib/elastic_apm/transport/connection.rb
+++ b/lib/elastic_apm/transport/connection.rb
@@ -21,7 +21,7 @@ module ElasticAPM
       def initialize(config)
         @config = config
         @metadata = JSON.fast_generate(
-          Serializers::MetadataSerializer.new(config).build(
+          Serializers::MetadataSerializer.new.build(
             Metadata.new(config)
           )
         )

--- a/lib/elastic_apm/transport/connection/proxy_pipe.rb
+++ b/lib/elastic_apm/transport/connection/proxy_pipe.rb
@@ -27,7 +27,6 @@ module ElasticAPM
             @io = io
             @compress = compress
             @bytes_sent = Concurrent::AtomicFixnum.new(0)
-            @config = ElasticAPM.agent&.config # this is silly, fix Logging
 
             return unless compress
             enable_compression!

--- a/lib/elastic_apm/transport/filters/secrets_filter.rb
+++ b/lib/elastic_apm/transport/filters/secrets_filter.rb
@@ -24,7 +24,6 @@ module ElasticAPM
         ].freeze
 
         def initialize(config)
-          @config = config
           @key_filters =
             KEY_FILTERS +
             config.custom_key_filters +

--- a/lib/elastic_apm/transport/serializers.rb
+++ b/lib/elastic_apm/transport/serializers.rb
@@ -9,11 +9,6 @@ module ElasticAPM
 
       # @api private
       class Serializer
-        def initialize(config)
-          @config = config
-        end
-
-        attr_reader :config
 
         private
 
@@ -46,12 +41,12 @@ module ElasticAPM
 
       # @api private
       class Container
-        def initialize(config)
-          @transaction = Serializers::TransactionSerializer.new(config)
-          @span = Serializers::SpanSerializer.new(config)
-          @error = Serializers::ErrorSerializer.new(config)
-          @metadata = Serializers::MetadataSerializer.new(config)
-          @metricset = Serializers::MetricsetSerializer.new(config)
+        def initialize
+          @transaction = Serializers::TransactionSerializer.new
+          @span = Serializers::SpanSerializer.new
+          @error = Serializers::ErrorSerializer.new
+          @metadata = Serializers::MetadataSerializer.new
+          @metricset = Serializers::MetricsetSerializer.new
         end
 
         attr_reader :transaction, :span, :error, :metadata, :metricset
@@ -73,8 +68,8 @@ module ElasticAPM
         end
       end
 
-      def self.new(config)
-        Container.new(config)
+      def self.new
+        Container.new
       end
     end
   end

--- a/lib/elastic_apm/transport/serializers/error_serializer.rb
+++ b/lib/elastic_apm/transport/serializers/error_serializer.rb
@@ -6,7 +6,7 @@ module ElasticAPM
       # @api private
       class ErrorSerializer < Serializer
         def context_serializer
-          @context_serializer ||= ContextSerializer.new(config)
+          @context_serializer ||= ContextSerializer.new
         end
 
         def build(error)

--- a/lib/elastic_apm/transport/serializers/span_serializer.rb
+++ b/lib/elastic_apm/transport/serializers/span_serializer.rb
@@ -5,10 +5,10 @@ module ElasticAPM
     module Serializers
       # @api private
       class SpanSerializer < Serializer
-        def initialize(config)
+        def initialize
           super
 
-          @context_serializer = ContextSerializer.new(config)
+          @context_serializer = ContextSerializer.new
         end
 
         attr_reader :context_serializer

--- a/lib/elastic_apm/transport/serializers/transaction_serializer.rb
+++ b/lib/elastic_apm/transport/serializers/transaction_serializer.rb
@@ -6,7 +6,7 @@ module ElasticAPM
       # @api private
       class TransactionSerializer < Serializer
         def context_serializer
-          @context_serializer ||= ContextSerializer.new(config)
+          @context_serializer ||= ContextSerializer.new
         end
 
         def build(transaction)

--- a/lib/elastic_apm/transport/worker.rb
+++ b/lib/elastic_apm/transport/worker.rb
@@ -26,7 +26,6 @@ module ElasticAPM
         serializers:,
         filters:
       )
-        @config = config
         @queue = queue
 
         @serializers = serializers

--- a/spec/elastic_apm/agent_spec.rb
+++ b/spec/elastic_apm/agent_spec.rb
@@ -100,6 +100,10 @@ module ElasticAPM
     end
 
     context 'reporting', :intercept do
+      before { ElasticAPM.start(config) }
+      after { ElasticAPM.stop }
+      subject { ElasticAPM.agent }
+
       describe '#report' do
         it 'queues a request' do
           expect { subject.report(actual_exception) }

--- a/spec/elastic_apm/agent_spec.rb
+++ b/spec/elastic_apm/agent_spec.rb
@@ -16,6 +16,7 @@ module ElasticAPM
 
     context 'life cycle', :mock_intake do
       describe '.start' do
+        before { allow(ElasticAPM).to receive(:config).and_return(config) }
         it 'starts an instance and only one' do
           first_instance = Agent.start Config.new
           expect(Agent.instance).to_not be_nil
@@ -145,6 +146,7 @@ module ElasticAPM
     end
 
     context 'metrics', :mock_intake do
+      before { allow(ElasticAPM).to receive(:config).and_return(config) }
       it 'starts' do
         subject.start
         expect(subject.metrics).to be_running

--- a/spec/elastic_apm/context_builder_spec.rb
+++ b/spec/elastic_apm/context_builder_spec.rb
@@ -5,8 +5,7 @@ module ElasticAPM
     describe '#build' do
       let(:config) { Config.new }
       let(:subject) { described_class.new }
-      before { ElasticAPM.start(config) }
-      after { ElasticAPM.stop }
+      before { allow(ElasticAPM).to receive(:config).and_return(config) }
 
       it 'enriches request' do
         env = Rack::MockRequest.env_for(

--- a/spec/elastic_apm/context_builder_spec.rb
+++ b/spec/elastic_apm/context_builder_spec.rb
@@ -1,10 +1,12 @@
 # frozen_string_literal: true
 
 module ElasticAPM
-  RSpec.describe ContextBuilder do
+  RSpec.describe ContextBuilder, :intercept do
     describe '#build' do
       let(:config) { Config.new }
-      let(:subject) { described_class.new(config) }
+      let(:subject) { described_class.new }
+      before { ElasticAPM.start(config) }
+      after { ElasticAPM.stop }
 
       it 'enriches request' do
         env = Rack::MockRequest.env_for(

--- a/spec/elastic_apm/error_builder_spec.rb
+++ b/spec/elastic_apm/error_builder_spec.rb
@@ -7,6 +7,7 @@ module ElasticAPM
                  disable_send: true)
     end
     subject { ElasticAPM.agent.error_builder }
+    # We start an agent in this test so real request errors can be captured
     before { ElasticAPM.start(config) }
     after { ElasticAPM.stop }
 
@@ -34,13 +35,13 @@ module ElasticAPM
               ElasticAPM.build_context rack_env: env, for_type: :transaction
 
         transaction = ElasticAPM.with_transaction context: context do |txn|
-              ElasticAPM.set_label(:my_tag, '123')
-              ElasticAPM.set_custom_context(all_the_other_things: 'blah blah')
-              ElasticAPM.set_user(Struct.new(:id).new(321))
-              ElasticAPM.report actual_exception
+          ElasticAPM.set_label(:my_tag, '123')
+          ElasticAPM.set_custom_context(all_the_other_things: 'blah blah')
+          ElasticAPM.set_user(Struct.new(:id).new(321))
+          ElasticAPM.report actual_exception
 
-              txn
-            end
+          txn
+        end
 
         error = @intercepted.errors.last
         expect(error.transaction).to eq(sampled: true, type: 'custom')

--- a/spec/elastic_apm/instrumenter_spec.rb
+++ b/spec/elastic_apm/instrumenter_spec.rb
@@ -110,16 +110,16 @@ module ElasticAPM
 
       it 'reports metrics', :mock_time do
         subject.start_transaction('a_transaction', config: config)
-        travel 100
+        travel 150
         subject.start_span('a_span', 'a', subtype: 'b')
-        travel 100
+        travel 150
         subject.end_span
-        travel 100
+        travel 150
         subject.end_transaction('result')
 
         txn_set, = agent.metrics.get(:transaction).collect
 
-        expect(txn_set.samples[:'transaction.duration.sum.us']).to eq 300
+        expect(txn_set.samples[:'transaction.duration.sum.us']).to eq 450
         expect(txn_set.samples[:'transaction.duration.count']).to eq 1
         expect(txn_set.transaction).to match(
           name: 'a_transaction',
@@ -139,7 +139,7 @@ module ElasticAPM
         txn_self_time = brk_sets.find do |d|
           d.span&.fetch(:type) == 'app'
         end
-        expect(txn_self_time.samples[:'span.self_time.sum.us']).to eq 200
+        expect(txn_self_time.samples[:'span.self_time.sum.us']).to eq 300
         expect(txn_self_time.samples[:'span.self_time.count']).to eq 1
         expect(txn_self_time.transaction).to match(
           name: 'a_transaction',
@@ -148,7 +148,7 @@ module ElasticAPM
         expect(txn_self_time.span).to match(type: 'app', subtype: nil)
 
         spn_self_time = brk_sets.find { |d| d.span&.fetch(:type) == 'a' }
-        expect(spn_self_time.samples[:'span.self_time.sum.us']).to eq 100
+        expect(spn_self_time.samples[:'span.self_time.sum.us']).to eq 150
         expect(spn_self_time.samples[:'span.self_time.count']).to eq 1
         expect(spn_self_time.transaction).to match(
           name: 'a_transaction',

--- a/spec/elastic_apm/logging_spec.rb
+++ b/spec/elastic_apm/logging_spec.rb
@@ -10,6 +10,7 @@ module ElasticAPM
       def initialize(config)
         @config = config
       end
+      attr_reader :config
     end
 
     let(:config) do

--- a/spec/elastic_apm/metadata/process_info_spec.rb
+++ b/spec/elastic_apm/metadata/process_info_spec.rb
@@ -3,7 +3,7 @@
 module ElasticAPM
   RSpec.describe Metadata::ProcessInfo do
     describe '#initialize' do
-      subject { described_class.new(Config.new) }
+      subject { described_class.new }
 
       it 'knows about the process' do
         expect(subject.argv).to be_a Array

--- a/spec/elastic_apm/metadata/service_info_spec.rb
+++ b/spec/elastic_apm/metadata/service_info_spec.rb
@@ -5,7 +5,14 @@ require 'spec_helper'
 module ElasticAPM
   RSpec.describe Metadata::ServiceInfo do
     describe '#initialize' do
-      subject { described_class.new(Config.new) }
+      let(:config) { Config.new }
+      subject do
+        described_class.new(
+        service_name: config.service_name,
+        framework_name: config.framework_name,
+        framework_version: config.framework_version,
+        service_version: config.service_version)
+      end
 
       it 'knows the runtime (mri)', unless: RSpec::Support::Ruby.jruby? do
         expect(subject.runtime.name).to eq 'ruby'

--- a/spec/elastic_apm/metadata/system_info_spec.rb
+++ b/spec/elastic_apm/metadata/system_info_spec.rb
@@ -3,7 +3,8 @@
 module ElasticAPM
   RSpec.describe Metadata::SystemInfo do
     describe '#initialize' do
-      subject { described_class.new(Config.new) }
+      let(:config) { Config.new }
+      subject { described_class.new(hostname: config.hostname) }
 
       it 'has values' do
         %i[hostname architecture platform].each do |key|

--- a/spec/elastic_apm/metrics/set_spec.rb
+++ b/spec/elastic_apm/metrics/set_spec.rb
@@ -5,6 +5,8 @@ module ElasticAPM
     RSpec.describe Set do
       let(:config) { Config.new }
       subject { described_class.new config }
+      before { ElasticAPM.start(config) }
+      after { ElasticAPM.stop }
 
       describe 'disabled?' do
         it 'can be disabled' do

--- a/spec/elastic_apm/metrics/set_spec.rb
+++ b/spec/elastic_apm/metrics/set_spec.rb
@@ -5,8 +5,7 @@ module ElasticAPM
     RSpec.describe Set do
       let(:config) { Config.new }
       subject { described_class.new config }
-      before { ElasticAPM.start(config) }
-      after { ElasticAPM.stop }
+      before { allow(ElasticAPM).to receive(:config).and_return(config) }
 
       describe 'disabled?' do
         it 'can be disabled' do

--- a/spec/elastic_apm/metrics/vm_set_spec.rb
+++ b/spec/elastic_apm/metrics/vm_set_spec.rb
@@ -4,8 +4,7 @@ module ElasticAPM
   module Metrics
     RSpec.describe VMSet do
       let(:config) { Config.new }
-      before { ElasticAPM.start(config) }
-      after { ElasticAPM.stop }
+      before { allow(ElasticAPM).to receive(:config).and_return(config) }
 
       subject { described_class.new config }
 

--- a/spec/elastic_apm/metrics/vm_set_spec.rb
+++ b/spec/elastic_apm/metrics/vm_set_spec.rb
@@ -4,6 +4,8 @@ module ElasticAPM
   module Metrics
     RSpec.describe VMSet do
       let(:config) { Config.new }
+      before { ElasticAPM.start(config) }
+      after { ElasticAPM.stop }
 
       subject { described_class.new config }
 

--- a/spec/elastic_apm/metrics_spec.rb
+++ b/spec/elastic_apm/metrics_spec.rb
@@ -7,6 +7,7 @@ module ElasticAPM
     let(:config) { Config.new }
     let(:callback) { ->(_) {} }
     subject { described_class.new(config, &callback) }
+    before { allow(ElasticAPM).to receive(:config).and_return(config) }
 
     describe 'life cycle' do
       describe '#start' do

--- a/spec/elastic_apm/span_spec.rb
+++ b/spec/elastic_apm/span_spec.rb
@@ -10,6 +10,9 @@ module ElasticAPM
         trace_context: trace_context
       )
     end
+    let(:config) { Config.new(disable_send: true) }
+    before { ElasticAPM.start(config) }
+    after { ElasticAPM.stop }
 
     let(:trace_context) do
       TraceContext.parse("00-#{'1' * 32}-#{'2' * 16}-01")

--- a/spec/elastic_apm/subscriber_spec.rb
+++ b/spec/elastic_apm/subscriber_spec.rb
@@ -13,17 +13,16 @@ if enable
 
   module ElasticAPM
     RSpec.describe Subscriber, :mock_intake do
-      let(:config) { Config.new }
-      let(:agent) { Agent.new config }
+      let(:config) { { disable_send: true } }
 
       before do
         MockIntake.stub!
-        agent.start
+        ElasticAPM.start
       end
 
-      after { agent.stop }
+      after { ElasticAPM.stop }
 
-      subject { Subscriber.new(agent) }
+      subject { Subscriber.new(config) }
 
       describe '#register!' do
         it 'subscribes to AS::Notifications' do
@@ -48,7 +47,7 @@ if enable
 
       describe 'AS::Notifications API' do
         it 'adds spans from notifications', :intercept do
-          agent.start_transaction 'Test'
+          ElasticAPM.start_transaction 'Test'
 
           subject.start(
             'process_action.action_controller',
@@ -56,7 +55,7 @@ if enable
             controller: 'UsersController', action: 'index'
           )
 
-          span = agent.current_span
+          span = ElasticAPM.current_span
           expect(span).to be_running
           expect(span.name).to eq 'UsersController#index'
 
@@ -66,20 +65,19 @@ if enable
             nil
           )
 
-          agent.end_transaction
+          ElasticAPM.end_transaction
 
           expect(span).to_not be_running
           expect(span).to be_stopped
         end
 
         it 'ignores unknown notifications' do
-          agent = Agent.new Config.new(disable_send: true)
-          subject = Subscriber.new agent
-          agent.start_transaction 'Test'
+          subject = Subscriber.new config
+          ElasticAPM.start_transaction 'Test'
 
           expect do
             subject.start('unknown.notification', nil, {})
-          end.to_not change(agent, :current_span)
+          end.to_not change(ElasticAPM, :current_span)
         end
       end
     end

--- a/spec/elastic_apm/transport/base_spec.rb
+++ b/spec/elastic_apm/transport/base_spec.rb
@@ -18,6 +18,7 @@ module ElasticAPM
 
       describe '#stop' do
         let(:config) { Config.new(pool_size: 2) }
+        before { allow(ElasticAPM).to receive(:config).and_return(config) }
 
         it 'stops all workers', :mock_intake do
           subject.start

--- a/spec/elastic_apm/transport/connection/http_spec.rb
+++ b/spec/elastic_apm/transport/connection/http_spec.rb
@@ -6,6 +6,7 @@ module ElasticAPM
   module Transport
     RSpec.describe Connection::Http do
       after { WebMock.reset! }
+      before { allow(ElasticAPM).to receive(:config).and_return(config) }
 
       let(:config) { Config.new(http_compression: false) }
 

--- a/spec/elastic_apm/transport/connection/proxy_pipe_spec.rb
+++ b/spec/elastic_apm/transport/connection/proxy_pipe_spec.rb
@@ -3,6 +3,8 @@
 module ElasticAPM
   module Transport
     RSpec.describe Connection::ProxyPipe do
+      before { allow(ElasticAPM).to receive(:config).and_return(Config.new) }
+
       describe '.pipe' do
         it 'returns a reader and a writer' do
           begin

--- a/spec/elastic_apm/transport/connection_spec.rb
+++ b/spec/elastic_apm/transport/connection_spec.rb
@@ -7,6 +7,7 @@ module ElasticAPM
     RSpec.describe Connection do
       let(:config) { Config.new(http_compression: false) }
       subject { described_class.new(config) }
+      before { allow(ElasticAPM).to receive(:config).and_return(config) }
 
       after { WebMock.reset! }
 

--- a/spec/elastic_apm/transport/connection_spec.rb
+++ b/spec/elastic_apm/transport/connection_spec.rb
@@ -164,7 +164,7 @@ module ElasticAPM
         context 'and gzip off' do
           let(:config) { Config.new(http_compression: false) }
           let(:metadata) do
-            Serializers::MetadataSerializer.new(config).build(
+            Serializers::MetadataSerializer.new.build(
               Metadata.new(config)
             )
           end

--- a/spec/elastic_apm/transport/serializers/context_serializer_spec.rb
+++ b/spec/elastic_apm/transport/serializers/context_serializer_spec.rb
@@ -4,8 +4,7 @@ module ElasticAPM
   module Transport
     module Serializers
       RSpec.describe ContextSerializer do
-        let(:config) { Config.new }
-        subject { described_class.new config }
+        subject { described_class.new }
 
         it 'converts response.status_code to int' do
           context = Context.new

--- a/spec/elastic_apm/transport/serializers/error_serializer_spec.rb
+++ b/spec/elastic_apm/transport/serializers/error_serializer_spec.rb
@@ -6,13 +6,12 @@ module ElasticAPM
   module Transport
     module Serializers
       RSpec.describe ErrorSerializer do
-        let(:config) { Config.new }
         let(:builder) { ElasticAPM.agent.error_builder }
         let(:config) { Config.new(disable_send: true) }
         before { ElasticAPM.start(config) }
         after { ElasticAPM.stop }
 
-        subject { described_class.new(config) }
+        subject { described_class.new }
 
         context 'with an exception', :mock_time do
           it 'matches format' do

--- a/spec/elastic_apm/transport/serializers/error_serializer_spec.rb
+++ b/spec/elastic_apm/transport/serializers/error_serializer_spec.rb
@@ -93,6 +93,9 @@ module ElasticAPM
           end
 
           context 'with a context' do
+            before { ElasticAPM.start(disable_send: true) }
+            after { ElasticAPM.stop }
+
             it 'includes context' do
               env = Rack::MockRequest.env_for('/')
 

--- a/spec/elastic_apm/transport/serializers/error_serializer_spec.rb
+++ b/spec/elastic_apm/transport/serializers/error_serializer_spec.rb
@@ -8,6 +8,8 @@ module ElasticAPM
       RSpec.describe ErrorSerializer do
         let(:builder) { ElasticAPM.agent.error_builder }
         let(:config) { Config.new(disable_send: true) }
+        # We start an agent so that we can easily get an error_builder,
+        # context_builder, and start a transaction below
         before { ElasticAPM.start(config) }
         after { ElasticAPM.stop }
 

--- a/spec/elastic_apm/transport/serializers/metadata_serializer_spec.rb
+++ b/spec/elastic_apm/transport/serializers/metadata_serializer_spec.rb
@@ -8,9 +8,11 @@ module ElasticAPM
       RSpec.describe MetadataSerializer do
         subject { described_class.new }
         let(:result) { subject.build(metadata) }
+        before { allow(ElasticAPM).to receive(:config).and_return(config) }
 
         describe '#build' do
-          let(:metadata) { Metadata.new Config.new }
+          let(:config) { Config.new }
+          let(:metadata) { Metadata.new config }
 
           it 'is a bunch of hashes and no labels' do
             expect(result[:metadata]).to be_a Hash
@@ -21,9 +23,8 @@ module ElasticAPM
           end
 
           context 'when there are global_labels' do
-            let(:metadata) do
-              Metadata.new Config.new(global_labels: { apples: 'oranges' })
-            end
+            let(:config) { Config.new(global_labels: { apples: 'oranges' }) }
+            let(:metadata) { Metadata.new config }
 
             it 'is a bunch of hashes' do
               expect(result[:metadata]).to be_a Hash

--- a/spec/elastic_apm/transport/serializers/metadata_serializer_spec.rb
+++ b/spec/elastic_apm/transport/serializers/metadata_serializer_spec.rb
@@ -6,7 +6,7 @@ module ElasticAPM
   module Transport
     module Serializers
       RSpec.describe MetadataSerializer do
-        subject { described_class.new Config.new }
+        subject { described_class.new }
         let(:result) { subject.build(metadata) }
 
         describe '#build' do

--- a/spec/elastic_apm/transport/serializers/metricset_serializer_spec.rb
+++ b/spec/elastic_apm/transport/serializers/metricset_serializer_spec.rb
@@ -6,7 +6,7 @@ module ElasticAPM
   module Transport
     module Serializers
       RSpec.describe MetricsetSerializer do
-        subject { described_class.new Config.new }
+        subject { described_class.new }
 
         describe '#build' do
           let(:set) { Metricset.new(thing: 1.0, other: 321, tags: { a: 1 }) }

--- a/spec/elastic_apm/transport/serializers/span_serializer_spec.rb
+++ b/spec/elastic_apm/transport/serializers/span_serializer_spec.rb
@@ -7,7 +7,7 @@ module ElasticAPM
     module Serializers
       RSpec.describe SpanSerializer do
         let(:config) { Config.new }
-        subject { described_class.new config }
+        subject { described_class.new }
 
         describe '#build', :mock_time do
           let(:transaction) { Transaction.new(config: config).start }

--- a/spec/elastic_apm/transport/serializers/transaction_serializer_spec.rb
+++ b/spec/elastic_apm/transport/serializers/transaction_serializer_spec.rb
@@ -6,7 +6,7 @@ module ElasticAPM
   module Transport
     module Serializers
       RSpec.describe TransactionSerializer do
-        let(:builder) { described_class.new Config.new }
+        let(:builder) { described_class.new }
 
         before do
           @mock_uuid = SecureRandom.uuid
@@ -61,7 +61,7 @@ module ElasticAPM
               end
 
               transaction = @intercepted.transactions.first
-              result = described_class.new(Config.new).build(transaction)
+              result = described_class.new.build(transaction)
 
               span_count = result.dig(:transaction, :span_count)
               expect(span_count[:started]).to be 3

--- a/spec/elastic_apm/transport/serializers_spec.rb
+++ b/spec/elastic_apm/transport/serializers_spec.rb
@@ -4,9 +4,9 @@ module ElasticAPM
   module Transport
     RSpec.describe Serializers do
       let(:config) { Config.new }
-      subject { described_class.new(config) }
+      subject { described_class.new }
 
-      it 'initializes with config' do
+      it 'initializes serializers' do
         expect(subject).to be_a Serializers::Container
         expect(subject.transaction).to be_a Serializers::TransactionSerializer
         expect(subject.span).to be_a Serializers::SpanSerializer
@@ -46,7 +46,7 @@ module ElasticAPM
 
         it 'truncates values to 1024 chars' do
           obj = { test: 'X' * 2000 }
-          thing = TruncateSerializer.new(Config.new).serialize(obj)
+          thing = TruncateSerializer.new.serialize(obj)
           expect(thing[:test]).to match(/X{1023}…/)
         end
       end
@@ -60,7 +60,7 @@ module ElasticAPM
 
         it 'truncates values to 1024 chars' do
           obj = { test: 'X' * 2000 }
-          thing = TruncateSerializer.new(Config.new).serialize(obj)
+          thing = TruncateSerializer.new.serialize(obj)
           expect(thing[:test]).to match(/X{1023}…/)
         end
       end
@@ -76,7 +76,7 @@ module ElasticAPM
           obj = { string: 'X' * 2000,
                   bool: true,
                   numerical: 123 }
-          thing = TruncateSerializer.new(Config.new).serialize(obj)
+          thing = TruncateSerializer.new.serialize(obj)
           expect(thing[:string]).to match(/X{1023}…/)
           expect(thing[:bool]).to match(true)
           expect(thing[:numerical]).to match(123)

--- a/spec/elastic_apm/transport/worker_spec.rb
+++ b/spec/elastic_apm/transport/worker_spec.rb
@@ -7,7 +7,7 @@ module ElasticAPM
     RSpec.describe Worker do
       let(:config) { Config.new }
       let(:queue) { Queue.new }
-      let(:serializers) { Serializers.new config }
+      let(:serializers) { Serializers.new }
       let(:filters) { Filters.new config }
       subject do
         described_class.new(

--- a/spec/elastic_apm/transport/worker_spec.rb
+++ b/spec/elastic_apm/transport/worker_spec.rb
@@ -17,6 +17,7 @@ module ElasticAPM
           filters: filters
         )
       end
+      before { allow(ElasticAPM).to receive(:config).and_return(config) }
 
       describe '#initialize' do
         its(:filters) { should be_a Filters::Container }


### PR DESCRIPTION
Another approach than that in #740

Using `ElasticAPM.config` only from objects referring to dynamic options (i.e. remote config options). Other objects will take the config options they need in `#initialize`. 

These are the remote config options in 7.7 and where they are used in the agent:
**`active`**: `Agent.start`
**`api_request_size`**: `Connection`
**`api_request_time`**: `Connection`
**`capture_body`**: `ContextBuilder`
**`capture_headers`**: `ContextBuilder`
**`log_level`**: `Logging`
**`span_frames_min_duration`**: `Subscriber`, `ElasticAPM.start_span`, `Instrumenter#start_span`, `Span#long_enough_for_stacktrace?`
**`transaction_max_spans`**: `Transaction#inc_started_spans!`
**`transaction_sample_rate`**: `Instrumenter#random_sample?`


This describes each class and the rationale behind changing/not changing it:


**`ContextBuilder`**: This object is created in `Agent#initialize` and accepts `config` as an arg. The only config options it needs are dynamic ones: `capture_body` and `capture_headers`.
Changes:
- removed `config` being passed into `ContextBuilder#initialize`
- made references to `config` via `ElasticAPM.config`

**`ErrorBuilder`**: This object is created in `Agent#initialize` and was accepting the agent as an arg. It needs the `config` for the `default_labels`.
Changes:
- pass in `config` and set `@default_labels` using it.
- pass in `stacktrace_builder` and set it to an instance variable instead of holding a `@agent` instance variable

**`Instrumenter`**: This object is created in `Agent#initialize` and accepts `config` as an arg.
Changes:
- Removed `#initialize` arg and reference to `config` because the only need for it is via a `transaction` object

**`Metadata`**: This object is created in `Connection` and `UserAgent` and accepts `config` as an arg
Changes:
- No changes to method signature, the other objects created in `#initialize` need a `config`

**`Set`**: This object is created in many places, as there are other classes inheriting from it. It accepts `config` as an arg to `#initialize`.
Changes:
- Removed instance variable `@config`
- Only needs to know disabled metrics, so get the value from the `config` in `#initialize`

**`Normalizers`**: Leave this as-is. The `ActionView` normalizer needs a value from the `config`, so we keep an instance variable reference to it.
Changes: NONE

**`Subscriber`**: Previously had an instance variable reference to `@agent` so `current_span` and `current_transaction` could be evaluated.
Changes:
- Pass in config, as it is needed to initialize Normalizers in `Subscriber#initialize`
- Remove reference to `@agent` and get `current_span` and `current_transaction` via `ElasticAPM` instead

**`UserAgent`**: No change. `config` must be passed into `User#initialize` so that `Metadata` can be created.

**`ServiceInfo`**: This object needs to extract many values from the config. It also needs to get the `environment` value from the `config`, which is dynamic.
Changes:
- Removed instance variable `@config` and extract all necessary values from the `config` in `ServiceInfo#initialize`
- Define a method `environment` that gets the `config` via `ElasticAPM` and get the `environment` from there so it's dynamic.

**`SystemInfo`**: The only value needed by this object is `hostname`
Changes:
- Removed instance variable `@config` reference
- Pass in `hostname` value explicitly

**`ProcessInfo`**:
Changes:
- Removed instance variable `@config` reference, the object doesn't need `config` at all

**`BreakdownSet`**: `config` is passed to `BreakdownSet#initialize`. No reference is kept, it is used to disable breakdown metrics
Changes: NONE

**`Set`**: This object only needs to know what metrics are disabled from the config.
Changes:
- Removed instance variable `@config` reference and instead save the values of `config.disable_metrics` in `Set#initialize`

**`ActionView`**: This object needs the `@config.__view_paths` value
Changes: NONE

**`Base`**: This object needs to keep a reference to the `@config` so that Workers can be created.
Changes: NONE

**`Connection`**: This class needs `config` to be passed to `Connection#initialize` so that the `metadata` object can be created with it. It doesn't need to keep a `@config` instance variable because other config options needed are dynamic.
Changes:
- Removed `@config` instance variable
- Refer to `ElasticAPM.config` for dynamic values `api_request_time` and `api_request_size`

**`Filters`**: `config` is passed to `Filters#initialize` because it is needed to created `SecretsFilter`
Changes: NONE

**`SecretsFilter`**: `config` is needed for the `custom_key_filters` and `santize_field_names` values.
Changes:
- Removed `@config` instance variable and just extract the needed values in `SecretsFilter#initialize`

**`Headers`**: `config` is needed to instantiate `UserAgent` and so that headers can be merged.
Changes: NONE

**`Serializers`**: No serializers need a value from the `config`
Changes:
- Removed `config` from `#initialize` method signature 

**`Logging`**: The only reference to `config` from this module is to get the `log_level`. 
Changes:
- Reference `config` via `ElasticAPM.config` because `log_level` is a dynamic option.

**`CPUMemSet`**: There was a `attr_reader` for `config`
Changes:
- Remove `attr_reader` for `config`

**`Worker`**: This class itself doesn't need a reference to `config`. It was used for the `Logging` module. The `config` is passed to `Worker#initialize` because `Connection#initialize` needs it.
Changes:
- Removed `@config` instance variable and just pass the `config` to `Connection#initialize` in `Worker#initialize`

**`Http`**: This class needs a reference to `config` so that a client can be created.
Changes: NONE

Closes #725 