### PR TITLE
Update dynamo db test

### DIFF
--- a/spec/elastic_apm/spies/dynamo_db_spec.rb
+++ b/spec/elastic_apm/spies/dynamo_db_spec.rb
@@ -43,12 +43,17 @@ module ElasticAPM
             write_capacity_units: 1
           }
         },
+        export_table_to_point_in_time: {
+          table_arn: 'TableArn',
+          s3_bucket: 'S3Bucket'
+        },
         delete_backup: { backup_arn: '' },
         delete_item: { table_name: 'test', key: {} },
         delete_table: { table_name: 'test' },
         describe_backup: { backup_arn: 'test' },
         describe_continuous_backups: { table_name: 'test' },
         describe_contributor_insights: { table_name: 'test' },
+        describe_export: { export_arn: 'ExportArn' },
         describe_global_table: { global_table_name: 'test' },
         describe_global_table_settings: { global_table_name: 'test' },
         describe_table: { table_name: 'test' },


### PR DESCRIPTION
There are two more operations available via the latest `aws-sdk-dynamodb` gem that were missing from the required params hash. This was causing the test to fail as it iterated over `::Aws::DynamoDB::Client.api.operation_names`