### PR TITLE
Do not use URI.build as it disallows _ in hostname

### DIFF
--- a/lib/elastic_apm/spies/net_http.rb
+++ b/lib/elastic_apm/spies/net_http.rb
@@ -65,7 +65,7 @@ module ElasticAPM
             path, query = req.path.split('?')
 
             cls = use_ssl? ? URI::HTTPS : URI::HTTP
-            uri = cls.build([nil, host, port, path, query, nil])
+            uri = URI("#{use_ssl? ? 'https' : 'http'}://#{host}#{":#{port}" if port}#{path}#{"?#{query}" if query}")
 
             destination =
               ElasticAPM::Span::Context::Destination.from_uri(uri)


### PR DESCRIPTION
URI.build throws an InvalidComponentError if the host contains an undescrore.

When making requests to hosts with an underscore in its name (e.g. myapp_mysql) the apm spy throws an exception.

> This is just a quickfix. Please try to find a better solution to prevent this error.