### PR TITLE
Detect forking and restart all tasks/background threads

### DIFF
--- a/lib/elastic_apm/agent.rb
+++ b/lib/elastic_apm/agent.rb
@@ -270,6 +270,9 @@ module ElasticAPM
 
     def detect_forking!
       return if @pid == Process.pid
+
+      config.logger.debug "Detected forking,
+        restarting threads in process [PID:#{Process.pid}]"
       central_config.handle_forking!
       transport.handle_forking!
       instrumenter.handle_forking!

--- a/lib/elastic_apm/agent.rb
+++ b/lib/elastic_apm/agent.rb
@@ -273,7 +273,7 @@ module ElasticAPM
       central_config.handle_forking!
       transport.handle_forking!
       instrumenter.handle_forking!
-      #metrics.handle_forking!
+      metrics.handle_forking!
       @pid = Process.pid
     end
   end

--- a/lib/elastic_apm/agent.rb
+++ b/lib/elastic_apm/agent.rb
@@ -89,6 +89,7 @@ module ElasticAPM
         metrics: metrics,
         stacktrace_builder: stacktrace_builder
       ) { |event| enqueue event }
+      @pid = Process.pid
     end
 
     attr_reader(
@@ -163,6 +164,8 @@ module ElasticAPM
       trace_context: nil
     )
       return unless config.recording?
+      detect_forking!
+
       instrumenter.start_transaction(
         name,
         type,
@@ -263,6 +266,15 @@ module ElasticAPM
 
     def inspect
       super.split.first + '>'
+    end
+
+    def detect_forking!
+      return if @pid == Process.pid
+      #central_config.handle_forking!
+      transport.handle_forking!
+      #instrumenter.handle_forking!
+      #metrics.handle_forking!
+      @pid = Process.pid
     end
   end
 end

--- a/lib/elastic_apm/agent.rb
+++ b/lib/elastic_apm/agent.rb
@@ -191,6 +191,8 @@ module ElasticAPM
       parent: nil,
       sync: nil
     )
+      detect_forking!
+
       # We don't check config.recording? because the span
       # will not be created if there's no transaction.
       # We want to use the recording value from the config
@@ -233,6 +235,7 @@ module ElasticAPM
 
     def report(exception, context: nil, handled: true)
       return unless config.recording?
+      detect_forking!
       return if config.filter_exception_types.include?(exception.class.to_s)
 
       error = @error_builder.build_exception(
@@ -246,6 +249,8 @@ module ElasticAPM
 
     def report_message(message, context: nil, backtrace: nil, **attrs)
       return unless config.recording?
+      detect_forking!
+
       error = @error_builder.build_log(
         message,
         context: context,

--- a/lib/elastic_apm/agent.rb
+++ b/lib/elastic_apm/agent.rb
@@ -278,10 +278,12 @@ module ElasticAPM
 
       config.logger.debug "Detected forking,
         restarting threads in process [PID:#{Process.pid}]"
+
       central_config.handle_forking!
       transport.handle_forking!
       instrumenter.handle_forking!
       metrics.handle_forking!
+
       @pid = Process.pid
     end
   end

--- a/lib/elastic_apm/agent.rb
+++ b/lib/elastic_apm/agent.rb
@@ -272,7 +272,7 @@ module ElasticAPM
       return if @pid == Process.pid
       central_config.handle_forking!
       transport.handle_forking!
-      #instrumenter.handle_forking!
+      instrumenter.handle_forking!
       #metrics.handle_forking!
       @pid = Process.pid
     end

--- a/lib/elastic_apm/agent.rb
+++ b/lib/elastic_apm/agent.rb
@@ -270,7 +270,7 @@ module ElasticAPM
 
     def detect_forking!
       return if @pid == Process.pid
-      #central_config.handle_forking!
+      central_config.handle_forking!
       transport.handle_forking!
       #instrumenter.handle_forking!
       #metrics.handle_forking!

--- a/lib/elastic_apm/central_config.rb
+++ b/lib/elastic_apm/central_config.rb
@@ -104,7 +104,7 @@ module ElasticAPM
     def handle_forking!
       # A Concurrent::ScheduledTask has no way to detect if the internal
       # thread used to schedule the task has died. When forked, the state
-      # of the ScheduledTask could still be `processing`, although its
+      # of the ScheduledTask could still be `pending`, although its
       # internal thread has died. Therefore, our only option is to
       # forcibly reset the task when forked. ~estolfo
       @scheduled_task.reset

--- a/lib/elastic_apm/central_config.rb
+++ b/lib/elastic_apm/central_config.rb
@@ -101,6 +101,15 @@ module ElasticAPM
       @config.replace_options(update)
     end
 
+    def handle_forking!
+      # A Concurrent::ScheduledTask has no way to detect if the internal
+      # thread used to schedule the task has died. When forked, the state
+      # of the ScheduledTask could still be `processing`, although its
+      # internal thread has died. Therefore, our only option is to
+      # forcibly reset the task when forked. ~estolfo
+      @scheduled_task.reset
+    end
+
     private
 
     # rubocop:disable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity

--- a/lib/elastic_apm/central_config.rb
+++ b/lib/elastic_apm/central_config.rb
@@ -102,12 +102,8 @@ module ElasticAPM
     end
 
     def handle_forking!
-      # A Concurrent::ScheduledTask has no way to detect if the internal
-      # thread used to schedule the task has died. When forked, the state
-      # of the ScheduledTask could still be `pending`, although its
-      # internal thread has died. Therefore, our only option is to
-      # forcibly reset the task when forked. ~estolfo
-      schedule_next_fetch
+      stop
+      start
     end
 
     private

--- a/lib/elastic_apm/central_config.rb
+++ b/lib/elastic_apm/central_config.rb
@@ -107,7 +107,7 @@ module ElasticAPM
       # of the ScheduledTask could still be `pending`, although its
       # internal thread has died. Therefore, our only option is to
       # forcibly reset the task when forked. ~estolfo
-      @scheduled_task.reset
+      schedule_next_fetch
     end
 
     private

--- a/lib/elastic_apm/instrumenter.rb
+++ b/lib/elastic_apm/instrumenter.rb
@@ -83,6 +83,11 @@ module ElasticAPM
       @subscriber&.unregister!
     end
 
+    def handle_forking!
+      stop
+      start
+    end
+
     def subscriber=(subscriber)
       debug 'Registering subscriber'
       @subscriber = subscriber

--- a/lib/elastic_apm/spies/resque.rb
+++ b/lib/elastic_apm/spies/resque.rb
@@ -46,7 +46,7 @@ module ElasticAPM
             transaction.done 'success'
           rescue ::Exception => e
             ElasticAPM.report(e, handled: false)
-            transaction.done 'error'
+            transaction.done 'error' if transaction
             raise
           ensure
             ElasticAPM.end_transaction

--- a/lib/elastic_apm/spies/resque.rb
+++ b/lib/elastic_apm/spies/resque.rb
@@ -26,13 +26,6 @@ module ElasticAPM
 
       def install
         install_perform_spy
-        install_after_fork_hook
-      end
-
-      def install_after_fork_hook
-        ::Resque.after_fork do
-          ElasticAPM.restart
-        end
       end
 
       def install_perform_spy

--- a/lib/elastic_apm/transport/base.rb
+++ b/lib/elastic_apm/transport/base.rb
@@ -101,7 +101,7 @@ module ElasticAPM
         # used to monitor the execution interval has died. This is a
         # limitation of the Concurrent::TimerTask object. Ideally we'd be
         # able to restart the TimerTask, but we can't. Therefore, our only option
-        # when forked is to shutdown the task and create a new one.
+        # when forked is to shutdown the task and create a new one. ~estolfo
         stop_watcher
         ensure_worker_count
         create_watcher

--- a/lib/elastic_apm/transport/base.rb
+++ b/lib/elastic_apm/transport/base.rb
@@ -96,12 +96,9 @@ module ElasticAPM
       end
 
       def handle_forking!
-        # Note that you can't simply check watcher.running? because it will only
-        # return the state of the TimerTask, not whether the internal thread
-        # used to monitor the execution interval has died. This is a
-        # limitation of the Concurrent::TimerTask object. Ideally we'd be
-        # able to restart the TimerTask, but we can't. Therefore, our only option
-        # when forked is to shutdown the task and create a new one. ~estolfo
+        # We can't just stop and start again because the StopMessage
+        # will then be the first message processed when the transport is
+        # restarted.
         stop_watcher
         ensure_worker_count
         create_watcher

--- a/spec/elastic_apm/agent_spec.rb
+++ b/spec/elastic_apm/agent_spec.rb
@@ -182,5 +182,22 @@ module ElasticAPM
         end.to change(subject.transport.filters, :length).by 1
       end
     end
+
+    context 'when the process is forked' do
+      around do |ex|
+        subject.start
+        ex.run
+        subject.stop
+      end
+
+      it 'calls handle_forking! on all associated objects' do
+        allow(Process).to receive(:pid).and_return(1)
+        expect(subject.central_config).to receive(:handle_forking!)
+        expect(subject.transport).to receive(:handle_forking!)
+        expect(subject.instrumenter).to receive(:handle_forking!)
+        expect(subject.metrics).to receive(:handle_forking!)
+        subject.report_message('Everything went boom')
+      end
+    end
   end
 end

--- a/spec/elastic_apm/agent_spec.rb
+++ b/spec/elastic_apm/agent_spec.rb
@@ -192,10 +192,12 @@ module ElasticAPM
 
       it 'calls handle_forking! on all associated objects' do
         allow(Process).to receive(:pid).and_return(1)
+
         expect(subject.central_config).to receive(:handle_forking!)
         expect(subject.transport).to receive(:handle_forking!)
         expect(subject.instrumenter).to receive(:handle_forking!)
         expect(subject.metrics).to receive(:handle_forking!)
+
         subject.report_message('Everything went boom')
       end
     end

--- a/spec/elastic_apm/central_config_spec.rb
+++ b/spec/elastic_apm/central_config_spec.rb
@@ -273,6 +273,17 @@ module ElasticAPM
       end
     end
 
+    describe '#handle_forking!' do
+      it 'reschedules the scheduled task' do
+        req_stub = stub_response({ transaction_sample_rate: '0.5' })
+        subject.handle_forking!
+        subject.promise.wait
+        expect(subject.scheduled_task).to be_pending
+        expect(req_stub).to have_been_requested.at_least_once
+        subject.stop
+      end
+    end
+
     def stub_response(body, request: {}, response: {}, error: nil)
       url = 'http://localhost:8200/config/v1/agents?service.name=MyApp'
 

--- a/spec/elastic_apm/central_config_spec.rb
+++ b/spec/elastic_apm/central_config_spec.rb
@@ -276,10 +276,12 @@ module ElasticAPM
     describe '#handle_forking!' do
       it 'reschedules the scheduled task' do
         req_stub = stub_response({ transaction_sample_rate: '0.5' })
+
         subject.handle_forking!
         subject.promise.wait
         expect(subject.scheduled_task).to be_pending
         expect(req_stub).to have_been_requested.at_least_once
+
         subject.stop
       end
     end

--- a/spec/elastic_apm/instrumenter_spec.rb
+++ b/spec/elastic_apm/instrumenter_spec.rb
@@ -395,8 +395,10 @@ module ElasticAPM
       it 'restarts with the subscriber still registered' do
         subject.start
         subject.subscriber = subscriber
+
         expect(subscriber).to receive(:register!)
         subject.handle_forking!
+
         subject.stop
       end
     end

--- a/spec/elastic_apm/instrumenter_spec.rb
+++ b/spec/elastic_apm/instrumenter_spec.rb
@@ -389,5 +389,16 @@ module ElasticAPM
         expect(user.username).to eq 'abe'
       end
     end
+
+    describe '#handle_forking!' do
+      let(:subscriber) { double(register!: true, unregister!: true) }
+      it 'restarts with the subscriber still registered' do
+        subject.start
+        subject.subscriber = subscriber
+        expect(subscriber).to receive(:register!)
+        subject.handle_forking!
+        subject.stop
+      end
+    end
   end
 end

--- a/spec/elastic_apm/metrics_spec.rb
+++ b/spec/elastic_apm/metrics_spec.rb
@@ -165,5 +165,24 @@ module ElasticAPM
         expect(samples['c_with_tags']['value']).to be > 0
       end
     end
+
+    describe '#handle_forking!' do
+      before do
+        subject.handle_forking!
+      end
+      after { subject.stop }
+
+      it 'restarts the TimerTask' do
+        expect(subject.instance_variable_get(:@timer_task)).to be_running
+      end
+
+      context 'when not collecting metrics' do
+        let(:config) { Config.new(metrics_interval: 0) }
+
+        it 'does not create a TimerTask' do
+          expect(subject.instance_variable_get(:@timer_task)).to be nil
+        end
+      end
+    end
   end
 end

--- a/spec/elastic_apm/transport/base_spec.rb
+++ b/spec/elastic_apm/transport/base_spec.rb
@@ -93,6 +93,19 @@ module ElasticAPM
           expect(%w[sleep run]).to include(subject.send(:workers)[0].status)
         end
       end
+
+      describe '#handle_forking!' do
+        it 'boots the workers and watcher' do
+          subject.handle_forking!
+
+          expect(subject.watcher).to be_a(Concurrent::TimerTask)
+          expect(subject.watcher).to be_running
+          expect(subject.workers.size).to eq 1
+          expect(subject.workers.first).to be_alive
+
+          subject.stop
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
Todo:

- [x] Write tests
- [x] Call `detect_forking!` in each method that creates an event
- [x] Document changes in PR description
- [x] Update Resque implementation
- [x] Show findings from Resque tests and tests with Puma
- [x] Benchmark

[Puma test](https://gist.github.com/estolfo/55f5aae66caff4a2aa81c7cba3543718)
[Transport test](https://gist.github.com/estolfo/3285809388b94b77e83169be9ae80088)

**Transport**: 
- The previous solution for handling forking didn't work because in some cases, the process would be forked, events created, and then the forked process would be terminated before the watcher had a chance to bring up the workers. This was the case with a library like Resque that has potentially short-lived forks.
- We can't just stop and start again because the StopMessage will then be the first message processed when the transport is restarted.
- We also don't need a watcher mutex anymore because methods called on the watcher object won't come from different threads. Previously, `ensure_watcher_running` was called via `#submit`, which could be called from separate threads.

CentralConfig:
- It's "safe" to stop and start it again because the `scheduled_task` will be cancel, then recreated.

Instrumenter:
- There are no background threads, so it's fine to stop and start again.

Metrics:
- As the code comment says, ideally we'd be able to check if the timer task died and restart it but the `Concurrent::TimerTask` API does not have a way to detect if the internal thread has died. So we stop and start `Metrics` again. `@sets` is memoized in `#start` so that it's not recreated when `Metrics` is stopped and started again.

Benchmarks:
```
(master) $ FRAMEWORK=rails-6.0 bench/benchmark.rb
-- create_table(:posts, {:force=>true})
   -> 0.0080s
                      user     system      total        real
with agent:      21.338486   3.983200  25.321686 ( 24.874574)
without agent:   12.976541   2.314433  15.290974 ( 15.626493)

(forking-2) $ FRAMEWORK=rails-6.0 bench/benchmark.rb
-- create_table(:posts, {:force=>true})
   -> 0.0182s
                      user     system      total        real
with agent:      20.871092   3.956547  24.827639 ( 24.374119)
without agent:   11.765376   2.073324  13.838700 ( 13.869019)
```