### PR TITLE
Log the updated options from central config in addition to cumulative…

### DIFF
--- a/lib/elastic_apm/central_config.rb
+++ b/lib/elastic_apm/central_config.rb
@@ -100,9 +100,10 @@ module ElasticAPM
           assign(update)
         end
 
-        if @modified_options.any?
+        if update && update.any?
           info 'Updated config from Kibana'
-          debug 'Modified: %s', @modified_options.inspect
+          debug 'Modified: %s', update.inspect
+          debug 'Modified original options: %s', @modified_options.inspect
         end
       end
 

--- a/spec/elastic_apm/central_config_spec.rb
+++ b/spec/elastic_apm/central_config_spec.rb
@@ -4,7 +4,11 @@ module ElasticAPM
   RSpec.describe CentralConfig do
     after { WebMock.reset! }
 
-    let(:config) { Config.new service_name: 'MyApp' }
+    let(:config) do
+      Config.new(service_name: 'MyApp',
+                 log_level: Logger::DEBUG
+      )
+    end
     subject { described_class.new(config) }
 
     describe '#start' do
@@ -33,6 +37,7 @@ module ElasticAPM
       it 'queries APM Server and applies config' do
         req_stub = stub_response({ transaction_sample_rate: '0.5' })
         expect(config.logger).to receive(:info)
+        expect(config.logger).to receive(:debug).twice
 
         subject.fetch_and_apply_config
         subject.promise.wait


### PR DESCRIPTION
With this change, info and debug messages will only be logged if there have just been updates to the config via the remote config.

The logs will now look like this:
```
INFO -- : [ElasticAPM] Updated config from Kibana
DEBUG -- : [ElasticAPM] Modified: {"transaction_sample_rate"=>"0.5"}
DEBUG -- : [ElasticAPM] Modified original options: {"transaction_sample_rate"=>1.0}
```
Note that the message `[ElasticAPM] Modified original options: {...}` is unchanged by this PR but it will only be logged now when there has just been an update to the config. Previously it would be logged whenever the remote config was fetched and there had been an option modified at some point since the agent was started.

Closes #752 