### PR TITLE
ci(jenkins): avoid converge if only docs

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -273,6 +273,10 @@ pipeline {
       }
     }
     stage('Coverage converge') {
+      when {
+        beforeAgent true
+        expression { return env.ONLY_DOCS == "false" }
+      }
       steps{
         dir("${BASE_DIR}"){
           unpack_artifacts(rubyDownstreamJobs)


### PR DESCRIPTION
## What does this pull request do?

Fix a corner case with PRs that only affect docs

## Why is it important?

To avoid failing the build 

## Related issues

See https://github.com/elastic/apm-agent-ruby/pull/778