### PR TITLE
Implement sample_rate precision spec

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -49,6 +49,7 @@ endif::[]
 ===== Changed
 
 - Align the default value of `sanitize_field_names` with other agents {pull}867[#867]
+- Ensure max 4 digits of precision for `sample_rate` as per agent spec {pull}880[#880]
 
 [float]
 ===== Fixed

--- a/docs/configuration.asciidoc
+++ b/docs/configuration.asciidoc
@@ -853,6 +853,7 @@ To reduce overhead and storage requirements, you can set the sample rate to a va
 between `0.0` and `1.0`.
 We still record overall time and the result for unsampled transactions, but no
 context information, tags, or spans.
+Note that the sample rate will be rounded to 4 digits of precision.
 
 [float]
 [[config-use-experimental-sql-parser]]

--- a/lib/elastic_apm/config.rb
+++ b/lib/elastic_apm/config.rb
@@ -20,7 +20,7 @@
 require 'elastic_apm/config/bytes'
 require 'elastic_apm/config/duration'
 require 'elastic_apm/config/options'
-require 'elastic_apm/config/precision'
+require 'elastic_apm/config/round_float'
 require 'elastic_apm/config/regexp_list'
 require 'elastic_apm/config/wildcard_pattern_list'
 
@@ -97,7 +97,7 @@ module ElasticAPM
     option :stack_trace_limit,                 type: :int,    default: 999_999
     option :transaction_ignore_urls,           type: :list,   default: [],      converter: WildcardPatternList.new
     option :transaction_max_spans,             type: :int,    default: 500
-    option :transaction_sample_rate,           type: :float,  default: 1.0,     converter: Precision.new
+    option :transaction_sample_rate,           type: :float,  default: 1.0,     converter: RoundFloat.new
     option :use_elastic_traceparent_header,    type: :bool,   default: true
     option :use_legacy_sql_parser,             type: :bool,   default: false
     option :verify_server_cert,                type: :bool,   default: true

--- a/lib/elastic_apm/config.rb
+++ b/lib/elastic_apm/config.rb
@@ -17,9 +17,10 @@
 
 # frozen_string_literal: true
 
-require 'elastic_apm/config/options'
-require 'elastic_apm/config/duration'
 require 'elastic_apm/config/bytes'
+require 'elastic_apm/config/duration'
+require 'elastic_apm/config/options'
+require 'elastic_apm/config/precision'
 require 'elastic_apm/config/regexp_list'
 require 'elastic_apm/config/wildcard_pattern_list'
 
@@ -96,7 +97,7 @@ module ElasticAPM
     option :stack_trace_limit,                 type: :int,    default: 999_999
     option :transaction_ignore_urls,           type: :list,   default: [],      converter: WildcardPatternList.new
     option :transaction_max_spans,             type: :int,    default: 500
-    option :transaction_sample_rate,           type: :float,  default: 1.0
+    option :transaction_sample_rate,           type: :float,  default: 1.0,     converter: Precision.new
     option :use_elastic_traceparent_header,    type: :bool,   default: true
     option :use_legacy_sql_parser,             type: :bool,   default: false
     option :verify_server_cert,                type: :bool,   default: true

--- a/lib/elastic_apm/config/precision.rb
+++ b/lib/elastic_apm/config/precision.rb
@@ -1,0 +1,31 @@
+# Licensed to Elasticsearch B.V. under one or more contributor
+# license agreements. See the NOTICE file distributed with
+# this work for additional information regarding copyright
+# ownership. Elasticsearch B.V. licenses this file to you under
+# the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# frozen_string_literal: true
+
+require 'elastic_apm/util/precision_validator'
+
+module ElasticAPM
+  class Config
+    # @api private
+    class Precision
+      def call(value)
+        Util::PrecisionValidator.validate(value, precision: 4, minimum: 0.0001)
+      end
+    end
+  end
+end

--- a/lib/elastic_apm/config/round_float.rb
+++ b/lib/elastic_apm/config/round_float.rb
@@ -22,7 +22,7 @@ require 'elastic_apm/util/precision_validator'
 module ElasticAPM
   class Config
     # @api private
-    class Precision
+    class RoundFloat
       def call(value)
         Util::PrecisionValidator.validate(value, precision: 4, minimum: 0.0001)
       end

--- a/lib/elastic_apm/trace_context/tracestate.rb
+++ b/lib/elastic_apm/trace_context/tracestate.rb
@@ -17,6 +17,8 @@
 
 # frozen_string_literal: true
 
+require 'elastic_apm/util/precision_validator'
+
 module ElasticAPM
   class TraceContext
     # @api private
@@ -63,13 +65,9 @@ module ElasticAPM
         end
 
         def sample_rate=(val)
-          float = Float(val).round(3)
-
-          return nil unless (0.0..1.0).include?(float)
-
-          @sample_rate = float
-        rescue ArgumentError => e
-          nil
+          @sample_rate = Util::PrecisionValidator.validate(
+            val, precision: 4, minimum: 0.0001
+          )
         end
 
         def to_s

--- a/lib/elastic_apm/util/precision_validator.rb
+++ b/lib/elastic_apm/util/precision_validator.rb
@@ -20,22 +20,25 @@
 module ElasticAPM
   module Util
     # @api private
+    # Rounds half away from zero.
+    # If `minimum` is provided, and the value rounds to 0 (but was not zero to
+    # begin with), use the minimum instead.
     module PrecisionValidator
       extend self
 
       def validate(value, precision: 0, minimum: nil)
         float = Float(value)
-        return nil unless (0.0..1.0).include?(float)
+        return nil unless (0.0..1.0).cover?(float)
         return float if float == 0
 
-        multiplier = 10 ** precision
-        rounded = Float((float * multiplier + 0.5).floor) / multiplier
+        multiplier = Float(10**precision)
+        rounded = (float * multiplier + 0.5).floor / multiplier
         if rounded == 0 && minimum
           minimum
         else
           rounded
         end
-      rescue ArgumentError => e
+      rescue ArgumentError
         nil
       end
     end

--- a/lib/elastic_apm/util/precision_validator.rb
+++ b/lib/elastic_apm/util/precision_validator.rb
@@ -1,0 +1,43 @@
+# Licensed to Elasticsearch B.V. under one or more contributor
+# license agreements. See the NOTICE file distributed with
+# this work for additional information regarding copyright
+# ownership. Elasticsearch B.V. licenses this file to you under
+# the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# frozen_string_literal: true
+
+module ElasticAPM
+  module Util
+    # @api private
+    module PrecisionValidator
+      extend self
+
+      def validate(value, precision: 0, minimum: nil)
+        float = Float(value)
+        return nil unless (0.0..1.0).include?(float)
+        return float if float == 0
+
+        multiplier = 10 ** precision
+        rounded = Float((float * multiplier + 0.5).floor) / multiplier
+        if rounded == 0 && minimum
+          minimum
+        else
+          rounded
+        end
+      rescue ArgumentError => e
+        nil
+      end
+    end
+  end
+end

--- a/spec/elastic_apm/config_spec.rb
+++ b/spec/elastic_apm/config_spec.rb
@@ -136,6 +136,17 @@ module ElasticAPM
       end
     end
 
+    describe 'sample rate precision' do
+      context 'sets a minimum' do
+        subject { Config.new(transaction_sample_rate: '0.00001') }
+        its(:transaction_sample_rate) { should eq 0.0001 }
+      end
+      context 'ensures max 4 digits of precision' do
+        subject { Config.new(transaction_sample_rate: '0.55554') }
+        its(:transaction_sample_rate) { should eq 0.5555 }
+      end
+    end
+
     it 'yields itself to a given block' do
       config = Config.new { |c| c.server_url = 'somewhere-else.com' }
       expect(config.server_url).to eq 'somewhere-else.com'

--- a/spec/elastic_apm/trace_context/tracestate_spec.rb
+++ b/spec/elastic_apm/trace_context/tracestate_spec.rb
@@ -81,10 +81,10 @@ module ElasticAPM
         expect(state.to_header).to eq 'es=s:0.5'
       end
 
-      it 'rounds to three decimals' do
+      it 'ensures max 4 digits of precision' do
         state = described_class.new
-        state.sample_rate = 0.123456
-        expect(state.to_header).to eq('es=s:0.123')
+        state.sample_rate = 0.55554
+        expect(state.to_header).to eq('es=s:0.5555')
       end
     end
   end

--- a/spec/elastic_apm/util/precision_validator_spec.rb
+++ b/spec/elastic_apm/util/precision_validator_spec.rb
@@ -1,0 +1,78 @@
+# Licensed to Elasticsearch B.V. under one or more contributor
+# license agreements. See the NOTICE file distributed with
+# this work for additional information regarding copyright
+# ownership. Elasticsearch B.V. licenses this file to you under
+# the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+module ElasticAPM
+  RSpec.describe Util::PrecisionValidator do
+    context 'when not a float' do
+      it 'returns nil' do
+        expect(described_class.validate('a')).to eq nil
+      end
+    end
+
+    context 'less than 0' do
+      it 'returns nil' do
+        expect(described_class.validate(-1)).to eq nil
+      end
+    end
+
+    context 'greater than 1' do
+      it 'returns nil' do
+        expect(described_class.validate(2)).to eq nil
+      end
+    end
+
+    context 'equal to 1' do
+      it 'returns 1' do
+        expect(described_class.validate(1)).to eq 1
+      end
+    end
+
+    context 'equal to 0' do
+      it 'returns 1' do
+        expect(described_class.validate(0)).to eq 0
+      end
+    end
+
+    context 'less than the minimum' do
+      it 'returns the minimum' do
+        expect(described_class.validate(
+          0.00001, precision: 4, minimum: 0.0001)
+        ).to eq 0.0001
+      end
+    end
+
+    context 'more digits of precision and rounded down' do
+      it 'returns the rounded number' do
+        expect(described_class.validate(
+          0.55554, precision: 4, minimum: 0.0001)
+        ).to eq 0.5555
+      end
+    end
+
+    context 'more digits of precision and rounded up' do
+      it 'returns the rounded number' do
+        expect(described_class.validate(
+          0.55555, precision: 4, minimum: 0.0001)
+        ).to eq 0.5556
+      end
+    end
+  end
+end

--- a/spec/elastic_apm/util/precision_validator_spec.rb
+++ b/spec/elastic_apm/util/precision_validator_spec.rb
@@ -21,7 +21,7 @@ require 'spec_helper'
 
 module ElasticAPM
   RSpec.describe Util::PrecisionValidator do
-    context 'when not a float' do
+    context 'not a float' do
       it 'returns nil' do
         expect(described_class.validate('a')).to eq nil
       end
@@ -46,12 +46,12 @@ module ElasticAPM
     end
 
     context 'equal to 0' do
-      it 'returns 1' do
+      it 'returns 0' do
         expect(described_class.validate(0)).to eq 0
       end
     end
 
-    context 'less than the minimum' do
+    context 'between 0 and the minimum' do
       it 'returns the minimum' do
         expect(described_class.validate(
           0.00001, precision: 4, minimum: 0.0001)


### PR DESCRIPTION
This PR adds a `PrecisionValidator` in the Utils that can ensure a certain number of digits of precision of a number between 0 and 1. It optionally ensures a minimum.

The `PrecisionValidator` is used
- by a `Precision` Converter in the config when `transaction_sample_rate` is loaded
- by a `Tracestate` when `sample_rate` is set.

Closes #868 