### PR TITLE
Ensure that the running agent's config is used when restarted

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -50,6 +50,7 @@ endif::[]
 
 - Ensure that the log level is updated for the config's logger when value is changed {pull}755[#755]
 - Set config `false` values to `false`, not `nil` {pull}761[#761]
+- Ensure that the previously running agent's config is used in `ElasticAPM.restart` {pull}763[#763]
 
 [float]
 ===== Added

--- a/lib/elastic_apm.rb
+++ b/lib/elastic_apm.rb
@@ -51,7 +51,7 @@ module ElasticAPM
     # one, if it is provided.
     # Starts the agent if it is not running.
     # Stops and starts the agent if it is running.
-    def restart(config = {})
+    def restart(config = nil)
       config ||= agent&.config
       stop if running?
       start(config)

--- a/spec/elastic_apm_spec.rb
+++ b/spec/elastic_apm_spec.rb
@@ -36,8 +36,17 @@ RSpec.describe ElasticAPM do
       end
     end
     context 'when a new config is passed' do
+      before { ElasticAPM.start }
       it 'restarts the agent with the new config' do
         ElasticAPM.restart(api_buffer_size: 10)
+        expect(ElasticAPM::Agent).to be_running
+        expect(ElasticAPM.agent.config.api_buffer_size).to be(10)
+      end
+    end
+    context 'when no new config is passed' do
+      before { ElasticAPM.start(api_buffer_size: 10) }
+      it 'restarts the agent with the same config' do
+        ElasticAPM.restart
         expect(ElasticAPM::Agent).to be_running
         expect(ElasticAPM.agent.config.api_buffer_size).to be(10)
       end


### PR DESCRIPTION
This fixes a bug with the `ElasticAPM.restart` method: if the method is called with no config passed in, the previously running agent's config will not be used, though it should be.

Closes #764