### PR TITLE
Fix variable typo in instrumenter

### DIFF
--- a/lib/elastic_apm/instrumenter.rb
+++ b/lib/elastic_apm/instrumenter.rb
@@ -120,7 +120,7 @@ module ElasticAPM
       end
 
       if trace_context
-        samled = trace_context.recorded?
+        sampled = trace_context.recorded?
         sample_rate = trace_context.tracestate.sample_rate
       else
         sampled = random_sample?(config)


### PR DESCRIPTION
I noticed this small variable typo in the instrumenter when reviewing the code changes made in the last few months.