### PR TITLE
GraphQL: Get operation name from selected_operation

### DIFF
--- a/lib/elastic_apm/graphql.rb
+++ b/lib/elastic_apm/graphql.rb
@@ -74,7 +74,7 @@ module ElasticAPM
       private
 
       def query_name(query)
-        query.operation_name || UNNAMED
+        query.selected_operation_name || UNNAMED
       end
 
       def concat_names(results)


### PR DESCRIPTION
Fixes #779, hopefully