### PR TITLE
Update url for fetching json schema from apm-server repo

### DIFF
--- a/spec/support/match_json_schema_matcher.rb
+++ b/spec/support/match_json_schema_matcher.rb
@@ -20,14 +20,14 @@
 require 'spec_helper'
 require 'json-schema'
 
-base = 'https://raw.githubusercontent.com/elastic/apm-server/master/docs/spec'
+base = 'https://raw.githubusercontent.com/elastic/apm-server/master/docs/spec/v2'
 
 SCHEMA_URLS = {
   metadatas: "#{base}/metadata.json",
-  transactions: "#{base}/transactions/transaction.json",
-  spans: "#{base}/spans/span.json",
-  errors: "#{base}/errors/error.json",
-  metricset: "#{base}/metricsets/metricset.json"
+  transactions: "#{base}/transaction.json",
+  spans: "#{base}/span.json",
+  errors: "#{base}/error.json",
+  metricset: "#{base}/metricset.json"
 }.freeze
 
 RSpec::Matchers.define :match_json_schema do |schema|


### PR DESCRIPTION
The directory structure is different in the apm-server repo so I've updated the url for fetching the json schema.