### PR TITLE
Config values set to false should be false, not nil

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -49,6 +49,7 @@ endif::[]
 ===== Fixed
 
 - Ensure that the log level is updated for the config's logger when value is changed {pull}755[#755]
+- Set config `false` values to `false`, not `nil` {pull}761[#761]
 
 [[release-notes-3.6.0]]
 ==== 3.6.0 (2020-03-10)

--- a/lib/elastic_apm/config/options.rb
+++ b/lib/elastic_apm/config/options.rb
@@ -35,7 +35,7 @@ module ElasticAPM
 
         # rubocop:disable Metrics/CyclomaticComplexity
         def normalize(val)
-          return unless val
+          return if val.nil?
 
           if @converter
             return @converter.call(val)

--- a/spec/elastic_apm/config_spec.rb
+++ b/spec/elastic_apm/config_spec.rb
@@ -194,6 +194,16 @@ module ElasticAPM
       end
     end
 
+    context 'boolean values' do
+      subject { Config.new }
+
+      it 'allows false to be set' do
+        subject.capture_headers = false
+        expect(subject.capture_headers).to eq(false)
+        expect(subject.capture_headers?).to eq(false)
+      end
+    end
+
     context 'DEPRECATED' do
       describe 'default_tags' do
         subject { Config.new }


### PR DESCRIPTION
I noticed this minor issue when implementing support for `enabled`. The config sets a `false` option to `nil`, not `false`. Effectively, the two are the same but setting the option to `nil` is not "correct" and rather a sideffect of calling `Option#set` with a `false` value.