### PR TITLE
Only run subscribers spec if Rails is defined

### DIFF
--- a/spec/elastic_apm/subscriber_spec.rb
+++ b/spec/elastic_apm/subscriber_spec.rb
@@ -19,15 +19,7 @@
 
 require 'spec_helper'
 
-enable = false
-begin
-  require 'active_support/notifications'
-  enable = true
-rescue LoadError
-  puts '[INFO] Skipping Subscriber spec'
-end
-
-if enable
+if defined?(Rails)
   require 'elastic_apm/subscriber'
 
   module ElasticAPM


### PR DESCRIPTION
Because of a change in `ActiveSupport`, the `try` extension is no longer automatically required/defined when `active_support/notifications` is required. The `subscribers_spec` fails as a result.

We can't simply check if `ActiveSupport` is defined in the spec because other libraries require elements of `ActiveSupport`. In other words, `ActiveSupport` being defined doesn't necessarily mean that the `try` method is. For example, `Shoryuken` requires an extension from AS [here](https://github.com/phstc/shoryuken/blob/v5.0.5/lib/shoryuken/core_ext.rb#L63).

Just as a note, this was addressed in [a commit](https://github.com/rails/rails/commit/530f7805ed5790af1d472a041bc74089dc183f47) to Rails master but wasn't changed in the 6 branch.