### PR TITLE
Remove secrets from cookies for error reporting

### DIFF
--- a/lib/elastic_apm/transport/filters/secrets_filter.rb
+++ b/lib/elastic_apm/transport/filters/secrets_filter.rb
@@ -37,6 +37,7 @@ module ElasticAPM
           @sanitizer.strip_from! payload.dig(:transaction, :context, :request, :cookies)
           @sanitizer.strip_from! payload.dig(:transaction, :context, :response, :headers)
           @sanitizer.strip_from! payload.dig(:error, :context, :request, :headers)
+          @sanitizer.strip_from! payload.dig(:error, :context, :request, :cookies)
           @sanitizer.strip_from! payload.dig(:error, :context, :response, :headers)
           @sanitizer.strip_from! payload.dig(:transaction, :context, :request, :body)
 

--- a/spec/elastic_apm/transport/filters/secrets_filter_spec.rb
+++ b/spec/elastic_apm/transport/filters/secrets_filter_spec.rb
@@ -81,6 +81,22 @@ module ElasticAPM
           expect(body).to match('api_key' => '[FILTERED]', 'other' => 'not me')
         end
 
+        it 'removes secrets from cookies for error reporting' do
+          payload = { error: { context: { request: { cookies: {
+            auth_jwt: 'very zecret!',
+            untouched: 'very much'
+          } } } } }
+
+          subject.call(payload)
+
+          cookies = payload.dig(:error, :context, :request, :cookies)
+
+          expect(cookies).to match(
+            auth_jwt: '[FILTERED]',
+            untouched: 'very much'
+          )
+        end
+
         context 'with custom_key_filters' do
           before do
             # silence deprecation warning


### PR DESCRIPTION
Sensitive data are not filtered from cookies for the errors reporting.