### PR TITLE
Strip null values in cloud metadata

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -35,6 +35,15 @@ endif::[]
 [[release-notes-3.x]]
 === Ruby Agent version 3.x
 
+[float]
+[[unreleased]]
+==== Unreleased
+
+[float]
+===== Fixed
+
+- Fix reporting from Kubernetes based deploys to APM Server 7.9.x {pull}885[#885]
+
 [[release-notes-3.11.0]]
 ==== 3.11.0 (2020-10-27)
 

--- a/Gemfile
+++ b/Gemfile
@@ -22,7 +22,6 @@ source 'https://rubygems.org'
 git_source(:github) { |repo_name| "https://github.com/#{repo_name}" }
 
 # Tools
-gem 'bootsnap', require: false
 gem 'cucumber', require: false
 gem 'pry'
 gem 'rack-test'

--- a/lib/elastic_apm/transport/serializers/metadata_serializer.rb
+++ b/lib/elastic_apm/transport/serializers/metadata_serializer.rb
@@ -89,7 +89,7 @@ module ElasticAPM
         end
 
         def build_cloud(cloud)
-          {
+          strip_nulls!(
             provider: cloud.provider,
             account: {
               id: keyword_field(cloud.account_id),
@@ -106,11 +106,25 @@ module ElasticAPM
               name: keyword_field(cloud.project_name),
             },
             region: keyword_field(cloud.region)
-          }
+          )
         end
 
         def build_labels(labels)
           keyword_object(labels)
+        end
+
+        # A bug in APM Server 7.9 disallows null values in `cloud`
+        def strip_nulls!(hash)
+          hash.each do |key, value|
+            case value
+            when Hash
+              strip_nulls!(value)
+              hash.delete(key) if value.empty?
+            when nil then hash.delete(key)
+            end
+          end
+
+          hash
         end
       end
     end

--- a/lib/elastic_apm/transport/serializers/metadata_serializer.rb
+++ b/lib/elastic_apm/transport/serializers/metadata_serializer.rb
@@ -115,8 +115,8 @@ module ElasticAPM
 
         # A bug in APM Server 7.9 disallows null values in `cloud`
         def strip_nulls!(hash)
-          hash.each do |key, value|
-            case value
+          hash.keys.each do |key|
+            case value = hash[key]
             when Hash
               strip_nulls!(value)
               hash.delete(key) if value.empty?

--- a/spec/elastic_apm/transport/serializers/metadata_serializer_spec.rb
+++ b/spec/elastic_apm/transport/serializers/metadata_serializer_spec.rb
@@ -68,13 +68,8 @@ module ElasticAPM
               metadata.cloud.account_id = 'asdf'
 
               expect(result.dig(:metadata, :cloud)).to match(
-                account: { id: 'asdf', name: nil },
-                availability_zone: nil,
-                instance: { id: nil, name: nil },
-                machine: { type: nil },
-                project: { id: nil, name: nil },
-                provider: 'something',
-                region: nil
+                account: { id: 'asdf' },
+                provider: 'something'
               )
             end
           end


### PR DESCRIPTION
Fixes elastic/apm-agent-ruby#884 