### PR TITLE
Use Module#prepend where possible

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -27,6 +27,8 @@ gem 'pry'
 gem 'rack-test'
 gem 'rspec', '~> 3'
 gem 'rspec-its'
+gem 'rubocop', require: false
+gem 'rubocop-performance', require: false
 gem 'timecop'
 gem 'webmock'
 

--- a/lib/elastic_apm.rb
+++ b/lib/elastic_apm.rb
@@ -387,7 +387,7 @@ module ElasticAPM
     # @yield [Hash] A filter. Used if provided. Otherwise using `callback`
     # @return [Bool] true
     def add_filter(key, callback = nil, &block)
-      if callback.nil? && !block_given?
+      if callback.nil? && !block
         raise ArgumentError, '#add_filter needs either `callback\' or a block'
       end
 

--- a/lib/elastic_apm/central_config.rb
+++ b/lib/elastic_apm/central_config.rb
@@ -66,9 +66,9 @@ module ElasticAPM
     def fetch_and_apply_config
       @promise =
         Concurrent::Promise
-        .execute(&method(:fetch_config))
-        .on_success(&method(:handle_success))
-        .rescue(&method(:handle_error))
+        .execute { fetch_config }
+        .on_success { |resp| handle_success(resp) }
+        .rescue { |err| handle_error(err) }
     end
 
     def fetch_config
@@ -182,7 +182,7 @@ module ElasticAPM
 
       @scheduled_task =
         Concurrent::ScheduledTask
-        .execute(seconds, &method(:fetch_and_apply_config))
+        .execute(seconds) { fetch_and_apply_config }
     end
   end
 end

--- a/lib/elastic_apm/config/regexp_list.rb
+++ b/lib/elastic_apm/config/regexp_list.rb
@@ -23,7 +23,7 @@ module ElasticAPM
     class RegexpList
       def call(value)
         value = value.is_a?(String) ? value.split(',') : Array(value)
-        value.map(&Regexp.method(:new))
+        value.map { |p| Regexp.new(p) }
       end
     end
   end

--- a/lib/elastic_apm/config/wildcard_pattern_list.rb
+++ b/lib/elastic_apm/config/wildcard_pattern_list.rb
@@ -59,7 +59,7 @@ module ElasticAPM
 
       def call(value)
         value = value.is_a?(String) ? value.split(',') : Array(value)
-        value.map(&WildcardPattern.method(:new))
+        value.map { |p| WildcardPattern.new(p) }
       end
     end
   end

--- a/lib/elastic_apm/span_helpers.rb
+++ b/lib/elastic_apm/span_helpers.rb
@@ -42,7 +42,7 @@ module ElasticAPM
               return super(*args)
             end
 
-            ElasticAPM.with_span "#{name}", "#{type}" do
+            ElasticAPM.with_span name.to_s, type.to_s do
               super(*args)
             end
           end

--- a/lib/elastic_apm/span_helpers.rb
+++ b/lib/elastic_apm/span_helpers.rb
@@ -36,19 +36,17 @@ module ElasticAPM
         name ||= method.to_s
         type ||= Span::DEFAULT_TYPE
 
-        klass.class_eval <<-RUBY, __FILE__, __LINE__ + 1
-          alias :"__without_apm_#{method}" :"#{method}"
-
-          def #{method}(*args, &block)
+        klass.prepend(Module.new do
+          define_method(method) do |*args|
             unless ElasticAPM.current_transaction
-              return __without_apm_#{method}(*args, &block)
+              return super(*args)
             end
 
             ElasticAPM.with_span "#{name}", "#{type}" do
-              __without_apm_#{method}(*args, &block)
+              super(*args)
             end
           end
-        RUBY
+        end)
       end
     end
 

--- a/lib/elastic_apm/spies/action_dispatch.rb
+++ b/lib/elastic_apm/spies/action_dispatch.rb
@@ -22,6 +22,7 @@ module ElasticAPM
   module Spies
     # @api private
     class ActionDispatchSpy
+      # @api private
       module Ext
         def render_exception(env, exception)
           context = ElasticAPM.build_context(rack_env: env, for_type: :error)

--- a/lib/elastic_apm/spies/action_dispatch.rb
+++ b/lib/elastic_apm/spies/action_dispatch.rb
@@ -22,17 +22,17 @@ module ElasticAPM
   module Spies
     # @api private
     class ActionDispatchSpy
-      def install
-        ::ActionDispatch::ShowExceptions.class_eval do
-          alias render_exception_without_apm render_exception
+      module Ext
+        def render_exception(env, exception)
+          context = ElasticAPM.build_context(rack_env: env, for_type: :error)
+          ElasticAPM.report(exception, context: context, handled: false)
 
-          def render_exception(env, exception)
-            context = ElasticAPM.build_context(rack_env: env, for_type: :error)
-            ElasticAPM.report(exception, context: context, handled: false)
-
-            render_exception_without_apm env, exception
-          end
+          super(env, exception)
         end
+      end
+
+      def install
+        ::ActionDispatch::ShowExceptions.prepend(Ext)
       end
     end
 

--- a/lib/elastic_apm/spies/dynamo_db.rb
+++ b/lib/elastic_apm/spies/dynamo_db.rb
@@ -32,6 +32,7 @@ module ElasticAPM
         # rubocop:enable Style/ExplicitBlockArgument
       end
 
+      # @api private
       module Ext
         def self.prepended(mod)
           mod.api.operation_names.each do |operation_name|

--- a/lib/elastic_apm/spies/dynamo_db.rb
+++ b/lib/elastic_apm/spies/dynamo_db.rb
@@ -33,16 +33,18 @@ module ElasticAPM
       end
 
       module Ext
-        ::Aws::DynamoDB::Client.api.operation_names.each do |operation_name|
-          define_method(operation_name) do |params = {}, options = {}|
-            ElasticAPM.with_span(
-              operation_name,
-              'db',
-              subtype: 'dynamodb',
-              action: operation_name
-            ) do
-              ElasticAPM::Spies::DynamoDBSpy.without_net_http do
-                super(params, options)
+        def self.prepended(mod)
+          mod.api.operation_names.each do |operation_name|
+            define_method(operation_name) do |params = {}, options = {}|
+              ElasticAPM.with_span(
+                operation_name,
+                'db',
+                subtype: 'dynamodb',
+                action: operation_name
+              ) do
+                ElasticAPM::Spies::DynamoDBSpy.without_net_http do
+                  super(params, options)
+                end
               end
             end
           end

--- a/lib/elastic_apm/spies/elasticsearch.rb
+++ b/lib/elastic_apm/spies/elasticsearch.rb
@@ -37,46 +37,46 @@ module ElasticAPM
           end
       end
 
-      def install
-        ::Elasticsearch::Transport::Client.class_eval do
-          alias perform_request_without_apm perform_request
-
-          def perform_request(method, path, *args, &block)
-            unless ElasticAPM.current_transaction
-              return perform_request_without_apm(method, path, *args, &block)
-            end
-
-            name = format(NAME_FORMAT, method, path)
-            statement = []
-
-            statement << { params: args&.[](0) }
-
-            if ElasticAPM.agent.config.capture_elasticsearch_queries
-              unless args[1].nil? || args[1].empty?
-                statement << {
-                  body: ElasticAPM::Spies::ElasticsearchSpy
-                             .sanitizer.strip_from(args[1])
-                }
-              end
-            end
-
-            context = Span::Context.new(
-              db: { statement: statement.reduce({}, :merge).to_json },
-              destination: {
-                name: SUBTYPE,
-                resource: SUBTYPE,
-                type: TYPE
-              }
-            )
-
-            ElasticAPM.with_span(
-              name,
-              TYPE,
-              subtype: SUBTYPE,
-              context: context
-            ) { perform_request_without_apm(method, path, *args, &block) }
+      module Ext
+        def perform_request(method, path, *args, &block)
+          unless ElasticAPM.current_transaction
+            return super(method, path, *args, &block)
           end
+
+          name = format(NAME_FORMAT, method, path)
+          statement = []
+
+          statement << { params: args&.[](0) }
+
+          if ElasticAPM.agent.config.capture_elasticsearch_queries
+            unless args[1].nil? || args[1].empty?
+              body =
+                ElasticAPM::Spies::ElasticsearchSpy
+                .sanitizer.strip_from(args[1])
+              statement << { body:  body }
+            end
+          end
+
+          context = Span::Context.new(
+            db: { statement: statement.reduce({}, :merge).to_json },
+            destination: {
+              name: SUBTYPE,
+              resource: SUBTYPE,
+              type: TYPE
+            }
+          )
+
+          ElasticAPM.with_span(
+            name,
+            TYPE,
+            subtype: SUBTYPE,
+            context: context
+          ) { super(method, path, *args, &block) }
         end
+      end
+
+      def install
+        ::Elasticsearch::Transport::Client.prepend(Ext)
       end
     end
 

--- a/lib/elastic_apm/spies/elasticsearch.rb
+++ b/lib/elastic_apm/spies/elasticsearch.rb
@@ -37,6 +37,7 @@ module ElasticAPM
           end
       end
 
+      # @api private
       module Ext
         def perform_request(method, path, *args, &block)
           unless ElasticAPM.current_transaction
@@ -53,7 +54,7 @@ module ElasticAPM
               body =
                 ElasticAPM::Spies::ElasticsearchSpy
                 .sanitizer.strip_from(args[1])
-              statement << { body:  body }
+              statement << { body: body }
             end
           end
 

--- a/lib/elastic_apm/spies/faraday.rb
+++ b/lib/elastic_apm/spies/faraday.rb
@@ -35,70 +35,67 @@ module ElasticAPM
         # rubocop:enable Style/ExplicitBlockArgument
       end
 
-      # rubocop:disable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
-      def install
-        ::Faraday::Connection.class_eval do
-          alias run_request_without_apm run_request
+      module Ext
+        def run_request(method, url, body, headers, &block)
+          unless (transaction = ElasticAPM.current_transaction)
+            return super(method, url, body, headers, &block)
+          end
 
-          def run_request(method, url, body, headers, &block)
-            unless (transaction = ElasticAPM.current_transaction)
-              return run_request_without_apm(method, url, body, headers, &block)
+          uri = URI(build_url(url))
+
+          # If url is set inside block it isn't available until yield,
+          # so we temporarily build the request to yield. This could be a
+          # problem if the block has side effects as it will be yielded twice
+          # ~mikker
+          unless uri.host
+            tmp_request = build_request(method) do |req|
+              yield(req) if block_given?
             end
+            uri = URI(tmp_request.path)
+          end
 
-            uri = URI(build_url(url))
+          host = uri.host
 
-            # If url is set inside block it isn't available until yield,
-            # so we temporarily build the request to yield. This could be a
-            # problem if the block has side effects as it will be yielded twice
-            # ~mikker
-            unless uri.host
-              tmp_request = build_request(method) do |req|
-                yield(req) if block_given?
+          upcased_method = method.to_s.upcase
+
+          destination = ElasticAPM::Span::Context::Destination.from_uri(uri)
+
+          context =
+            ElasticAPM::Span::Context.new(
+              http: { url: uri, method: upcased_method },
+              destination: destination
+            )
+
+          ElasticAPM.with_span(
+            "#{upcased_method} #{host}",
+            TYPE,
+            subtype: SUBTYPE,
+            action: upcased_method,
+            context: context
+          ) do |span|
+            ElasticAPM::Spies::FaradaySpy.without_net_http do
+              trace_context = span&.trace_context || transaction.trace_context
+
+              result = super(method, url, body, headers) do |req|
+                trace_context.apply_headers { |k, v| req[k] = v }
+
+                yield req if block_given?
               end
-              uri = URI(tmp_request.path)
-            end
 
-            host = uri.host
-
-            upcased_method = method.to_s.upcase
-
-            destination = ElasticAPM::Span::Context::Destination.from_uri(uri)
-
-            context =
-              ElasticAPM::Span::Context.new(
-                http: { url: uri, method: upcased_method },
-                destination: destination
-              )
-
-            ElasticAPM.with_span(
-              "#{upcased_method} #{host}",
-              TYPE,
-              subtype: SUBTYPE,
-              action: upcased_method,
-              context: context
-            ) do |span|
-              ElasticAPM::Spies::FaradaySpy.without_net_http do
-                trace_context = span&.trace_context || transaction.trace_context
-
-                result =
-                  run_request_without_apm(method, url, body, headers) do |req|
-                    trace_context.apply_headers { |k, v| req[k] = v }
-
-                    yield req if block_given?
-                  end
-
-                if (http = span&.context&.http)
-                  http.status_code = result.status.to_s
-                end
-
-                span&.outcome = Span::Outcome.from_http_status(result.status)
-                result
+              if (http = span&.context&.http)
+                http.status_code = result.status.to_s
               end
+
+              span&.outcome = Span::Outcome.from_http_status(result.status)
+              result
             end
           end
         end
       end
-      # rubocop:enable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
+
+      def install
+        ::Faraday::Connection.prepend(Ext)
+      end
     end
 
     register 'Faraday', 'faraday', FaradaySpy.new

--- a/lib/elastic_apm/spies/faraday.rb
+++ b/lib/elastic_apm/spies/faraday.rb
@@ -35,7 +35,9 @@ module ElasticAPM
         # rubocop:enable Style/ExplicitBlockArgument
       end
 
+      # @api private
       module Ext
+        # rubocop:disable Metrics/PerceivedComplexity, Metrics/CyclomaticComplexity
         def run_request(method, url, body, headers, &block)
           unless (transaction = ElasticAPM.current_transaction)
             return super(method, url, body, headers, &block)
@@ -49,7 +51,7 @@ module ElasticAPM
           # ~mikker
           unless uri.host
             tmp_request = build_request(method) do |req|
-              yield(req) if block_given?
+              yield(req) if block
             end
             uri = URI(tmp_request.path)
           end
@@ -79,7 +81,7 @@ module ElasticAPM
               result = super(method, url, body, headers) do |req|
                 trace_context.apply_headers { |k, v| req[k] = v }
 
-                yield req if block_given?
+                yield req if block
               end
 
               if (http = span&.context&.http)
@@ -91,6 +93,7 @@ module ElasticAPM
             end
           end
         end
+        # rubocop:enable Metrics/PerceivedComplexity, Metrics/CyclomaticComplexity
       end
 
       def install

--- a/lib/elastic_apm/spies/http.rb
+++ b/lib/elastic_apm/spies/http.rb
@@ -25,6 +25,7 @@ module ElasticAPM
       TYPE = 'ext'
       SUBTYPE = 'http_rb'
 
+      # @api private
       module Ext
         def perform(req, options)
           unless (transaction = ElasticAPM.current_transaction)

--- a/lib/elastic_apm/spies/http.rb
+++ b/lib/elastic_apm/spies/http.rb
@@ -24,48 +24,49 @@ module ElasticAPM
     class HTTPSpy
       TYPE = 'ext'
       SUBTYPE = 'http_rb'
-      def install
-        ::HTTP::Client.class_eval do
-          alias perform_without_apm perform
 
-          def perform(req, options)
-            unless (transaction = ElasticAPM.current_transaction)
-              return perform_without_apm(req, options)
+      module Ext
+        def perform(req, options)
+          unless (transaction = ElasticAPM.current_transaction)
+            return super(req, options)
+          end
+
+          method = req.verb.to_s.upcase
+          host = req.uri.host
+
+          destination =
+            ElasticAPM::Span::Context::Destination.from_uri(req.uri)
+          context = ElasticAPM::Span::Context.new(
+            http: { url: req.uri, method: method },
+            destination: destination
+          )
+
+          name = "#{method} #{host}"
+
+          ElasticAPM.with_span(
+            name,
+            TYPE,
+            subtype: SUBTYPE,
+            action: method,
+            context: context
+          ) do |span|
+            trace_context = span&.trace_context || transaction.trace_context
+            trace_context.apply_headers { |key, value| req[key] = value }
+
+            result = super(req, options)
+
+            if (http = span&.context&.http)
+              http.status_code = result.status.to_s
             end
 
-            method = req.verb.to_s.upcase
-            host = req.uri.host
-
-            destination =
-              ElasticAPM::Span::Context::Destination.from_uri(req.uri)
-            context = ElasticAPM::Span::Context.new(
-              http: { url: req.uri, method: method },
-              destination: destination
-            )
-
-            name = "#{method} #{host}"
-
-            ElasticAPM.with_span(
-              name,
-              TYPE,
-              subtype: SUBTYPE,
-              action: method,
-              context: context
-            ) do |span|
-              trace_context = span&.trace_context || transaction.trace_context
-              trace_context.apply_headers { |key, value| req[key] = value }
-
-              result = perform_without_apm(req, options)
-
-              if (http = span&.context&.http)
-                http.status_code = result.status.to_s
-              end
-
-              span&.outcome = Span::Outcome.from_http_status(result.status)
-              result
-            end
+            span&.outcome = Span::Outcome.from_http_status(result.status)
+            result
           end
         end
+      end
+
+      def install
+        ::HTTP::Client.prepend(Ext)
       end
     end
 

--- a/lib/elastic_apm/spies/net_http.rb
+++ b/lib/elastic_apm/spies/net_http.rb
@@ -46,7 +46,9 @@ module ElasticAPM
         end
       end
 
+      # @api private
       module Ext
+        # rubocop:disable Metrics/PerceivedComplexity, Metrics/CyclomaticComplexity
         def request(req, body = nil, &block)
           unless (transaction = ElasticAPM.current_transaction)
             return super(req, body, &block)
@@ -96,6 +98,7 @@ module ElasticAPM
             result
           end
         end
+        # rubocop:enable Metrics/PerceivedComplexity, Metrics/CyclomaticComplexity
       end
 
       def install

--- a/lib/elastic_apm/spies/net_http.rb
+++ b/lib/elastic_apm/spies/net_http.rb
@@ -46,65 +46,61 @@ module ElasticAPM
         end
       end
 
-      # rubocop:disable Metrics/CyclomaticComplexity
-      # rubocop:disable Metrics/PerceivedComplexity
-      def install
-        Net::HTTP.class_eval do
-          alias request_without_apm request
+      module Ext
+        def request(req, body = nil, &block)
+          unless (transaction = ElasticAPM.current_transaction)
+            return super(req, body, &block)
+          end
 
-          def request(req, body = nil, &block)
-            unless (transaction = ElasticAPM.current_transaction)
-              return request_without_apm(req, body, &block)
+          if ElasticAPM::Spies::NetHTTPSpy.disabled?
+            return super(req, body, &block)
+          end
+
+          host = req['host']&.split(':')&.first || address
+          method = req.method.to_s.upcase
+          path, query = req.path.split('?')
+
+          url = use_ssl? ? +'https://' : +'http://'
+          url << host
+          url << ":#{port}" if port
+          url << path
+          url << "?#{query}" if query
+          uri = URI(url)
+
+          destination =
+            ElasticAPM::Span::Context::Destination.from_uri(uri)
+
+          context =
+            ElasticAPM::Span::Context.new(
+              http: { url: uri, method: method },
+              destination: destination
+            )
+
+          ElasticAPM.with_span(
+            "#{method} #{host}",
+            TYPE,
+            subtype: SUBTYPE,
+            action: method,
+            context: context
+          ) do |span|
+            trace_context = span&.trace_context || transaction.trace_context
+            trace_context.apply_headers { |key, value| req[key] = value }
+
+            result = super(req, body, &block)
+
+            if (http = span&.context&.http)
+              http.status_code = result.code
             end
 
-            if ElasticAPM::Spies::NetHTTPSpy.disabled?
-              return request_without_apm(req, body, &block)
-            end
-
-            host = req['host']&.split(':')&.first || address
-            method = req.method.to_s.upcase
-            path, query = req.path.split('?')
-
-            url = use_ssl? ? +'https://' : +'http://'
-            url << host
-            url << ":#{port}" if port
-            url << path
-            url << "?#{query}" if query
-            uri = URI(url)
-
-            destination =
-              ElasticAPM::Span::Context::Destination.from_uri(uri)
-
-            context =
-              ElasticAPM::Span::Context.new(
-                http: { url: uri, method: method },
-                destination: destination
-              )
-
-            ElasticAPM.with_span(
-              "#{method} #{host}",
-              TYPE,
-              subtype: SUBTYPE,
-              action: method,
-              context: context
-            ) do |span|
-              trace_context = span&.trace_context || transaction.trace_context
-              trace_context.apply_headers { |key, value| req[key] = value }
-
-              result = request_without_apm(req, body, &block)
-
-              if (http = span&.context&.http)
-                http.status_code = result.code
-              end
-
-              span&.outcome = Span::Outcome.from_http_status(result.code)
-              result
-            end
+            span&.outcome = Span::Outcome.from_http_status(result.code)
+            result
           end
         end
       end
-      # rubocop:enable Metrics/CyclomaticComplexity
-      # rubocop:enable Metrics/PerceivedComplexity
+
+      def install
+        Net::HTTP.prepend(Ext)
+      end
     end
 
     register 'Net::HTTP', 'net/http', NetHTTPSpy.new

--- a/lib/elastic_apm/spies/rake.rb
+++ b/lib/elastic_apm/spies/rake.rb
@@ -22,41 +22,42 @@ module ElasticAPM
   module Spies
     # @api private
     class RakeSpy
-      def install
-        ::Rake::Task.class_eval do
-          alias execute_without_apm execute
+      module Ext
+        def execute(*args)
+          agent = ElasticAPM.start
 
-          def execute(*args)
-            agent = ElasticAPM.start
-
-            unless agent && agent.config.instrumented_rake_tasks.include?(name)
-              return execute_without_apm(*args)
-            end
-
-            transaction =
-              ElasticAPM.start_transaction("Rake::Task[#{name}]", 'Rake')
-
-            begin
-              result = execute_without_apm(*args)
-
-              transaction&.result = 'success'
-              transaction&.outcome = Transaction::Outcome::SUCCESS
-            rescue StandardError => e
-              transaction&.result = 'error'
-              transaction&.outcome = Transaction::Outcome::FAILURE
-              ElasticAPM.report(e)
-
-              raise
-            ensure
-              ElasticAPM.end_transaction
-              ElasticAPM.stop
-            end
-
-            result
+          unless agent && agent.config.instrumented_rake_tasks.include?(name)
+            return super(*args)
           end
+
+          transaction =
+            ElasticAPM.start_transaction("Rake::Task[#{name}]", 'Rake')
+
+          begin
+            result = super(*args)
+
+            transaction&.result = 'success'
+            transaction&.outcome = Transaction::Outcome::SUCCESS
+          rescue StandardError => e
+            transaction&.result = 'error'
+            transaction&.outcome = Transaction::Outcome::FAILURE
+            ElasticAPM.report(e)
+
+            raise
+          ensure
+            ElasticAPM.end_transaction
+            ElasticAPM.stop
+          end
+
+          result
         end
       end
+
+      def install
+        ::Rake::Task.prepend(Ext)
+      end
     end
+
     register 'Rake::Task', 'rake', RakeSpy.new
   end
 end

--- a/lib/elastic_apm/spies/rake.rb
+++ b/lib/elastic_apm/spies/rake.rb
@@ -22,6 +22,7 @@ module ElasticAPM
   module Spies
     # @api private
     class RakeSpy
+      # @api private
       module Ext
         def execute(*args)
           agent = ElasticAPM.start

--- a/lib/elastic_apm/spies/redis.rb
+++ b/lib/elastic_apm/spies/redis.rb
@@ -22,6 +22,7 @@ module ElasticAPM
   module Spies
     # @api private
     class RedisSpy
+      # @api private
       module Ext
         def call(command, &block)
           name = command[0].upcase

--- a/lib/elastic_apm/spies/redis.rb
+++ b/lib/elastic_apm/spies/redis.rb
@@ -22,20 +22,20 @@ module ElasticAPM
   module Spies
     # @api private
     class RedisSpy
-      def install
-        ::Redis::Client.class_eval do
-          alias call_without_apm call
+      module Ext
+        def call(command, &block)
+          name = command[0].upcase
 
-          def call(command, &block)
-            name = command[0].upcase
+          return super(command, &block) if command[0] == :auth
 
-            return call_without_apm(command, &block) if command[0] == :auth
-
-            ElasticAPM.with_span(name.to_s, 'db.redis') do
-              call_without_apm(command, &block)
-            end
+          ElasticAPM.with_span(name.to_s, 'db.redis') do
+            super(command, &block)
           end
         end
+      end
+
+      def install
+        ::Redis::Client.prepend(Ext)
       end
     end
 

--- a/lib/elastic_apm/spies/resque.rb
+++ b/lib/elastic_apm/spies/resque.rb
@@ -24,29 +24,25 @@ module ElasticAPM
     class ResqueSpy
       TYPE = 'Resque'
 
-      def install
-        install_perform_spy
+      module Ext
+        def perform
+          name = @payload && @payload['class']&.to_s
+          transaction = ElasticAPM.start_transaction(name, TYPE)
+          super
+          transaction&.done 'success'
+          transaction&.outcome = Transaction::Outcome::SUCCESS
+        rescue ::Exception => e
+          ElasticAPM.report(e, handled: false)
+          transaction&.done 'error'
+          transaction&.outcome = Transaction::Outcome::FAILURE
+          raise
+        ensure
+          ElasticAPM.end_transaction
+        end
       end
 
-      def install_perform_spy
-        ::Resque::Job.class_eval do
-          alias :perform_without_elastic_apm :perform
-
-          def perform
-            name = @payload && @payload['class']&.to_s
-            transaction = ElasticAPM.start_transaction(name, TYPE)
-            perform_without_elastic_apm
-            transaction&.done 'success'
-            transaction&.outcome = Transaction::Outcome::SUCCESS
-          rescue ::Exception => e
-            ElasticAPM.report(e, handled: false)
-            transaction&.done 'error'
-            transaction&.outcome = Transaction::Outcome::FAILURE
-            raise
-          ensure
-            ElasticAPM.end_transaction
-          end
-        end
+      def install
+        ::Resque::Job.prepend(Ext)
       end
     end
 

--- a/lib/elastic_apm/spies/resque.rb
+++ b/lib/elastic_apm/spies/resque.rb
@@ -24,6 +24,7 @@ module ElasticAPM
     class ResqueSpy
       TYPE = 'Resque'
 
+      # @api private
       module Ext
         def perform
           name = @payload && @payload['class']&.to_s

--- a/lib/elastic_apm/spies/sequel.rb
+++ b/lib/elastic_apm/spies/sequel.rb
@@ -31,61 +31,52 @@ module ElasticAPM
         @summarizer ||= Sql.summarizer
       end
 
-      # rubocop:disable Metrics/PerceivedComplexity, Metrics/CyclomaticComplexity
+      module Ext
+        def log_connection_yield(sql, connection, args = nil, &block)
+          unless ElasticAPM.current_transaction
+            return super(sql, connection, args, &block)
+          end
+
+          subtype = database_type.to_s
+
+          name =
+            ElasticAPM::Spies::SequelSpy.summarizer.summarize sql
+
+          context = ElasticAPM::Span::Context.new(
+            db: { statement: sql, type: 'sql', user: opts[:user] },
+            destination: { name: subtype, resource: subtype, type: TYPE }
+          )
+
+          span = ElasticAPM.start_span(
+            name,
+            TYPE,
+            subtype: subtype,
+            action: ACTION,
+            context: context
+          )
+          super(sql, connection, args, &block).tap do |result|
+            if name =~ /^(UPDATE|DELETE)/
+              if connection.respond_to?(:changes)
+                span.context.db.rows_affected = connection.changes
+              elsif result.is_a?(Integer)
+                span.context.db.rows_affected = result
+              end
+            end
+          end
+        rescue
+          span&.outcome = Span::Outcome::FAILURE
+          raise
+        ensure
+          span&.outcome ||= Span::Outcome::SUCCESS
+          ElasticAPM.end_span
+        end
+      end
+
       def install
         require 'sequel/database/logging'
 
-        ::Sequel::Database.class_eval do
-          alias log_connection_yield_without_apm log_connection_yield
-
-          def log_connection_yield(sql, connection, args = nil, &block)
-            unless ElasticAPM.current_transaction
-              return log_connection_yield_without_apm(
-                sql, connection, args, &block
-              )
-            end
-
-            subtype = database_type.to_s
-
-            name =
-              ElasticAPM::Spies::SequelSpy.summarizer.summarize sql
-
-            context = ElasticAPM::Span::Context.new(
-              db: { statement: sql, type: 'sql', user: opts[:user] },
-              destination: { name: subtype, resource: subtype, type: TYPE }
-            )
-
-            span = ElasticAPM.start_span(
-              name,
-              TYPE,
-              subtype: subtype,
-              action: ACTION,
-              context: context
-            )
-            log_connection_yield_without_apm(
-              sql,
-              connection,
-              args,
-              &block
-            ).tap do |result|
-              if name =~ /^(UPDATE|DELETE)/
-                if connection.respond_to?(:changes)
-                  span.context.db.rows_affected = connection.changes
-                elsif result.is_a?(Integer)
-                  span.context.db.rows_affected = result
-                end
-              end
-            end
-          rescue
-            span&.outcome = Span::Outcome::FAILURE
-            raise
-          ensure
-            span&.outcome ||= Span::Outcome::SUCCESS
-            ElasticAPM.end_span
-          end
-        end
+        ::Sequel::Database.prepend(Ext)
       end
-      # rubocop:enable Metrics/PerceivedComplexity, Metrics/CyclomaticComplexity
     end
 
     register 'Sequel', 'sequel', SequelSpy.new

--- a/lib/elastic_apm/spies/sequel.rb
+++ b/lib/elastic_apm/spies/sequel.rb
@@ -31,7 +31,9 @@ module ElasticAPM
         @summarizer ||= Sql.summarizer
       end
 
+      # @api private
       module Ext
+        # rubocop:disable Metrics/PerceivedComplexity, Metrics/CyclomaticComplexity
         def log_connection_yield(sql, connection, args = nil, &block)
           unless ElasticAPM.current_transaction
             return super(sql, connection, args, &block)
@@ -70,6 +72,7 @@ module ElasticAPM
           span&.outcome ||= Span::Outcome::SUCCESS
           ElasticAPM.end_span
         end
+        # rubocop:enable Metrics/PerceivedComplexity, Metrics/CyclomaticComplexity
       end
 
       def install

--- a/lib/elastic_apm/spies/sidekiq.rb
+++ b/lib/elastic_apm/spies/sidekiq.rb
@@ -65,32 +65,29 @@ module ElasticAPM
         end
       end
 
-      def install_processor
-        require 'sidekiq/processor'
-
-        Sidekiq::Processor.class_eval do
-          alias start_without_apm start
-          alias terminate_without_apm terminate
-
-          def start
-            result = start_without_apm
-
+      module Ext
+        def start
+          super.tap do
             # Already running from Railtie if Rails
             if ElasticAPM.running?
               ElasticAPM.agent.config.logger = Sidekiq.logger
             else
               ElasticAPM.start
             end
-
-            result
           end
+        end
 
-          def terminate
-            terminate_without_apm
-
+        def terminate
+          super.tap do
             ElasticAPM.stop
           end
         end
+      end
+
+      def install_processor
+        require 'sidekiq/processor'
+
+        Sidekiq::Processor.prepend(Ext)
       end
 
       def install

--- a/lib/elastic_apm/spies/sidekiq.rb
+++ b/lib/elastic_apm/spies/sidekiq.rb
@@ -65,6 +65,7 @@ module ElasticAPM
         end
       end
 
+      # @api private
       module Ext
         def start
           super.tap do

--- a/lib/elastic_apm/spies/sinatra.rb
+++ b/lib/elastic_apm/spies/sinatra.rb
@@ -22,35 +22,33 @@ module ElasticAPM
   module Spies
     # @api private
     class SinatraSpy
-      def install
-        ::Sinatra::Base.class_eval do
-          alias dispatch_without_apm! dispatch!
-          alias compile_template_without_apm compile_template
+      module Ext
+        def dispatch!(*args, &block)
+          super(*args, &block).tap do
+            next unless (transaction = ElasticAPM.current_transaction)
+            next unless (route = env['sinatra.route'])
 
-          def dispatch!(*args, &block)
-            dispatch_without_apm!(*args, &block).tap do
-              next unless (transaction = ElasticAPM.current_transaction)
-              next unless (route = env['sinatra.route'])
-
-              transaction.name = route
-            end
-          end
-
-          def compile_template(engine, data, opts, *args, &block)
-            opts[:__elastic_apm_template_name] =
-              case data
-              when Symbol then data.to_s
-              else format('Inline %s', engine)
-              end
-
-            compile_template_without_apm(engine, data, opts, *args, &block)
+            transaction.name = route
           end
         end
+
+        def compile_template(engine, data, opts, *args, &block)
+          opts[:__elastic_apm_template_name] =
+            case data
+            when Symbol then data.to_s
+            else format('Inline %s', engine)
+            end
+
+          super(engine, data, opts, *args, &block)
+        end
+      end
+
+      def install
+        ::Sinatra::Base.prepend(Ext)
       end
     end
 
     register 'Sinatra::Base', 'sinatra/base', SinatraSpy.new
-
     require 'elastic_apm/spies/tilt'
   end
 end

--- a/lib/elastic_apm/spies/sinatra.rb
+++ b/lib/elastic_apm/spies/sinatra.rb
@@ -22,6 +22,7 @@ module ElasticAPM
   module Spies
     # @api private
     class SinatraSpy
+      # @api private
       module Ext
         def dispatch!(*args, &block)
           super(*args, &block).tap do

--- a/lib/elastic_apm/spies/tilt.rb
+++ b/lib/elastic_apm/spies/tilt.rb
@@ -24,6 +24,7 @@ module ElasticAPM
     class TiltSpy
       TYPE = 'template.tilt'
 
+      # @api private
       module Ext
         def render(*args, &block)
           name = options[:__elastic_apm_template_name] || 'Unknown template'

--- a/lib/elastic_apm/spies/tilt.rb
+++ b/lib/elastic_apm/spies/tilt.rb
@@ -24,18 +24,18 @@ module ElasticAPM
     class TiltSpy
       TYPE = 'template.tilt'
 
-      def install
-        ::Tilt::Template.class_eval do
-          alias render_without_apm render
+      module Ext
+        def render(*args, &block)
+          name = options[:__elastic_apm_template_name] || 'Unknown template'
 
-          def render(*args, &block)
-            name = options[:__elastic_apm_template_name] || 'Unknown template'
-
-            ElasticAPM.with_span name, TYPE do
-              render_without_apm(*args, &block)
-            end
+          ElasticAPM.with_span name, TYPE do
+            super(*args, &block)
           end
         end
+      end
+
+      def install
+        ::Tilt::Template.prepend(Ext)
       end
     end
 

--- a/lib/elastic_apm/stacktrace_builder.rb
+++ b/lib/elastic_apm/stacktrace_builder.rb
@@ -38,7 +38,9 @@ module ElasticAPM
 
     def initialize(config)
       @config = config
-      @cache = Util::LruCache.new(2048, &method(:build_frame))
+      @cache = Util::LruCache.new(2048) do |cache, frame|
+        build_frame(cache, frame)
+      end
     end
 
     attr_reader :config

--- a/lib/elastic_apm/util/deep_dup.rb
+++ b/lib/elastic_apm/util/deep_dup.rb
@@ -48,7 +48,7 @@ module ElasticAPM
       end
 
       def array(arr)
-        arr.map(&method(:deep_dup))
+        arr.map { |obj| deep_dup(obj) }
       end
 
       def hash(hsh)

--- a/spec/support/mock_intake.rb
+++ b/spec/support/mock_intake.rb
@@ -112,7 +112,7 @@ class MockIntake
 
   def parse_request_body(request)
     body =
-      if request.env['HTTP_CONTENT_ENCODING'] =~ /gzip/
+      if request.env['HTTP_CONTENT_ENCODING'].include?('gzip')
         gunzip(request.body.read)
       else
         request.body.read


### PR DESCRIPTION
This leaves us with only the module based APIs still using `class_eval`, specifically `delayed_job` and `sucker_punch`. The problem being that at the time of hooking up the integration, the target modules have already been included and so prepending doesn't modify the including classes.

I propose we leave them as is for now and change them in a future version if we come up with a scheme or they introduce some sort of plugin api that could help us avoid `class_eval`.

This PR is a breaking change not because it removes any features but because it might interfere with other libraries still using class_eval and thereby possibly introduce the infinite loop when trying to look up stacktraces after an exception([#753 ](https://github.com/elastic/apm-agent-ruby/issues/753) for example).