### PR TITLE
Add tests and adjustments to classes that can be restarted

### DIFF
--- a/lib/elastic_apm/instrumenter.rb
+++ b/lib/elastic_apm/instrumenter.rb
@@ -52,6 +52,9 @@ module ElasticAPM
 
     def start
       debug 'Starting instrumenter'
+      # We call register! on @subscriber in case the
+      # instrumenter was stopped and started again
+      @subscriber&.register!
     end
 
     def stop

--- a/lib/elastic_apm/transport/base.rb
+++ b/lib/elastic_apm/transport/base.rb
@@ -39,11 +39,13 @@ module ElasticAPM
 
       def start
         debug '%s: Starting Transport', pid_str
+        # Set @stopped to false first, in case transport is restarted;
+        # ensure_worker_count requires @stopped to be false
+        # ~estolfo
+        @stopped.make_false unless @stopped.false?
 
         ensure_watcher_running
         ensure_worker_count
-
-        @stopped.make_false unless @stopped.false?
       end
 
       def stop
@@ -145,7 +147,8 @@ module ElasticAPM
             thread.kill
           end
 
-          @workers.clear
+          # Maintain the @worker array size for when transport is restarted
+          @workers.fill(nil)
         end
       end
 

--- a/spec/elastic_apm/central_config_spec.rb
+++ b/spec/elastic_apm/central_config_spec.rb
@@ -33,6 +33,20 @@ module ElasticAPM
       end
     end
 
+    describe 'stop and start again' do
+      before do
+        subject.start
+        subject.stop
+      end
+      after { subject.stop }
+      it 'restarts fetching the config' do
+        req_stub = stub_response({ transaction_sample_rate: '0.5' })
+        subject.start
+        subject.promise.wait
+        expect(req_stub).to have_been_requested.at_least_once
+      end
+    end
+
     describe '#fetch_and_apply_config' do
       it 'queries APM Server and applies config' do
         req_stub = stub_response({ transaction_sample_rate: '0.5' })

--- a/spec/elastic_apm/central_config_spec.rb
+++ b/spec/elastic_apm/central_config_spec.rb
@@ -6,8 +6,7 @@ module ElasticAPM
 
     let(:config) do
       Config.new(service_name: 'MyApp',
-                 log_level: Logger::DEBUG
-      )
+                 log_level: Logger::DEBUG)
     end
     subject { described_class.new(config) }
 
@@ -39,6 +38,7 @@ module ElasticAPM
         subject.stop
       end
       after { subject.stop }
+
       it 'restarts fetching the config' do
         req_stub = stub_response({ transaction_sample_rate: '0.5' })
         subject.start

--- a/spec/elastic_apm/instrumenter_spec.rb
+++ b/spec/elastic_apm/instrumenter_spec.rb
@@ -47,10 +47,11 @@ module ElasticAPM
 
         before do
           subject.subscriber = subscriber
-
           subject.start_transaction(config: config)
           subject.stop
         end
+        after { subject.stop }
+
         it 're-registers the subscriber' do
           expect(subscriber).to receive(:register!)
           subject.start

--- a/spec/elastic_apm/instrumenter_spec.rb
+++ b/spec/elastic_apm/instrumenter_spec.rb
@@ -41,6 +41,21 @@ module ElasticAPM
           expect(subscriber).to have_received(:unregister!)
         end
       end
+
+      describe 'stop and start again' do
+        let(:subscriber) { double(register!: true, unregister!: true) }
+
+        before do
+          subject.subscriber = subscriber
+
+          subject.start_transaction(config: config)
+          subject.stop
+        end
+        it 're-registers the subscriber' do
+          expect(subscriber).to receive(:register!)
+          subject.start
+        end
+      end
     end
 
     describe '#start_transaction' do

--- a/spec/elastic_apm/metrics_spec.rb
+++ b/spec/elastic_apm/metrics_spec.rb
@@ -22,6 +22,15 @@ module ElasticAPM
         end
       end
 
+      describe 'stop and start again' do
+        it 'restarts collecting metrics' do
+          subject.start
+          subject.stop
+          subject.start
+          expect(subject.instance_variable_get(:@timer_task)).to be_running
+        end
+      end
+
       context 'when disabled' do
         let(:config) { Config.new metrics_interval: '0s' }
 
@@ -78,9 +87,6 @@ module ElasticAPM
 
     context 'thread safety stress test', :mock_intake do
       it 'handles multiple threads reporting and collecting at the same time' do
-        config = Config.new(metrics_interval: '100ms')
-        queue = Queue.new
-        metrics = Metrics.new(config) { queue.push metricset }
         thread_count = 1_000
 
         names = Array.new(5).map do

--- a/spec/elastic_apm/metrics_spec.rb
+++ b/spec/elastic_apm/metrics_spec.rb
@@ -23,9 +23,13 @@ module ElasticAPM
       end
 
       describe 'stop and start again' do
-        it 'restarts collecting metrics' do
+        before do
           subject.start
           subject.stop
+        end
+        after { subject.stop }
+
+        it 'restarts collecting metrics' do
           subject.start
           expect(subject.instance_variable_get(:@timer_task)).to be_running
         end

--- a/spec/elastic_apm/transport/base_spec.rb
+++ b/spec/elastic_apm/transport/base_spec.rb
@@ -32,7 +32,7 @@ module ElasticAPM
 
           wait_for transactions: 6
 
-          expect(subject.send(:workers).length).to be 0
+          expect(subject.send(:workers)).to eq([nil, nil])
         end
       end
 
@@ -60,6 +60,19 @@ module ElasticAPM
 
             expect(subject.queue.length).to be 5
           end
+        end
+      end
+
+      describe 'stop and start again' do
+        before do
+          subject.start
+          subject.stop
+          subject.start
+        end
+        after { subject.stop }
+        it 'starts the worker threads again' do
+          expect(subject.send(:workers).length).to be 1
+          expect(['sleep', 'run']).to include(subject.send(:workers)[0].status)
         end
       end
     end

--- a/spec/elastic_apm/transport/base_spec.rb
+++ b/spec/elastic_apm/transport/base_spec.rb
@@ -70,9 +70,10 @@ module ElasticAPM
           subject.start
         end
         after { subject.stop }
+
         it 'starts the worker threads again' do
           expect(subject.send(:workers).length).to be 1
-          expect(['sleep', 'run']).to include(subject.send(:workers)[0].status)
+          expect(%w[sleep run]).to include(subject.send(:workers)[0].status)
         end
       end
     end


### PR DESCRIPTION
Some objects required adjustments so that they could reliably be stopped and started again. 
These changes are necessarily in order to handle forking in web servers with master/worker architecture.

Related to #724 