### PR TITLE
Put env var config for rails on the main page

### DIFF
--- a/docs/getting-started-rails.asciidoc
+++ b/docs/getting-started-rails.asciidoc
@@ -25,4 +25,6 @@ server_url: http://localhost:8200
 secret_token: ''
 ----
 
+Or if you prefer environment variables, skip the file and set `ELASTIC_APM_SERVER_URL` and `ELASTIC_APM_SECRET_TOKEN` in your local or server environment.
+
 This automatically sets up error logging and performance tracking but of course there are knobs to turn if you'd like to. See <<configuration>>.


### PR DESCRIPTION
## What does this pull request do?

Updates Rails getting started docs.

## Why is it important?

I finally set up elastic apm for safecast.org.

When doing so I landed on https://www.elastic.co/guide/en/apm/agent/ruby/current/getting-started-rails.html pushes you toward `config/elastic_apm.yml` but I don’t think people really want to check in their token if they can avoid it.

I tried env substitution in the file, but that led to CI errors (https://app.circleci.com/pipelines/github/Safecast/safecastapi/415/workflows/33c23466-cca2-4266-84e6-c4b877c4b0ee/jobs/897).

I thought it would be nice if `ELASTIC_APM_SERVER_URL` and `ELASTIC_APM_SECRET_TOKEN` were front-and-center.