### PR TITLE
Handle invalid utf-8 byte sequences in sql summarizer and DB statement

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -35,6 +35,16 @@ endif::[]
 [[release-notes-3.x]]
 === Ruby Agent version 3.x
 
+[float]
+[[unreleased]]
+==== Unreleased
+
+[float]
+===== Fixed
+
+- Handle invalid utf-8 byte sequences in sql summarizer and DB statement {pull}896[#896]
+
+
 [[release-notes-3.12.1]]
 ==== 3.12.1 (2020-11-16)
 

--- a/lib/elastic_apm/span/context/db.rb
+++ b/lib/elastic_apm/span/context/db.rb
@@ -30,7 +30,7 @@ module ElasticAPM
           rows_affected: nil
         )
           @instance = instance
-          @statement = statement.encode('utf-8', invalid: :replace, undef: :replace)
+          @statement = statement&.encode('utf-8', invalid: :replace, undef: :replace)
           @type = type
           @user = user
           @rows_affected = rows_affected

--- a/lib/elastic_apm/span/context/db.rb
+++ b/lib/elastic_apm/span/context/db.rb
@@ -30,7 +30,7 @@ module ElasticAPM
           rows_affected: nil
         )
           @instance = instance
-          @statement = statement
+          @statement = statement.encode('utf-8', invalid: :replace, undef: :replace)
           @type = type
           @user = user
           @rows_affected = rows_affected

--- a/lib/elastic_apm/sql/signature.rb
+++ b/lib/elastic_apm/sql/signature.rb
@@ -36,8 +36,8 @@ module ElasticAPM
       end
 
       def initialize(sql)
-        @sql = sql
-        @tokenizer = Tokenizer.new(sql)
+        @sql = sql.encode('utf-8', invalid: :replace, undef: :replace)
+        @tokenizer = Tokenizer.new(@sql)
       end
 
       def parse

--- a/spec/elastic_apm/span/context_spec.rb
+++ b/spec/elastic_apm/span/context_spec.rb
@@ -33,6 +33,14 @@ module ElasticAPM
         it 'adds a db object' do
           expect(subject.db.statement).to eq 'asd'
         end
+
+        context 'when the statement contains invalid utf-8 byte sequences' do
+          subject { described_class.new db: { statement: ",&\xB4kh" } }
+
+          it 'replaces the byte sequences' do
+            expect(subject.db.statement).to eq ',&�kh'
+          end
+        end
       end
 
       context 'with http' do

--- a/spec/elastic_apm/sql/signature_spec.rb
+++ b/spec/elastic_apm/sql/signature_spec.rb
@@ -43,6 +43,21 @@ module ElasticAPM
           end
         end
       end
+
+      describe 'invalid UTF-8 byte sequences' do
+        context 'when the string contains an invalid byte sequence' do
+          it 'encodes to UTF-8 and replaces invalid byte sequences' do
+            string = "INSERT INTO \"checksums\" (\"checksum\") VALUES ( \",&\xB4kh\")"
+            expect(described_class.parse(string)).to eq("INSERT INTO checksums")
+          end
+        end
+        context 'when the entire string is an invalid byte sequence' do
+          it 'encodes to UTF-8 and replaces invalid byte sequences' do
+            string = "\xB4"
+            expect(described_class.parse(string)).to eq("�")
+          end
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
Fixes #895 

- Enforce utf-8 encoding of sql strings and replace invalid characters with �.
- Enforce utf-8 encoding of the DB statement and replace invalid characters with �. 

Note that we must do this when the `Sql::Signature` object is created, as opposed to in the `Sql::Tokenizer` because in case the string cannot be parsed, [the first character is returned via `@sql.split`](https://github.com/elastic/apm-agent-ruby/blob/v3.12.1/lib/elastic_apm/sql/signature.rb#L50). That will fail if the first character is an invalid utf-8 byte sequence.