### PR TITLE
ci(jenkins): disable stages for only docs

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -59,14 +59,23 @@ pipeline {
         deleteDir()
         gitCheckout(basedir: "${BASE_DIR}", githubNotifyFirstTimeContributor: true, reference: "${env.REFERENCE_REPO}")
         stash allowEmpty: true, name: 'source', useDefaultExcludes: false
+        script {
+          dir("${BASE_DIR}"){
+            // Skip all the stages except docs for PR's with asciidoc changes only
+            env.ONLY_DOCS = isGitRegionMatch(patterns: [ '.*\\.asciidoc' ], comparator: 'regexp', shouldMatchAll: true)
+          }
+        }
       }
     }
     stage('Sanity checks') {
       when {
         beforeAgent true
-        anyOf {
-          not { changeRequest() }
-          expression { return params.Run_As_Master_Branch }
+        allOf {
+          expression { return env.ONLY_DOCS == "false" }
+          anyOf {
+            not { changeRequest() }
+            expression { return params.Run_As_Master_Branch }
+          }
         }
       }
       options { skipDefaultCheckout() }
@@ -91,6 +100,10 @@ pipeline {
     */
     stage('Test') {
       options { skipDefaultCheckout() }
+      when {
+        beforeAgent true
+        expression { return env.ONLY_DOCS == "false" }
+      }
       steps {
         withGithubNotify(context: 'Tests', tab: 'tests') {
           deleteDir()
@@ -113,9 +126,12 @@ pipeline {
       agent none
       when {
         beforeAgent true
-        anyOf {
-          changeRequest()
-          expression { return !params.Run_As_Master_Branch }
+        allOf {
+          expression { return env.ONLY_DOCS == "false" }
+          anyOf {
+            changeRequest()
+            expression { return !params.Run_As_Master_Branch }
+          }
         }
       }
       steps {

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -61,8 +61,8 @@ pipeline {
         stash allowEmpty: true, name: 'source', useDefaultExcludes: false
         script {
           dir("${BASE_DIR}"){
-            // Skip all the stages except docs for PR's with asciidoc changes only
-            env.ONLY_DOCS = isGitRegionMatch(patterns: [ '.*\\.asciidoc' ], comparator: 'regexp', shouldMatchAll: true)
+            // Skip all the stages except docs for PR's with asciidoc and md changes only
+            env.ONLY_DOCS = isGitRegionMatch(patterns: [ '.*\\.(asciidoc|md)' ], shouldMatchAll: true)
           }
         }
       }


### PR DESCRIPTION
### What

- Any builds for any branch or PR that only contains changes related to the asciidoc then it will skip all the stages but the `checkout`

### Why

Docs validation happens with the `elasticsearch-ci/docs` therefore there is no need to validate anything in our end.