### PR TITLE
Elasticsearch client integration: Use body in db statement

### DIFF
--- a/docs/configuration.asciidoc
+++ b/docs/configuration.asciidoc
@@ -288,6 +288,16 @@ If your service handles data like this, we advise to only enable this feature wi
 Whether or not to attach the request headers to transactions and errors.
 
 [float]
+[[config-capture-elasticsearch-queries]]
+==== `capture_elasticsearch_queries`
+|============
+| Environment                                 | `Config` key                    | Default
+| `ELASTIC_APM_CAPTURE_ELASTICSEARCH_QUERIES` | `capture_elasticsearch_queries` | `false`
+|============
+
+Whether or not to capture the body from requests in Elasticsearch.
+
+[float]
 [[config-capture-env]]
 ==== `capture_env`
 |============

--- a/lib/elastic_apm/config.rb
+++ b/lib/elastic_apm/config.rb
@@ -42,6 +42,7 @@ module ElasticAPM
     option :breakdown_metrics,                 type: :bool,   default: true
     option :capture_body,                      type: :string, default: 'off'
     option :capture_headers,                   type: :bool,   default: true
+    option :capture_elasticsearch_queries,     type: :bool,   default: false
     option :capture_env,                       type: :bool,   default: true
     option :central_config,                    type: :bool,   default: true
     option :current_user_email_method,         type: :string, default: 'email'

--- a/lib/elastic_apm/spies/elasticsearch.rb
+++ b/lib/elastic_apm/spies/elasticsearch.rb
@@ -34,12 +34,12 @@ module ElasticAPM
             name = format(NAME_FORMAT, method, path)
             statement = []
 
-            unless args[0].nil?
-              statement << { params: args[0] }
-            end
+            statement << { params: args&.[](0) }
 
-            unless args[1].nil? || args[1].empty?
-              statement << { body: args[1] }
+            if ElasticAPM.agent.config.capture_elasticsearch_queries
+              unless args[1].nil? || args[1].empty?
+                statement << { body: args[1] }
+              end
             end
 
             context = Span::Context.new(

--- a/lib/elastic_apm/spies/elasticsearch.rb
+++ b/lib/elastic_apm/spies/elasticsearch.rb
@@ -32,10 +32,18 @@ module ElasticAPM
 
           def perform_request(method, path, *args, &block)
             name = format(NAME_FORMAT, method, path)
-            statement = args[0].is_a?(String) ? args[0] : args[0].to_json
+            statement = []
+
+            unless args[0].nil?
+              statement << { params: args[0] }
+            end
+
+            unless args[1].nil? || args[1].empty?
+              statement << { body: args[1] }
+            end
 
             context = Span::Context.new(
-              db: { statement: statement },
+              db: { statement: statement.reduce({}, :merge).to_json },
               destination: {
                 name: SUBTYPE,
                 resource: SUBTYPE,

--- a/lib/elastic_apm/transport/filters/hash_sanitizer.rb
+++ b/lib/elastic_apm/transport/filters/hash_sanitizer.rb
@@ -1,0 +1,77 @@
+# Licensed to Elasticsearch B.V. under one or more contributor
+# license agreements. See the NOTICE file distributed with
+# this work for additional information regarding copyright
+# ownership. Elasticsearch B.V. licenses this file to you under
+# the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# frozen_string_literal: true
+
+module ElasticAPM
+  module Transport
+    module Filters
+      class HashSanitizer
+        FILTERED = '[FILTERED]'
+
+        KEY_FILTERS = [
+          /passw(or)?d/i,
+          /auth/i,
+          /^pw$/,
+          /secret/i,
+          /token/i,
+          /api[-._]?key/i,
+          /session[-._]?id/i,
+          /(set[-_])?cookie/i
+        ].freeze
+
+        VALUE_FILTERS = [
+          # (probably) credit card number
+          /^\d{4}[- ]?\d{4}[- ]?\d{4}[- ]?\d{4}$/
+        ].freeze
+
+        attr_accessor :key_filters
+
+        def initialize
+          @key_filters = KEY_FILTERS
+        end
+
+        def strip_from!(obj, key_filters = KEY_FILTERS)
+          return unless obj&.is_a?(Hash)
+
+          obj.each do |k, v|
+            if filter_key?(k)
+              next obj[k] = FILTERED
+            end
+
+            case v
+            when Hash
+              strip_from!(v)
+            when String
+              if filter_value?(v)
+                obj[k] = FILTERED
+              end
+            end
+          end
+        end
+
+        def filter_key?(key)
+          @key_filters.any? { |regex| regex.match(key) }
+        end
+
+        def filter_value?(value)
+          VALUE_FILTERS.any? { |regex| regex.match(value) }
+        end
+      end
+    end
+  end
+end

--- a/lib/elastic_apm/transport/filters/secrets_filter.rb
+++ b/lib/elastic_apm/transport/filters/secrets_filter.rb
@@ -17,74 +17,30 @@
 
 # frozen_string_literal: true
 
+require 'elastic_apm/transport/filters/hash_sanitizer'
+
 module ElasticAPM
   module Transport
     module Filters
       # @api private
       class SecretsFilter
-        FILTERED = '[FILTERED]'
-
-        KEY_FILTERS = [
-          /passw(or)?d/i,
-          /auth/i,
-          /^pw$/,
-          /secret/i,
-          /token/i,
-          /api[-._]?key/i,
-          /session[-._]?id/i,
-          /(set[-_])?cookie/i
-        ].freeze
-
-        VALUE_FILTERS = [
-          # (probably) credit card number
-          /^\d{4}[- ]?\d{4}[- ]?\d{4}[- ]?\d{4}$/
-        ].freeze
-
         def initialize(config)
           @config = config
-          @key_filters =
-            KEY_FILTERS +
-            config.custom_key_filters +
-            config.sanitize_field_names
+          @sanitizer = HashSanitizer.new
+          @sanitizer.key_filters += config.custom_key_filters +
+                                     config.sanitize_field_names
         end
 
         def call(payload)
-          strip_from! payload.dig(:transaction, :context, :request, :headers)
-          strip_from! payload.dig(:transaction, :context, :request, :env)
-          strip_from! payload.dig(:transaction, :context, :request, :cookies)
-          strip_from! payload.dig(:transaction, :context, :response, :headers)
-          strip_from! payload.dig(:error, :context, :request, :headers)
-          strip_from! payload.dig(:error, :context, :response, :headers)
-          strip_from! payload.dig(:transaction, :context, :request, :body)
+          @sanitizer.strip_from! payload.dig(:transaction, :context, :request, :headers)
+          @sanitizer.strip_from! payload.dig(:transaction, :context, :request, :env)
+          @sanitizer.strip_from! payload.dig(:transaction, :context, :request, :cookies)
+          @sanitizer.strip_from! payload.dig(:transaction, :context, :response, :headers)
+          @sanitizer.strip_from! payload.dig(:error, :context, :request, :headers)
+          @sanitizer.strip_from! payload.dig(:error, :context, :response, :headers)
+          @sanitizer.strip_from! payload.dig(:transaction, :context, :request, :body)
 
           payload
-        end
-
-        def strip_from!(obj)
-          return unless obj&.is_a?(Hash)
-
-          obj.each do |k, v|
-            if filter_key?(k)
-              next obj[k] = FILTERED
-            end
-
-            case v
-            when Hash
-              strip_from!(v)
-            when String
-              if filter_value?(v)
-                obj[k] = FILTERED
-              end
-            end
-          end
-        end
-
-        def filter_key?(key)
-          @key_filters.any? { |regex| regex.match(key) }
-        end
-
-        def filter_value?(value)
-          VALUE_FILTERS.any? { |regex| regex.match(value) }
         end
       end
     end

--- a/spec/elastic_apm/spies/elasticsearch_spec.rb
+++ b/spec/elastic_apm/spies/elasticsearch_spec.rb
@@ -48,29 +48,57 @@ module ElasticAPM
     end
 
     context 'a post request with body' do
-      it 'uses the body in the statement', :intercept do
+      before do
         WebMock.stub_request(:post, %r{http://localhost:9200/.*})
           .with(body: %r{.*})
-
-        client = Elasticsearch::Client.new log: false
-
-        with_agent do
-          ElasticAPM.with_transaction do
-            client.bulk(
-              body: {
-                index: { _index: 'users', data: { name: 'Fernando' } }
-              }
-            )
-          end
-        end
-
-        net_span, span = @intercepted.spans
-
-        expect(span.name).to eq('POST _bulk')
-        expect(span.context.db.statement)
-          .to eq('{"params":{},"body":{"index":{"_index":"users","data":{"name":"Fernando"}}}}')
-        span
       end
+
+      let(:client) { Elasticsearch::Client.new log: false }
+
+      context 'when capture_elasticsearch_queries is true' do
+        it 'uses the body in the statement', :intercept do
+          with_agent do
+            ElasticAPM.with_transaction do
+              ElasticAPM.agent.config.capture_elasticsearch_queries = true
+              client.bulk(
+                body: {
+                  index: { _index: 'users', data: { name: 'Fernando' } }
+                }
+              )
+            end
+          end
+
+          net_span, span = @intercepted.spans
+
+          expect(span.name).to eq('POST _bulk')
+          expect(span.context.db.statement)
+            .to eq('{"params":{},"body":{"index":{"_index":"users","data":{"name":"Fernando"}}}}')
+          span
+        end
+      end
+
+      context 'when capture_elasticsearch_queries is false' do
+        it 'does not use the body in the statement', :intercept do
+          with_agent do
+            ElasticAPM.with_transaction do
+              ElasticAPM.agent.config.capture_elasticsearch_queries = false
+              client.bulk(
+                body: {
+                  index: { _index: 'users', data: { name: 'Fernando' } }
+                }
+              )
+            end
+          end
+
+          net_span, span = @intercepted.spans
+
+          expect(span.name).to eq('POST _bulk')
+          expect(span.context.db.statement)
+            .to eq('{"params":{}}')
+          span
+        end
+      end
+
     end
   end
 end


### PR DESCRIPTION
I have been working on an example app integrating this agent and the [Elasticsearch Ruby client](github.com/elastic/elasticsearch-ruby). Looking at the information on the requests on the APM Server, I noticed some more information could be provided.

The apm client uses the elasticsearch client's `perform_request`, and passes its parameters as statements to APM. However some endpoints don't use parameters and use body instead, or use both.

## What does this pull request do?

This PR makes it so that the Elasticsearch spy sends both parameters and body to the APM server on each request. So if there's only a parameter, the information will remain the same. But if there's a body, json will be passed in with a `params` and a `body` key with the corresponding information. This could be improved to pass in just the body if there's only a body and not use these keys, more tests for when having both, etc. But before working further on this code, I wanted to check in if this is even relevant or useful for the agent. Not including the body could be a decision made by design, since it might be too much information, although it does seem like the server trims the information to how much it can show.

Here's a screenshot of how the body would look in a bulk example:
![image](https://user-images.githubusercontent.com/689327/81794184-4fd42d80-9502-11ea-8c9a-6432c4fb6eb7.png)

Let me know what you think, thanks!

## Why is it important?

It could be useful to see the request bodies in the APM Server, but it could also be too much information depending on what kind of request it is (e.g. a bulk request with many records).

## Checklist
<!--
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] I have signed the [Contributor License Agreement](https://www.elastic.co/contributor-agreement/). 
- [ ] My code follows the style guidelines of this project (See `.rubocop.yml`)
- [x] I have rebased my changes on top of the latest master branch
<!--
Update your local repository with the most recent code from the main repo, and rebase your branch on top of the latest master branch. We prefer your initial changes to be squashed into a single commit. Later, if we ask you to make changes, add them as separate commits. This makes them easier to review.
-->
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing [**unit** tests](https://github.com/elastic/apm-agent-ruby/blob/master/CONTRIBUTING.md#testing) pass locally with my changes
<!--
Run the test suite to make sure that nothing is broken. See https://github.com/elastic/apm-agent-ruby/blob/master/CONTRIBUTING.md#testing for details.
-->
- [ ] I have made corresponding changes to the documentation
- [ ] I have updated [CHANGELOG.asciidoc](CHANGELOG.asciidoc)
- [ ] I have updated [supported-technologies.asciidoc](docs/supported-technologies.asciidoc)
- [ ] Added an API method or config option? Document in which version this will be introduced

## Related issues
<!--
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.
- Closes #ISSUE_ID
- Relates #ISSUE_ID
- Requires #ISSUE_ID
- Superseds #ISSUE_ID
-->
