### PR TITLE
ci: run benchmark on a PR basis if comment

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -38,7 +38,7 @@ pipeline {
     quietPeriod(10)
   }
   triggers {
-    issueCommentTrigger('(?i).*(?:jenkins\\W+)?run\\W+(?:the\\W+)?tests(?:\\W+please)?.*')
+    issueCommentTrigger('(?i).*(?:jenkins\\W+)?run\\W+(?:the\\W+)?(?:benchmark\\W+)?tests(?:\\W+please)?.*')
   }
   parameters {
     booleanParam(name: 'Run_As_Master_Branch', defaultValue: false, description: 'Allow to run any steps on a PR, some steps normally only run on master branch.')
@@ -154,6 +154,7 @@ pipeline {
             branch "v\\d?"
             tag pattern: 'v\\d+.*', comparator: "REGEXP"
             expression { return params.Run_As_Master_Branch }
+            expression { return env.GITHUB_COMMENT?.contains('benchmark tests') }
           }
           expression { return params.bench_ci }
         }


### PR DESCRIPTION
## What does this pull request do?

Enable the benchmark stage on a PR basis if using the GH comment `jenkins run the benchmark tests please` or a more minimalistic comment with `jenkins run benchmark tests` or even with `run benchmark tests`

## Why is it important?

Help to run the benchmark on a PR basis using a GitHub comment can facilitate the CI interactions.

## Questions

- [x] Will this affect anything in the benchmark dashboards?
