### PR TITLE
Update Opentracing bridge

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -50,6 +50,7 @@ endif::[]
 
 - Allow underscores in hostnames in Net::HTTP spy {pull}804[#804]
 - Don't change log level on logger object via remote config {pull}809[#809]
+- Update and fix the Opentracing bridge {pull}791[#791]
 
 [float]
 [[release-notes-3.7.0]]

--- a/lib/elastic_apm/opentracing.rb
+++ b/lib/elastic_apm/opentracing.rb
@@ -85,12 +85,7 @@ module ElasticAPM
       def finish(clock_end: Util.monotonic_micros, end_time: nil)
         return unless (agent = ElasticAPM.agent)
 
-        if end_time
-          warn '[ElasticAPM] DEPRECATED: Setting a custom end time as a ' \
-            '`Time` is deprecated. Use `clock_end:` and monotonic time instead.'
-          clock_end = end_time
-        end
-
+        clock_end = Util.micros(end_time) if end_time
         elastic_span.done clock_end: clock_end
 
         case elastic_span

--- a/lib/elastic_apm/opentracing.rb
+++ b/lib/elastic_apm/opentracing.rb
@@ -80,13 +80,12 @@ module ElasticAPM
           ElasticAPM.report_message message
         end
       end
-
       # rubocop:enable Lint/UnusedMethodArgument
-      def finish(clock_end: Util.monotonic_micros, end_time: nil)
+
+      def finish(end_time: Time.now)
         return unless (agent = ElasticAPM.agent)
 
-        clock_end = Util.micros(end_time) if end_time
-        elastic_span.done clock_end: clock_end
+        elastic_span.done clock_end: Util.micros(end_time)
 
         case elastic_span
         when ElasticAPM::Transaction

--- a/lib/elastic_apm/opentracing.rb
+++ b/lib/elastic_apm/opentracing.rb
@@ -227,7 +227,7 @@ module ElasticAPM
 
         if block_given?
           begin
-            yield scope
+            return yield scope
           ensure
             scope.close
           end

--- a/lib/elastic_apm/opentracing.rb
+++ b/lib/elastic_apm/opentracing.rb
@@ -54,6 +54,8 @@ module ElasticAPM
         else
           elastic_span.context.labels[key] = val
         end
+
+        self
       end
 
       def set_baggage_item(_key, _value)

--- a/lib/elastic_apm/opentracing.rb
+++ b/lib/elastic_apm/opentracing.rb
@@ -39,7 +39,7 @@ module ElasticAPM
         @span_context
       end
 
-      def set_label(key, val)
+      def set_tag(key, val)
         if elastic_span.is_a?(Transaction)
           case key.to_s
           when 'type'
@@ -210,7 +210,7 @@ module ElasticAPM
         child_of: nil,
         references: nil,
         start_time: Time.now,
-        labels: {},
+        tags: {},
         ignore_active_scope: false,
         finish_on_close: true,
         **
@@ -220,7 +220,7 @@ module ElasticAPM
           child_of: child_of,
           references: references,
           start_time: start_time,
-          labels: labels,
+          tags: tags,
           ignore_active_scope: ignore_active_scope
         )
         scope = scope_manager.activate(span, finish_on_close: finish_on_close)
@@ -243,7 +243,7 @@ module ElasticAPM
         child_of: nil,
         references: nil,
         start_time: Time.now,
-        labels: {},
+        tags: {},
         ignore_active_scope: false,
         **
       )
@@ -280,7 +280,7 @@ module ElasticAPM
         span_context ||=
           SpanContext.from_trace_context(elastic_span.trace_context)
 
-        labels.each do |key, value|
+        tags.each do |key, value|
           elastic_span.context.labels[key] = value
         end
 
@@ -344,7 +344,7 @@ module ElasticAPM
       def context_from_active_scope(ignore_active_scope)
         if ignore_active_scope
           ElasticAPM.agent&.config&.logger&.warn(
-            'ignore_active_scope might lead to unexpeced results'
+            'ignore_active_scope might lead to unexpected results'
           )
           return
         end

--- a/spec/integration/opentracing_spec.rb
+++ b/spec/integration/opentracing_spec.rb
@@ -371,7 +371,7 @@ RSpec.describe 'OpenTracing bridge', :intercept do
       end
     end
 
-    describe 'time' do
+    describe '#finish' do
       subject do
         ::OpenTracing.start_span(
           'namest',
@@ -383,18 +383,6 @@ RSpec.describe 'OpenTracing bridge', :intercept do
         before { subject.finish(end_time: Time.new(2020, 1, 1, 0, 0, 2)) }
 
         it 'converts to monotonic time' do
-          expect(subject.elastic_span.duration).to eq(1_000_000)
-        end
-      end
-
-      context 'when the span is finished with monotonic time as clock_time' do
-        before do
-          subject.finish(
-            clock_end: ElasticAPM::Util.micros(Time.new(2020, 1, 1, 0, 0, 2))
-          )
-        end
-
-        it 'uses the monotonic time' do
           expect(subject.elastic_span.duration).to eq(1_000_000)
         end
       end

--- a/spec/integration/opentracing_spec.rb
+++ b/spec/integration/opentracing_spec.rb
@@ -277,6 +277,11 @@ RSpec.describe 'OpenTracing bridge', :intercept do
             expect(subject.elastic_span.context.labels[:custom_key])
               .to eq 'custom_type'
           end
+
+          it 'returns self' do
+            expect(subject.set_tag :custom_key, 'custom_type')
+              .to be_a ElasticAPM::OpenTracing::Span
+          end
         end
       end
 

--- a/spec/integration/opentracing_spec.rb
+++ b/spec/integration/opentracing_spec.rb
@@ -29,9 +29,9 @@ RSpec.describe 'OpenTracing bridge', :intercept do
 
   context 'without an agent' do
     it 'is a noop' do
-      thing = double(ran: nil)
+      thing = double(ran: 'success')
 
-      tracer.start_active_span('namest') do |scope|
+      result = tracer.start_active_span('namest') do |scope|
         expect(scope).to be_a ElasticAPM::OpenTracing::Scope
 
         tracer.start_active_span('nested') do |nested_scope|
@@ -42,6 +42,7 @@ RSpec.describe 'OpenTracing bridge', :intercept do
       end
 
       expect(thing).to have_received(:ran).with('…')
+      expect(result).to eq 'success'
     end
   end
 
@@ -106,6 +107,19 @@ RSpec.describe 'OpenTracing bridge', :intercept do
 
         it 'is active' do
           expect(::OpenTracing.active_span).to be subject.span
+        end
+      end
+
+      context 'when a block is passed' do
+        it 'returns the result of the block' do
+          thing = double(ran: 'success')
+
+          result = tracer.start_active_span('namest') do
+            thing.ran('…')
+          end
+
+          expect(thing).to have_received(:ran).with('…')
+          expect(result).to eq 'success'
         end
       end
     end

--- a/spec/integration/opentracing_spec.rb
+++ b/spec/integration/opentracing_spec.rb
@@ -188,7 +188,7 @@ RSpec.describe 'OpenTracing bridge', :intercept do
     it 'traces nested spans' do
       OpenTracing.start_active_span(
         'operation_name',
-        labels: { test: '0' }
+        tags: { test: '0' }
       ) do |scope|
         expect(scope).to be_a(ElasticAPM::OpenTracing::Scope)
         expect(OpenTracing.active_span).to be scope.span
@@ -196,7 +196,7 @@ RSpec.describe 'OpenTracing bridge', :intercept do
 
         OpenTracing.start_active_span(
           'nested',
-          labels: { test: '1' }
+          tags: { test: '1' }
         ) do |nested_scope|
           expect(OpenTracing.active_span).to_not be_nil
           expect(nested_scope.span).to eq OpenTracing.active_span
@@ -248,7 +248,7 @@ RSpec.describe 'OpenTracing bridge', :intercept do
       end
     end
 
-    describe 'set_label' do
+    describe 'set_tag' do
       subject { described_class.new(elastic_span, trace_context) }
 
       shared_examples :opengraph_span do
@@ -257,9 +257,9 @@ RSpec.describe 'OpenTracing bridge', :intercept do
           expect(elastic_span.name).to eq 'Test'
         end
 
-        describe 'set_label' do
-          it 'sets label' do
-            subject.set_label :custom_key, 'custom_type'
+        describe 'set_tag' do
+          it 'sets elastic span label' do
+            subject.set_tag :custom_key, 'custom_type'
             expect(subject.elastic_span.context.labels[:custom_key])
               .to eq 'custom_type'
           end
@@ -275,10 +275,10 @@ RSpec.describe 'OpenTracing bridge', :intercept do
         it_behaves_like :opengraph_span
 
         it 'knows user fields' do
-          subject.set_label 'user.id', 1
-          subject.set_label 'user.username', 'someone'
-          subject.set_label 'user.email', 'someone@example.com'
-          subject.set_label 'user.other_field', 'someone@example.com'
+          subject.set_tag 'user.id', 1
+          subject.set_tag 'user.username', 'someone'
+          subject.set_tag 'user.email', 'someone@example.com'
+          subject.set_tag 'user.other_field', 'someone@example.com'
 
           user = subject.elastic_span.context.user
           expect(user.id).to eq 1
@@ -304,7 +304,7 @@ RSpec.describe 'OpenTracing bridge', :intercept do
         it_behaves_like :opengraph_span
 
         it "doesn't explode on user fields" do
-          expect { subject.set_label 'user.id', 1 }
+          expect { subject.set_tag 'user.id', 1 }
             .to_not raise_error
         end
       end


### PR DESCRIPTION
Resolves https://github.com/elastic/apm-agent-ruby/issues/754

As pointed out in the issue, there are a number of incompatibilities with the OpenTracing interface. They are addressed in this PR.

Thanks for @eric-christian for both pointing out these issues and his work to resolve them.

- [x] Added FORMAT_TEXT_MAP for injection/extraction
- [x] `start_active_span` { /code block/ }, when a code block is given, returns the result of the code block, not the scope
- [x] The methods `start_span` and `start_active_span` have to take the parameter `tags`, not labels. **There's no need to support both `labels` and `tags` on this method, as it was an API bug to have removed `tags` and replaced it with `labels`.**
- [x] `span.set_tag` must be implemented and has to return self. **I've removed the `set_label` method, as it should never have replaced `set_tag`.**
- [x] `span.finish` - the parameter end_time is not deprecated. Also we had issues with the default clock_end: Util.monotonic_micros. When a span is started, the default start_time is set as start_time = Util.micros(Time.now). Combining Util.micros(Time.now) with Util.monotonic_micros resulted in durations that looked like this big numbers 1586156283628015. We didn't go into more details here and simply stopped mixing them together. **`clock_end` is removed because it was an API bug to deprecate `end_time` in favor of it. The OpenTracing::Span#finish API uses a `Time` object as the `end_time` value so we should do the conversion ourselves. Also, `start_span` requires `start_time` to be a `Time` and we do the conversion, so the same should be done in `#finish`**
- [x] The parameter `child_of` is supposed to be the parent span or parent span_context of the newly created span. The extracted span_context from ElasticAPM is already changed to represent a child of the once injected context.
- [x] `tracer.extract` has to return a `OpenTracing::SpanContext`, not an `ElasticAPM::TraceContext`.