### PR TITLE
docs: add disable instructions

### DIFF
--- a/docs/debugging.asciidoc
+++ b/docs/debugging.asciidoc
@@ -28,3 +28,17 @@ Things to consider:
   - Experiencing high load? The agent can spawn multiple instances of its Workers that pick off the queue by changing the option `pool_size` (default is `1`).
   - If you have high load you may also consider setting `transaction_sample_rate` to something smaller than `1.0`. This determines whether to include _spans_ for every _transaction_. If you have enough traffic, skipping some (probably) identical spans won't have a noticeable effect on your data.
 
+[float]
+[[disable-agent]]
+=== Disable the Agent
+
+In the unlikely event the agent causes disruptions to a production application,
+you can disable the agent while you troubleshoot.
+
+If you have access to <<dynamic-configuration,dynamic configuration>>,
+you can disable the recording of events by setting <<config-recording,`recording`>> to `false`.
+When changed at runtime from a supported source, there's no need to restart your application.
+
+If that doesn't work, or you don't have access to dynamic configuration, you can disable the agent by setting
+<<config-enabled,`enabled`>> to `false`.
+You'll need to restart your application for the changes to apply.


### PR DESCRIPTION
## What does this pull request do?

To assist support, we're adding disable instructions to each Agent's troubleshooting docs.

<img width="687" alt="Screen Shot 2020-07-29 at 1 06 21 PM" src="https://user-images.githubusercontent.com/5618806/88847767-5f2b5480-d19c-11ea-9df2-71df4ed4fd78.png">


## Related issues

For https://github.com/elastic/observability-docs/issues/35.
