### PR TITLE
Updates to Resque support and documentation

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -51,6 +51,7 @@ endif::[]
 - Ensure that the log level is updated for the config's logger when value is changed {pull}755[#755]
 - Set config `false` values to `false`, not `nil` {pull}761[#761]
 - Ensure that the previously running agent's config is used in `ElasticAPM.restart` {pull}763[#763]
+- Handle the Resque spy's payload class value being a String or Class and update docs {pull}768[#768]
 
 [float]
 ===== Added

--- a/docs/supported-technologies.asciidoc
+++ b/docs/supported-technologies.asciidoc
@@ -113,6 +113,9 @@ I, [XXX #81227]  INFO -- : Running before_first_fork hooks
 D, [XXX #81227] DEBUG -- : Starting ElasticAPM agent
 ----
 
+Also be sure to set the Resque environment variable `RUN_AT_EXIT_HOOKS` to `true`. Otherwise, the fork may be
+terminated before the agent has a chance to send all the fork's events to the APM server.
+
 [float]
 [[supported-technologies-grpc]]
 === gRPC

--- a/lib/elastic_apm/spies/resque.rb
+++ b/lib/elastic_apm/spies/resque.rb
@@ -23,7 +23,7 @@ module ElasticAPM
           alias :perform_without_elastic_apm :perform
 
           def perform
-            name = @payload && @payload['class']&.name
+            name = @payload && @payload['class']&.to_s
             transaction = ElasticAPM.start_transaction(name, TYPE)
             perform_without_elastic_apm
             transaction.done 'success'


### PR DESCRIPTION
While testing a solution to handle master-worker architectures, I found an occasional error in the resque spy when the `@payload` `class` value is a String, not a `Class` object.

Also, I discovered that Resque calls `exit!` when terminating a fork, which bypasses `at_exit` hooks. If the agent's `at_exit` hook is not called, the events aren't flushed so some may not make it to the APM server. Therefore, users must set the Resque env variable `RUN_AT_EXIT_HOOKS` to `true` in order to ensure that all agent events created in a fork are sent to the APM server.