### PR TITLE
test: google-protobuf >=3.12 supports for ruby >=2.5

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -39,6 +39,7 @@ gem 'elasticsearch', require: nil
 gem 'fakeredis', require: nil
 gem 'faraday', require: nil
 gem 'graphql', require: nil
+gem 'google-protobuf', '< 3.12' if !defined?(JRUBY_VERSION) && RUBY_VERSION < '2.5'
 gem 'grpc' if !defined?(JRUBY_VERSION) && RUBY_VERSION < '2.7'
 gem 'json-schema', require: nil
 gem 'mongo', require: nil


### PR DESCRIPTION
## What does this pull request do?

[google-protobuf/versions/3.12.0-x86_64-linux](https://rubygems.org/gems/google-protobuf/versions/3.12.0-x86_64-linux) requires ruby >=2.5

## Why is it important?

Fix the broken builds

## Related issues

Closes https://github.com/elastic/apm-agent-ruby/issues/798
