### PR TITLE
Net::HTTP spy: Allow underscores in hostnames

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -36,6 +36,14 @@ endif::[]
 === Ruby Agent version 3.x
 
 [float]
+[[unreleased]]
+==== Unreleased
+
+===== Fixed
+
+- Allow underscores in hostnames in Net::HTTP spy {pull}804[#804]
+
+[float]
 [[release-notes-3.7.0]]
 ==== 3.7.0 (2020-05-14)
 

--- a/lib/elastic_apm/spies/net_http.rb
+++ b/lib/elastic_apm/spies/net_http.rb
@@ -64,8 +64,12 @@ module ElasticAPM
             method = req.method.to_s.upcase
             path, query = req.path.split('?')
 
-            cls = use_ssl? ? URI::HTTPS : URI::HTTP
-            uri = cls.build([nil, host, port, path, query, nil])
+            url = use_ssl? ? +'https://' : +'http://'
+            url << host
+            url << ":#{port}" if port
+            url << path
+            url << "?#{query}" if query
+            uri = URI(url)
 
             destination =
               ElasticAPM::Span::Context::Destination.from_uri(uri)

--- a/spec/elastic_apm/spies/net_http_spec.rb
+++ b/spec/elastic_apm/spies/net_http_spec.rb
@@ -217,5 +217,21 @@ module ElasticAPM
       expect(span.context.destination.resource).to eq '[::1]:80'
       expect(span.context.destination.type).to eq 'external'
     end
+
+    it 'allows underscores in hostnames' do
+      WebMock.stub_request(:get, %r{http://exa_ple.com/.*})
+
+      with_agent do
+        ElasticAPM.with_transaction 'Net::HTTP test' do
+          Net::HTTP.start('exa_ple.com', 80) do |http|
+            http.get '/somewhere?thing=1'
+          end
+        end
+      end
+
+      span, = @intercepted.spans
+
+      expect(span.name).to eq 'GET exa_ple.com'
+    end
   end
 end


### PR DESCRIPTION
Fixes https://github.com/elastic/apm-agent-ruby/pull/801