### PR TITLE
Check if env variable exists before setting up SimpleCov

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,7 +1,10 @@
 # frozen_string_literal: true
-require 'simplecov'
-SimpleCov.coverage_dir("coverage/matrix_results/" + ENV["TEST_MATRIX"])
-SimpleCov.start { add_filter('/spec/') }
+
+if ENV["TEST_MATRIX"]
+  require 'simplecov'
+  SimpleCov.coverage_dir("coverage/matrix_results/" + ENV["TEST_MATRIX"])
+  SimpleCov.start { add_filter('/spec/') }
+end
 
 ENV['RAILS_ENV'] = ENV['RACK_ENV'] = 'test'
 


### PR DESCRIPTION
`ENV["TEST_MATRIX"]` is defined on Jenkins so there's no problem with this code in CI.
When running tests locally, there is an error because the env variable doesn't exist.

```
$ rspec

An error occurred while loading spec_helper.
Failure/Error: SimpleCov.coverage_dir("coverage/matrix_results/" + ENV["TEST_MATRIX"])

TypeError:
  no implicit conversion of nil into String
# ./spec/spec_helper.rb:3:in `+'
# ./spec/spec_helper.rb:3:in `<top (required)>'
No examples found.
```