### PR TITLE
Swap out config options object when values are updated

### DIFF
--- a/lib/elastic_apm/central_config.rb
+++ b/lib/elastic_apm/central_config.rb
@@ -81,14 +81,10 @@ module ElasticAPM
         update[key] = @modified_options.delete(key)
       end
 
-      update_config(update)
+      @config.replace_options(update)
     end
 
     private
-
-    def update_config(new_options)
-      @config = config.dup.tap { |new_config| new_config.assign(new_options) }
-    end
 
     # rubocop:disable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
     def handle_success(resp)

--- a/lib/elastic_apm/config.rb
+++ b/lib/elastic_apm/config.rb
@@ -138,6 +138,13 @@ module ElasticAPM
       warn "The option `#{name}' has been removed."
     end
 
+    def replace_options(new_options)
+      return unless new_options
+      options_copy = @options.dup
+      new_options.each { |key, value| options_copy.fetch(key.to_sym).set(value) }
+      @options = options_copy
+    end
+
     def app=(app)
       case app_type?(app)
       when :sinatra

--- a/lib/elastic_apm/instrumenter.rb
+++ b/lib/elastic_apm/instrumenter.rb
@@ -178,7 +178,7 @@ module ElasticAPM
         sync: sync
       )
 
-      if backtrace && transaction.config.span_frames_min_duration?
+      if backtrace && transaction.span_frames_min_duration
         span.original_backtrace = backtrace
       end
 
@@ -234,7 +234,7 @@ module ElasticAPM
     end
 
     def update_transaction_metrics(transaction)
-      return unless transaction.config.collect_metrics?
+      return unless transaction.collect_metrics
 
       tags = {
         'transaction.name': transaction.name,
@@ -252,7 +252,7 @@ module ElasticAPM
       ).inc!
 
       return unless transaction.sampled?
-      return unless transaction.config.breakdown_metrics?
+      return unless transaction.breakdown_metrics
 
       @metrics.get(:breakdown).counter(
         :'transaction.breakdown.count',
@@ -273,7 +273,7 @@ module ElasticAPM
     end
 
     def update_span_metrics(span)
-      return unless span.transaction.config.breakdown_metrics?
+      return unless span.transaction.breakdown_metrics
 
       tags = {
         'span.type': span.type,

--- a/lib/elastic_apm/normalizers/grape/endpoint_run.rb
+++ b/lib/elastic_apm/normalizers/grape/endpoint_run.rb
@@ -33,7 +33,7 @@ module ElasticAPM
         private
 
         def transaction_from_host_app?(transaction)
-          transaction.config.framework_name != FRAMEWORK_NAME
+          transaction.framework_name != FRAMEWORK_NAME
         end
 
         def endpoint(env)

--- a/spec/elastic_apm/transaction_spec.rb
+++ b/spec/elastic_apm/transaction_spec.rb
@@ -13,7 +13,11 @@ module ElasticAPM
       it { should be_sampled }
       its(:trace_context) { should be_a TraceContext }
       its(:context) { should be_a Context }
-      its(:config) { should be_a Config }
+      its(:span_frames_min_duration) { should be_a Float }
+      its(:collect_metrics) { should be true }
+      its(:breakdown_metrics) { should be true }
+      its(:framework_name) { should be nil }
+      its(:transaction_max_spans) { should be_a Integer }
       its(:started_spans) { should be 0 }
       its(:dropped_spans) { should be 0 }
       its(:notifications) { should be_empty }


### PR DESCRIPTION
This is another approach to supporting dynamic config options. 
It swaps out the `config`'s `options` object for a new one when options are updated.