### PR TITLE
fix: check that docker is installed

### DIFF
--- a/.ci/packer_cache.sh
+++ b/.ci/packer_cache.sh
@@ -2,13 +2,15 @@
 
 source /usr/local/bin/bash_standard_lib.sh
 
-grep "-" .ci/.jenkins_ruby.yml | grep -v 'observability-ci' | cut -d'-' -f2- | \
-while read -r version;
-do
-    transformedName=${version/:/-}
-    transformedVersion=$(echo "${version}" | cut -d":" -f2)
-    imageName="apm-agent-ruby"
-    registryImageName="docker.elastic.co/observability-ci/${imageName}:${transformedName}"
-    (retry 2 docker pull "${registryImageName}")
-    docker tag "${registryImageName}" "${imageName}:${transformedVersion}"
-done
+if [ -x "$(command -v docker)" ]; then
+  grep "-" .ci/.jenkins_ruby.yml | grep -v 'observability-ci' | cut -d'-' -f2- | \
+  while read -r version;
+  do
+      transformedName=${version/:/-}
+      transformedVersion=$(echo "${version}" | cut -d":" -f2)
+      imageName="apm-agent-ruby"
+      registryImageName="docker.elastic.co/observability-ci/${imageName}:${transformedName}"
+      (retry 2 docker pull "${registryImageName}")
+      docker tag "${registryImageName}" "${imageName}:${transformedVersion}"
+  done
+fi


### PR DESCRIPTION
## What does this PR do?

It checks that Docker is installed before run it.

## Why is it important?

Some worker types do not have Docker installed this breaks the packer build.