### PR TITLE
Move stacktrace building to worker threads

### DIFF
--- a/lib/elastic_apm/span.rb
+++ b/lib/elastic_apm/span.rb
@@ -97,11 +97,12 @@ module ElasticAPM
 
     def done(clock_end: Util.monotonic_micros)
       stop clock_end
+      self
+    end
 
+    def prepare_for_serialization!
       build_stacktrace! if should_build_stacktrace?
       self.original_backtrace = nil # release original
-
-      self
     end
 
     def stopped?

--- a/lib/elastic_apm/transport/worker.rb
+++ b/lib/elastic_apm/transport/worker.rb
@@ -77,6 +77,10 @@ module ElasticAPM
       private
 
       def serialize_and_filter(resource)
+        if resource.respond_to?(:prepare_for_serialization!)
+          resource.prepare_for_serialization!
+        end
+
         serialized = serializers.serialize(resource)
 
         # if a filter returns nil, it means skip the event

--- a/spec/elastic_apm/transport/worker_spec.rb
+++ b/spec/elastic_apm/transport/worker_spec.rb
@@ -103,6 +103,17 @@ module ElasticAPM
             expect(subject.connection.calls.length).to be 0
           end
         end
+
+        context 'with a preparable resource' do
+          it 'prepares the thing for processing' do
+            preparable = double(prepare_for_serialization!: true)
+
+            queue.push preparable
+            Thread.new { subject.work_forever }.join 0.2
+
+            expect(preparable).to have_received(:prepare_for_serialization!)
+          end
+        end
       end
 
       describe '#process' do


### PR DESCRIPTION
Closes #285 

The reading and building of stacktraces is still the _slowest_ thing the agent does. This PR moves that work off the main thread. This doesn't remove the work load but it removes the direct impact on applications' response time.