### PR TITLE
Mongo spy: Remove event before checking for span

### DIFF
--- a/lib/elastic_apm/spies/mongo.rb
+++ b/lib/elastic_apm/spies/mongo.rb
@@ -85,8 +85,8 @@ module ElasticAPM
         end
 
         def pop_event(event)
-          return unless (curr = ElasticAPM.current_span)
           span = @events.delete(event.operation_id)
+          return unless (curr = ElasticAPM.current_span)
 
           curr == span && ElasticAPM.end_span
         end


### PR DESCRIPTION
Re #803, this ensures we're not keeping all events around.