### PR TITLE
Revert #839

### DIFF
--- a/lib/elastic_apm/config.rb
+++ b/lib/elastic_apm/config.rb
@@ -326,7 +326,7 @@ module ElasticAPM
       self.logger ||= ::Rails.logger
 
       self.__root_path = ::Rails.root.to_s
-      self.__view_paths = ::ActionController::Base.view_paths.map(&:to_s)
+      self.__view_paths = app.config.paths['app/views'].existent + [::Rails.root.to_s]
     end
 
     def rails_app_name(app)

--- a/spec/integration/rails_paths_spec.rb
+++ b/spec/integration/rails_paths_spec.rb
@@ -52,7 +52,7 @@ if defined?(Rails)
     end
 
     it 'sets the paths' do
-      expect(ElasticAPM.agent.config.__view_paths.first).to match(%r{/.*/test/path})
+      expect(ElasticAPM.agent.config.__view_paths.first).to match(%r{test/path})
       expect(ElasticAPM.agent.config.__root_path).to eq('rootz')
     end
   end


### PR DESCRIPTION
The `rails#master` specs fail from the change in #839. I haven't been able to diagnose why _exactly_ they do so but they didn't before.

The change was made so that views from engines would be included. My thought with adding `Rails.root` to the list was that, if you're splitting into engines, you probably keep those inside the same dir.