### PR TITLE
Define finalizer on ProxyPipe::Write to close gzip writer

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -52,6 +52,7 @@ endif::[]
 - Set config `false` values to `false`, not `nil` {pull}761[#761]
 - Ensure that the previously running agent's config is used in `ElasticAPM.restart` {pull}763[#763]
 - Handle the Resque spy's payload class value being a String or Class and update docs {pull}768[#768]
+- Add finalizer on ProxyPipe::Write so Zlib::GzipWriter is properly closed {pull}787[#787]
 
 [float]
 ===== Added

--- a/lib/elastic_apm/transport/connection/proxy_pipe.rb
+++ b/lib/elastic_apm/transport/connection/proxy_pipe.rb
@@ -48,6 +48,11 @@ module ElasticAPM
 
             return unless compress
             enable_compression!
+            ObjectSpace.define_finalizer(self, self.class.finalize(@io))
+          end
+
+          def self.finalize(io)
+            proc { io.close }
           end
 
           attr_reader :io


### PR DESCRIPTION
Under certain circumstances, the `Zlib::GzipWriter` object is not explicitly closed before garbage collected. This change adds a finalizer that is called when the `ProxyPipe::Write` object is GC'ed that closes the io object.

See this Resque log before the change:
```ruby
I, [2020-05-05T15:38:13.449083 #2375]  INFO -- : got: (Job{sleep} | Sleeper | [5])
D, [2020-05-05T15:38:13.450551 #2375] DEBUG -- : resque-2.0.0: Forked 2439 at 1588685893
I, [2020-05-05T15:38:23.463600 #2439]  INFO -- : done: (Job{sleep} | Sleeper | [5])
zlib(finalizer): Zlib::GzipWriter object must be closed explicitly.
zlib(finalizer): the stream was freed prematurely.
D, [2020-05-05T15:38:23.498151 #2375] DEBUG -- : Checking sleep
D, [2020-05-05T15:38:23.500094 #2375] DEBUG -- : Sleeping for 5.0 seconds
D, [2020-05-05T15:38:23.500296 #2375] DEBUG -- : resque-2.0.0: Waiting for sleep
```

and with the change:
```ruby
I, [2020-05-05T16:12:59.452847 #7489]  INFO -- : got: (Job{sleep} | Sleeper | [1])
D, [2020-05-05T16:12:59.455798 #7489] DEBUG -- : resque-2.0.0: Forked 7519 at 1588687979
I, [2020-05-05T16:12:59.462202 #7519]  INFO -- : Running after_fork hooks with [(Job{sleep} | Sleeper | [1])]
I, [2020-05-05T16:13:09.491798 #7519]  INFO -- : done: (Job{sleep} | Sleeper | [1])
D, [2020-05-05T16:13:09.530467 #7489] DEBUG -- : Checking sleep
D, [2020-05-05T16:13:09.531188 #7489] DEBUG -- : Sleeping for 5.0 seconds
D, [2020-05-05T16:13:09.531225 #7489] DEBUG -- : resque-2.0.0: Waiting for sleep
```
Closes https://github.com/elastic/apm-agent-ruby/issues/769