### PR TITLE
ci: aggregate downstream test results

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -340,8 +340,7 @@ def runBenchmark(version){
 }
 
 def runJob(String rubyVersion, int sleep = 1){
-  def buildFailed = false
-  def buildObject, ret
+  def buildObject, ret, buildNumber, buildName
   def branch = env.CHANGE_ID?.trim() ? env.CHANGE_TARGET : env.BRANCH_NAME
   def jobName = "${env.DOWNSTREAM_PIPELINE}/${env.BRANCH_NAME}"
   try {
@@ -354,28 +353,25 @@ def runJob(String rubyVersion, int sleep = 1){
                         ],
                         quietPeriod: quiet)
     ret = buildObject
+    buildName = buildObject.getProjectName()
+    buildNumber = buildObject.getNumber()?.toString()
   } catch(e) {
     log(level: 'DEBUG', text: "There was an error when running the build ${e}")
     rubyTasksFailed = true
-    buildFailed = true
     ret = e
+    buildName = e.getProjectName()
+    buildNumber = e.getNumber()?.toString()
+    warnError("Downstream Failed '${rubyVersion}'") {
+      error("Downstream job for '${rubyVersion}' failed")
+    }
   } finally {
     rubyDownstreamJobs["${rubyVersion}"] = ret
     // Aggregate test results from downstream jobs.
-    buildNumber = buildObject?.getNumber()?.toString()
-    buildName = buildObject?.getProjectName()
-    log(level: 'DEBUG', text: "build ${buildName?.trim()}  ${buildNumber?.trim()}")
+    log(level: 'DEBUG', text: "build ${buildName?.trim()} ${buildNumber?.trim()}")
     dir(rubyVersion) {
       copyArtifacts(projectName: jobName, filter: '**/ruby-agent-junit.xml', selector: specific(buildNumber: buildNumber))
     }
     junit(testResults: "${rubyVersion}/**/ruby-agent-junit.xml", allowEmptyResults: true, keepLongStdio: true)
-
-    // Let's report the failure in the stage at the very end.
-    if (buildFailed) {
-      warnError("Downstream Failed '${rubyVersion}'") {
-        error("Downstream job for '${rubyVersion}' failed")
-      }
-    }
   }
 }
 

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -281,7 +281,7 @@ pipeline {
         dir("${BASE_DIR}"){
           unpack_artifacts(rubyDownstreamJobs)
           sh(script: "./spec/scripts/coverage_converge.sh")
-          cobertura coberturaReportFile: "coverage/coverage.xml"        
+          cobertura coberturaReportFile: "coverage/coverage.xml"
         }
       }
     }
@@ -339,6 +339,7 @@ def runBenchmark(version){
 }
 
 def runJob(String rubyVersion, int sleep = 1){
+  def buildFailed = false
   def buildObject
   def branch = env.CHANGE_ID?.trim() ? env.CHANGE_TARGET : env.BRANCH_NAME
   def jobName = "apm-agent-ruby/apm-agent-ruby-downstream/${env.BRANCH_NAME}"
@@ -353,20 +354,25 @@ def runJob(String rubyVersion, int sleep = 1){
                         quietPeriod: quiet)
   } catch(e) {
     rubyTasksFailed = true
+    buildFailed = true
     buildObject = e
-    warnError('Downstream Failed') {
-      error("Downstream job for '${rubyVersion}' failed")
-    }
   } finally {
     dir(rubyVersion) {
       copyArtifacts(projectName: jobName, 
-                    excludes: 'coverage/**/*.*', 
+                    includes: '**/ruby-agent-junit.xml',
                     selector: specific(buildNumber: buildObject.number.toString()))
     }
     // Aggregate test results from downstream jobs.
     junit(testResults: "${rubyVersion}/**/ruby-agent-junit.xml", allowEmptyResults: true, keepLongStdio: true)
     archiveArtifacts(artifacts: "${rubyVersion}/**", allowEmptyArchive: true, onlyIfSuccessful: false)
     rubyDownstreamJobs["${rubyVersion}"] = buildObject
+
+    // Let's report the failure in the stage at the very end.
+    if (buildFailed) {
+      warnError("Downstream Failed '${rubyVersion}'") {
+        error("Downstream job for '${rubyVersion}' failed")
+      }
+    }
   }
 }
 

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -1,5 +1,5 @@
 #!/usr/bin/env groovy
-@Library('apm@current') _
+@Library('apm@fix/error-build-downstreams') _
 
 import co.elastic.matrix.*
 import groovy.transform.Field

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -282,6 +282,8 @@ pipeline {
           unpack_artifacts(rubyDownstreamJobs)
           sh(script: "./spec/scripts/coverage_converge.sh")
           cobertura coberturaReportFile: "coverage/coverage.xml"
+          // Aggregate test results from downstream jobs.
+          junit(testResults: '**/spec/junit-reports/**/ruby-agent-junit.xml', allowEmptyResults: true, keepLongStdio: true)
         }
       }
     }

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -358,6 +358,7 @@ def runJob(String rubyVersion, int sleep = 1){
     rubyTasksFailed = true
     buildFailed = true
     buildNumber = buildObject.number.toString()
+    log(level: 'INFO', text: "Job failed '${buildObject?.name}' - ${buildNumber}")
     buildObject = e
   } finally {
     dir(rubyVersion) {

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -19,7 +19,7 @@ pipeline {
   environment {
     REPO = 'apm-agent-ruby'
     BASE_DIR = "src/github.com/elastic/${env.REPO}"
-    PIPELINE_LOG_LEVEL = 'INFO'
+    PIPELINE_LOG_LEVEL = 'DEBUG'
     NOTIFY_TO = credentials('notify-to')
     JOB_GCS_BUCKET = credentials('gcs-bucket')
     CODECOV_SECRET = 'secret/apm-team/ci/apm-agent-ruby-codecov'
@@ -355,6 +355,7 @@ def runJob(String rubyVersion, int sleep = 1){
                         quietPeriod: quiet)
     ret = buildObject
   } catch(e) {
+    log(level: 'DEBUG', text: "There was an error when running the build ${e}")
     rubyTasksFailed = true
     buildFailed = true
     ret = e
@@ -363,6 +364,7 @@ def runJob(String rubyVersion, int sleep = 1){
     // Aggregate test results from downstream jobs.
     buildNumber = buildObject?.getNumber()?.toString()
     buildName = buildObject?.getProjectName()
+    log(level: 'DEBUG', text: "build ${buildName?.trim()}  ${buildNumber?.trim()}")
     dir(rubyVersion) {
       copyArtifacts(projectName: jobName, filter: '**/ruby-agent-junit.xml', selector: specific(buildNumber: buildNumber))
     }

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -354,14 +354,16 @@ def runJob(String rubyVersion, int sleep = 1){
                         ],
                         quietPeriod: quiet)
     buildNumber = buildObject.number.toString()
+    log(level: 'INFO', text: "Job ran successfully '${buildObject?.getProjectName()}' - ${buildNumber}")
   } catch(e) {
     rubyTasksFailed = true
     buildFailed = true
     buildNumber = buildObject.number.toString()
-    log(level: 'INFO', text: "Job failed '${buildObject?.name}' - ${buildNumber}")
+    log(level: 'INFO', text: "Job failed '${buildObject?.getProjectName()}' - ${buildNumber}")
     buildObject = e
   } finally {
     dir(rubyVersion) {
+      log(level: 'INFO', text: 'Fetch test results from the downstream to be aggregated.')
       copyArtifacts(projectName: jobName, filter: '**/ruby-agent-junit.xml', selector: specific(buildNumber: buildNumber))
     }
     // Aggregate test results from downstream jobs.

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -26,6 +26,7 @@ pipeline {
     DOCKER_REGISTRY = 'docker.elastic.co'
     DOCKER_SECRET = 'secret/apm-team/ci/docker-registry/prod'
     GITHUB_CHECK_ITS_NAME = 'Integration Tests'
+    DOWNSTREAM_PIPELINE = 'apm-agent-ruby/apm-agent-ruby-downstream'
     ITS_PIPELINE = 'apm-integration-tests-selector-mbp/master'
     RELEASE_SECRET = 'secret/apm-team/ci/apm-agent-ruby-rubygems-release'
     OPBEANS_REPO = 'opbeans-ruby'
@@ -295,7 +296,7 @@ pipeline {
 
 def unpack_artifacts(builds) {
     builds.values().each() { build ->
-      copyArtifacts(projectName: "apm-agent-ruby/apm-agent-ruby-downstream/${env.BRANCH_NAME}", 
+      copyArtifacts(projectName: "${env.DOWNSTREAM_PIPELINE}/${env.BRANCH_NAME}", 
                     filter: 'coverage/**/*.*',
                     selector: specific(buildNumber: build.number.toString()))
     }
@@ -340,11 +341,9 @@ def runBenchmark(version){
 
 def runJob(String rubyVersion, int sleep = 1){
   def buildFailed = false
-  def buildObject
-  def buildNumber
-  def buildName
+  def buildObject, ret
   def branch = env.CHANGE_ID?.trim() ? env.CHANGE_TARGET : env.BRANCH_NAME
-  def jobName = "apm-agent-ruby/apm-agent-ruby-downstream/${env.BRANCH_NAME}"
+  def jobName = "${env.DOWNSTREAM_PIPELINE}/${env.BRANCH_NAME}"
   try {
     def quiet = (sleep * randomNumber(min: 2, max: 6)) + 5
     buildObject = build(job: jobName,
@@ -354,25 +353,20 @@ def runJob(String rubyVersion, int sleep = 1){
                           string(name: 'MERGE_TARGET', value: "${branch}")
                         ],
                         quietPeriod: quiet)
-    buildNumber = buildObject.number.toString()
-    buildName = buildObject?.getProjectName()
-    log(level: 'INFO', text: "Job ran successfully '${buildName}' - ${buildNumber}")
+    ret = buildObject
   } catch(e) {
     rubyTasksFailed = true
     buildFailed = true
-    buildNumber = buildObject.number.toString()
-    buildName = buildObject?.getProjectName()
-    log(level: 'INFO', text: "Job failed '${buildName}' - ${buildNumber}")
-    buildObject = e
+    ret = e
   } finally {
+    rubyDownstreamJobs["${rubyVersion}"] = ret
+    // Aggregate test results from downstream jobs.
+    buildNumber = buildObject?.getNumber()?.toString()
+    buildName = buildObject?.getProjectName()
     dir(rubyVersion) {
-      log(level: 'INFO', text: "Fetch test results from the downstream to be aggregated. ${rubyVersion?.trim()} - ${buildNumber?.trim()} - ${buildName?.trim()}")
       copyArtifacts(projectName: jobName, filter: '**/ruby-agent-junit.xml', selector: specific(buildNumber: buildNumber))
     }
-    // Aggregate test results from downstream jobs.
     junit(testResults: "${rubyVersion}/**/ruby-agent-junit.xml", allowEmptyResults: true, keepLongStdio: true)
-    archiveArtifacts(artifacts: "${rubyVersion}/**", allowEmptyArchive: true, onlyIfSuccessful: false)
-    rubyDownstreamJobs["${rubyVersion}"] = buildObject
 
     // Let's report the failure in the stage at the very end.
     if (buildFailed) {

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -281,9 +281,7 @@ pipeline {
         dir("${BASE_DIR}"){
           unpack_artifacts(rubyDownstreamJobs)
           sh(script: "./spec/scripts/coverage_converge.sh")
-          cobertura coberturaReportFile: "coverage/coverage.xml"
-          // Aggregate test results from downstream jobs.
-          junit(testResults: '**/spec/junit-reports/**/ruby-agent-junit.xml', allowEmptyResults: true, keepLongStdio: true)
+          cobertura coberturaReportFile: "coverage/coverage.xml"        
         }
       }
     }
@@ -297,7 +295,9 @@ pipeline {
 
 def unpack_artifacts(builds) {
     builds.values().each() { build ->
-      copyArtifacts(projectName: "apm-agent-ruby/apm-agent-ruby-downstream/${env.BRANCH_NAME}", selector: specific(buildNumber: build.number.toString()))
+      copyArtifacts(projectName: "apm-agent-ruby/apm-agent-ruby-downstream/${env.BRANCH_NAME}", 
+                    filter: 'coverage/**/*.*',
+                    selector: specific(buildNumber: build.number.toString()))
     }
 }
 
@@ -341,9 +341,10 @@ def runBenchmark(version){
 def runJob(String rubyVersion, int sleep = 1){
   def buildObject
   def branch = env.CHANGE_ID?.trim() ? env.CHANGE_TARGET : env.BRANCH_NAME
+  def jobName = "apm-agent-ruby/apm-agent-ruby-downstream/${env.BRANCH_NAME}"
   try {
     def quiet = (sleep * randomNumber(min: 2, max: 6)) + 5
-    buildObject = build(job: "apm-agent-ruby/apm-agent-ruby-downstream/${env.BRANCH_NAME}",
+    buildObject = build(job: jobName,
                         parameters: [
                           string(name: 'RUBY_VERSION', value: "${rubyVersion}"),
                           string(name: 'BRANCH_SPECIFIER', value: "${env.GIT_BASE_COMMIT}"),
@@ -357,6 +358,14 @@ def runJob(String rubyVersion, int sleep = 1){
       error("Downstream job for '${rubyVersion}' failed")
     }
   } finally {
+    dir(rubyVersion) {
+      copyArtifacts(projectName: jobName, 
+                    excludes: 'coverage/**/*.*', 
+                    selector: specific(buildNumber: buildObject.number.toString()))
+    }
+    // Aggregate test results from downstream jobs.
+    junit(testResults: "${rubyVersion}/**/ruby-agent-junit.xml", allowEmptyResults: true, keepLongStdio: true)
+    archiveArtifacts(artifacts: "${rubyVersion}/**", allowEmptyArchive: true, onlyIfSuccessful: false)
     rubyDownstreamJobs["${rubyVersion}"] = buildObject
   }
 }

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -342,6 +342,7 @@ def runJob(String rubyVersion, int sleep = 1){
   def buildFailed = false
   def buildObject
   def buildNumber
+  def buildName
   def branch = env.CHANGE_ID?.trim() ? env.CHANGE_TARGET : env.BRANCH_NAME
   def jobName = "apm-agent-ruby/apm-agent-ruby-downstream/${env.BRANCH_NAME}"
   try {
@@ -354,16 +355,18 @@ def runJob(String rubyVersion, int sleep = 1){
                         ],
                         quietPeriod: quiet)
     buildNumber = buildObject.number.toString()
-    log(level: 'INFO', text: "Job ran successfully '${buildObject?.getProjectName()}' - ${buildNumber}")
+    buildName = buildObject?.getProjectName()
+    log(level: 'INFO', text: "Job ran successfully '${buildName}' - ${buildNumber}")
   } catch(e) {
     rubyTasksFailed = true
     buildFailed = true
     buildNumber = buildObject.number.toString()
-    log(level: 'INFO', text: "Job failed '${buildObject?.getProjectName()}' - ${buildNumber}")
+    buildName = buildObject?.getProjectName()
+    log(level: 'INFO', text: "Job failed '${buildName}' - ${buildNumber}")
     buildObject = e
   } finally {
     dir(rubyVersion) {
-      log(level: 'INFO', text: 'Fetch test results from the downstream to be aggregated.')
+      log(level: 'INFO', text: "Fetch test results from the downstream to be aggregated. ${rubyVersion?.trim()} - ${buildNumber?.trim()} - ${buildName?.trim()}")
       copyArtifacts(projectName: jobName, filter: '**/ruby-agent-junit.xml', selector: specific(buildNumber: buildNumber))
     }
     // Aggregate test results from downstream jobs.

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -341,6 +341,7 @@ def runBenchmark(version){
 def runJob(String rubyVersion, int sleep = 1){
   def buildFailed = false
   def buildObject
+  def buildNumber
   def branch = env.CHANGE_ID?.trim() ? env.CHANGE_TARGET : env.BRANCH_NAME
   def jobName = "apm-agent-ruby/apm-agent-ruby-downstream/${env.BRANCH_NAME}"
   try {
@@ -352,15 +353,17 @@ def runJob(String rubyVersion, int sleep = 1){
                           string(name: 'MERGE_TARGET', value: "${branch}")
                         ],
                         quietPeriod: quiet)
+    buildNumber = buildObject.number.toString()
   } catch(e) {
     rubyTasksFailed = true
     buildFailed = true
+    buildNumber = buildObject.number.toString()
     buildObject = e
   } finally {
     dir(rubyVersion) {
       copyArtifacts(projectName: jobName, 
                     includes: '**/ruby-agent-junit.xml',
-                    selector: specific(buildNumber: buildObject.number.toString()))
+                    selector: specific(buildNumber: buildNumber))
     }
     // Aggregate test results from downstream jobs.
     junit(testResults: "${rubyVersion}/**/ruby-agent-junit.xml", allowEmptyResults: true, keepLongStdio: true)

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -361,9 +361,7 @@ def runJob(String rubyVersion, int sleep = 1){
     buildObject = e
   } finally {
     dir(rubyVersion) {
-      copyArtifacts(projectName: jobName, 
-                    includes: '**/ruby-agent-junit.xml',
-                    selector: specific(buildNumber: buildNumber))
+      copyArtifacts(projectName: jobName, filter: '**/ruby-agent-junit.xml', selector: specific(buildNumber: buildNumber))
     }
     // Aggregate test results from downstream jobs.
     junit(testResults: "${rubyVersion}/**/ruby-agent-junit.xml", allowEmptyResults: true, keepLongStdio: true)

--- a/.ci/downstreamTests.groovy
+++ b/.ci/downstreamTests.groovy
@@ -117,9 +117,9 @@ class RubyParallelTaskGenerator extends DefaultParallelTaskGenerator {
           saveResult(x, y, 0)
           steps.error("${label} tests failed : ${e.toString()}\n")
         } finally {
-          steps.junit(allowEmptyResults: true,
-            keepLongStdio: true,
-            testResults: "**/spec/junit-reports/**/ruby-agent-junit.xml")
+          def testResultsPattern = '**/spec/junit-reports/**/ruby-agent-junit.xml'
+          steps.junit(testResults: testResultsPattern, allowEmptyResults: true, keepLongStdio: true)
+          steps.archiveArtifacts(artifacts: testResultsPattern, allowEmptyArchive: true, onlyIfSuccessful: false)
         }
       }
     }


### PR DESCRIPTION
##  What does this pull request do?

Aggregate the downstream test results in the upstream pipeline

## Why is it important?

Enable GitHub PR comments from the parenstream pipeline with the test results. Otherwise when using parenstream/downstream pattern the test results are not reported.

## Tests

Tests are reported in the parentstream, for instance

![image](https://user-images.githubusercontent.com/2871786/81085071-a3d18780-8eee-11ea-84c2-241a220b2062.png)

![image](https://user-images.githubusercontent.com/2871786/81074066-67972a80-8ee0-11ea-9e38-691b07220616.png)

And therefore those details are also reported in the GitHub PR comment https://github.com/elastic/apm-agent-ruby/pull/786#issuecomment-623651784 