### PR TITLE
ci: comment PRs with the build status

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -1,5 +1,5 @@
 #!/usr/bin/env groovy
-@Library('apm@current') _
+@Library('apm@test/tests-reporting') _
 
 import co.elastic.matrix.*
 import groovy.transform.Field

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -1,5 +1,5 @@
 #!/usr/bin/env groovy
-@Library('apm@test/tests-reporting') _
+@Library('apm@current') _
 
 import co.elastic.matrix.*
 import groovy.transform.Field

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -284,7 +284,7 @@ pipeline {
   }
   post {
     cleanup {
-      notifyBuildResult(downstreamJobs: rubyDownstreamJobs)
+      notifyBuildResult(prComment: true, downstreamJobs: rubyDownstreamJobs)
     }
   }
 }


### PR DESCRIPTION
## What does this PR do?

Enhance the build reporting with a message in the PR that contains the build status for the last commit. It does reuse the message.

## Why is it important?

One place to analyse the build status

## How to test this PR locally

See the comments that are generated on the fly