### PR TITLE
Ensure that a new central config fetch is scheduled after network error

### DIFF
--- a/lib/elastic_apm/central_config.rb
+++ b/lib/elastic_apm/central_config.rb
@@ -148,7 +148,7 @@ module ElasticAPM
     def schedule_next_fetch(resp = nil)
       headers = resp&.headers
       seconds =
-        if headers['Cache-Control']
+        if headers && headers['Cache-Control']
           CacheControl.new(headers['Cache-Control']).max_age
         else
           DEFAULT_MAX_AGE


### PR DESCRIPTION
Closes #771 

Maybe a better solution would be to refactor and use a `TimerTask`. See the issue description.