### PR TITLE
ci: reduce log verbosity

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -19,7 +19,7 @@ pipeline {
   environment {
     REPO = 'apm-agent-ruby'
     BASE_DIR = "src/github.com/elastic/${env.REPO}"
-    PIPELINE_LOG_LEVEL='DEBUG'
+    PIPELINE_LOG_LEVEL = 'INFO'
     NOTIFY_TO = credentials('notify-to')
     JOB_GCS_BUCKET = credentials('gcs-bucket')
     CODECOV_SECRET = 'secret/apm-team/ci/apm-agent-ruby-codecov'


### PR DESCRIPTION
## What does this pull request do?

Reduce verbosity in the CI build logs

## Why is it important?

Not needed so far. Otherwise the 100 lines log details are not relevant.

![image](https://user-images.githubusercontent.com/2871786/80972178-b6c45900-8e15-11ea-8ea1-a11377cfa21c.png)
