### PR TITLE
Remove support for ruby 2.3 and jruby-9.1

### DIFF
--- a/.ci/.jenkins_exclude.yml
+++ b/.ci/.jenkins_exclude.yml
@@ -1,27 +1,4 @@
 exclude:
-  # Ruby 2.3
-  # Only includes rails-5.2, sinatra-2.0
-  - RUBY_VERSION: ruby:2.3
-    FRAMEWORK: rails-6.0
-  - RUBY_VERSION: ruby:2.3
-    FRAMEWORK: rails-5.1
-  - RUBY_VERSION: ruby:2.3
-    FRAMEWORK: rails-5.0
-  - RUBY_VERSION: ruby:2.3
-    FRAMEWORK: rails-4.2
-  - RUBY_VERSION: ruby:2.3
-    FRAMEWORK: sinatra-1.4
-  - RUBY_VERSION: ruby:2.3
-    FRAMEWORK: grape-1.3
-  - RUBY_VERSION: ruby:2.3
-    FRAMEWORK: grape-1.3,sinatra-2.0,rails-6.0
-  - RUBY_VERSION: ruby:2.3
-    FRAMEWORK: rails-master
-  - RUBY_VERSION: ruby:2.3
-    FRAMEWORK: sinatra-master
-  - RUBY_VERSION: ruby:2.3
-    FRAMEWORK: grape-master
-
   - RUBY_VERSION: ruby:2.7
     FRAMEWORK: rails-4.2
   - RUBY_VERSION: jruby:9.2

--- a/.ci/.jenkins_exclude.yml
+++ b/.ci/.jenkins_exclude.yml
@@ -3,8 +3,6 @@ exclude:
     FRAMEWORK: rails-4.2
   - RUBY_VERSION: jruby:9.2
     FRAMEWORK: rails-4.2
-  - RUBY_VERSION: jruby:9.1
-    FRAMEWORK: rails-4.2
   - RUBY_VERSION: docker.elastic.co/observability-ci/jruby:9.2-13-jdk
     FRAMEWORK: rails-4.2
   - RUBY_VERSION: docker.elastic.co/observability-ci/jruby:9.2-12-jdk
@@ -13,14 +11,8 @@ exclude:
     FRAMEWORK: rails-4.2
   - RUBY_VERSION: docker.elastic.co/observability-ci/jruby:9.2-8-jdk
     FRAMEWORK: rails-4.2
-  - RUBY_VERSION: docker.elastic.co/observability-ci/jruby:9.1-7-jdk
-    FRAMEWORK: rails-4.2
 
   - RUBY_VERSION: ruby:2.4
-    FRAMEWORK: rails-6.0
-  - RUBY_VERSION: jruby:9.1
-    FRAMEWORK: rails-6.0
-  - RUBY_VERSION: docker.elastic.co/observability-ci/jruby:9.1-7-jdk
     FRAMEWORK: rails-6.0
 
   # Only test master on newest ruby
@@ -32,8 +24,6 @@ exclude:
     FRAMEWORK: rails-master
   - RUBY_VERSION: jruby:9.2
     FRAMEWORK: rails-master
-  - RUBY_VERSION: jruby:9.1
-    FRAMEWORK: rails-master
   - RUBY_VERSION: docker.elastic.co/observability-ci/jruby:9.2-13-jdk
     FRAMEWORK: rails-master
   - RUBY_VERSION: docker.elastic.co/observability-ci/jruby:9.2-12-jdk
@@ -41,8 +31,6 @@ exclude:
   - RUBY_VERSION: docker.elastic.co/observability-ci/jruby:9.2-11-jdk
     FRAMEWORK: rails-master
   - RUBY_VERSION: docker.elastic.co/observability-ci/jruby:9.2-8-jdk
-    FRAMEWORK: rails-master
-  - RUBY_VERSION: docker.elastic.co/observability-ci/jruby:9.1-7-jdk
     FRAMEWORK: rails-master
 
   - RUBY_VERSION: ruby:2.5
@@ -51,8 +39,6 @@ exclude:
     FRAMEWORK: sinatra-master
   - RUBY_VERSION: jruby:9.2
     FRAMEWORK: sinatra-master
-  - RUBY_VERSION: jruby:9.1
-    FRAMEWORK: sinatra-master
   - RUBY_VERSION: docker.elastic.co/observability-ci/jruby:9.2-13-jdk
     FRAMEWORK: sinatra-master
   - RUBY_VERSION: docker.elastic.co/observability-ci/jruby:9.2-12-jdk
@@ -60,8 +46,6 @@ exclude:
   - RUBY_VERSION: docker.elastic.co/observability-ci/jruby:9.2-11-jdk
     FRAMEWORK: sinatra-master
   - RUBY_VERSION: docker.elastic.co/observability-ci/jruby:9.2-8-jdk
-    FRAMEWORK: sinatra-master
-  - RUBY_VERSION: docker.elastic.co/observability-ci/jruby:9.1-7-jdk
     FRAMEWORK: sinatra-master
 
   - RUBY_VERSION: ruby:2.6
@@ -72,8 +56,6 @@ exclude:
     FRAMEWORK: grape-master
   - RUBY_VERSION: jruby:9.2
     FRAMEWORK: grape-master
-  - RUBY_VERSION: jruby:9.1
-    FRAMEWORK: grape-master
   - RUBY_VERSION: docker.elastic.co/observability-ci/jruby:9.2-13-jdk
     FRAMEWORK: grape-master
   - RUBY_VERSION: docker.elastic.co/observability-ci/jruby:9.2-12-jdk
@@ -81,16 +63,9 @@ exclude:
   - RUBY_VERSION: docker.elastic.co/observability-ci/jruby:9.2-11-jdk
     FRAMEWORK: grape-master
   - RUBY_VERSION: docker.elastic.co/observability-ci/jruby:9.2-8-jdk
-    FRAMEWORK: grape-master
-  - RUBY_VERSION: docker.elastic.co/observability-ci/jruby:9.1-7-jdk
     FRAMEWORK: grape-master
 
   # Unsupported
-  - RUBY_VERSION: jruby:9.1
-    FRAMEWORK: grape-1.3
-  - RUBY_VERSION: docker.elastic.co/observability-ci/jruby:9.1-7-jdk
-    FRAMEWORK: grape-1.3
-
   - RUBY_VERSION: ruby:2.6
     FRAMEWORK: grape-1.3,sinatra-2.0,rails-6.0
   - RUBY_VERSION: ruby:2.5
@@ -99,8 +74,6 @@ exclude:
     FRAMEWORK: grape-1.3,sinatra-2.0,rails-6.0
   - RUBY_VERSION: jruby:9.2
     FRAMEWORK: grape-1.3,sinatra-2.0,rails-6.0
-  - RUBY_VERSION: jruby:9.1
-    FRAMEWORK: grape-1.3,sinatra-2.0,rails-6.0
   - RUBY_VERSION: docker.elastic.co/observability-ci/jruby:9.2-13-jdk
     FRAMEWORK: grape-1.3,sinatra-2.0,rails-6.0
   - RUBY_VERSION: docker.elastic.co/observability-ci/jruby:9.2-12-jdk
@@ -108,6 +81,4 @@ exclude:
   - RUBY_VERSION: docker.elastic.co/observability-ci/jruby:9.2-11-jdk
     FRAMEWORK: grape-1.3,sinatra-2.0,rails-6.0
   - RUBY_VERSION: docker.elastic.co/observability-ci/jruby:9.2-8-jdk
-    FRAMEWORK: grape-1.3,sinatra-2.0,rails-6.0
-  - RUBY_VERSION: docker.elastic.co/observability-ci/jruby:9.1-7-jdk
     FRAMEWORK: grape-1.3,sinatra-2.0,rails-6.0

--- a/.ci/.jenkins_ruby.yml
+++ b/.ci/.jenkins_ruby.yml
@@ -3,7 +3,6 @@ RUBY_VERSION:
   - ruby:2.6
   - ruby:2.5
   - ruby:2.4
-  - ruby:2.3
   - jruby:9.2
   - jruby:9.1
   - docker.elastic.co/observability-ci/jruby:9.2-13-jdk

--- a/.ci/.jenkins_ruby.yml
+++ b/.ci/.jenkins_ruby.yml
@@ -4,9 +4,7 @@ RUBY_VERSION:
   - ruby:2.5
   - ruby:2.4
   - jruby:9.2
-  - jruby:9.1
   - docker.elastic.co/observability-ci/jruby:9.2-13-jdk
   - docker.elastic.co/observability-ci/jruby:9.2-12-jdk
   - docker.elastic.co/observability-ci/jruby:9.2-11-jdk
   - docker.elastic.co/observability-ci/jruby:9.2-8-jdk
-  - docker.elastic.co/observability-ci/jruby:9.1-7-jdk

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -132,10 +132,3 @@ Style/StringConcatenation:
 
 Style/DocumentDynamicEvalDefinition:
   Enabled: false
-
-# Applies to > ruby 2.3, enable when 2.3 support is dropped
-Performance/RegexpMatch:
-  Enabled: false
-
-Style/HashTransformValues:
-  Enabled: false

--- a/Gemfile
+++ b/Gemfile
@@ -86,7 +86,7 @@ frameworks_versions.each do |framework, version|
 end
 
 if frameworks_versions.key?('rails')
-  unless frameworks_versions['rails'] =~ /^(master|6)/
+  unless /^(master|6)/.match?(frameworks_versions['rails'])
     gem 'delayed_job', require: nil
   end
 end
@@ -94,7 +94,7 @@ end
 if RUBY_PLATFORM == 'java'
   gem 'activerecord-jdbcsqlite3-adapter'
   gem 'jdbc-sqlite3'
-elsif frameworks_versions['rails'] =~ /^(4|5)/
+elsif /^(4|5)/.match?(frameworks_versions['rails'])
   gem 'sqlite3', '~> 1.3.6'
 else
   gem 'sqlite3'

--- a/lib/elastic_apm/context/response.rb
+++ b/lib/elastic_apm/context/response.rb
@@ -38,9 +38,7 @@ module ElasticAPM
       attr_reader :headers
 
       def headers=(headers)
-        @headers = headers&.each_with_object({}) do |(k, v), hsh|
-          hsh[k] = v.to_s
-        end
+        @headers = headers&.transform_values(&:to_s)
       end
     end
   end

--- a/lib/elastic_apm/normalizers.rb
+++ b/lib/elastic_apm/normalizers.rb
@@ -39,8 +39,8 @@ module ElasticAPM # :nodoc:
     end
 
     def self.build(config)
-      normalizers = @registered.each_with_object({}) do |(name, klass), built|
-        built[name] = klass.new(config)
+      normalizers = @registered.transform_values do |klass|
+        klass.new(config)
       end
 
       Collection.new(normalizers)

--- a/lib/elastic_apm/spies/sequel.rb
+++ b/lib/elastic_apm/spies/sequel.rb
@@ -57,7 +57,7 @@ module ElasticAPM
             context: context
           )
           super(sql, connection, args, &block).tap do |result|
-            if name =~ /^(UPDATE|DELETE)/
+            if /^(UPDATE|DELETE)/.match?(name)
               if connection.respond_to?(:changes)
                 span.context.db.rows_affected = connection.changes
               elsif result.is_a?(Integer)

--- a/lib/elastic_apm/sql/tokenizer.rb
+++ b/lib/elastic_apm/sql/tokenizer.rb
@@ -110,7 +110,7 @@ module ElasticAPM
             next next_char
           end
 
-          next next_char if peek =~ ALPHA
+          next next_char if ALPHA.match?(peek)
 
           break
         end
@@ -251,7 +251,7 @@ module ElasticAPM
           when 'e', 'E'
             return NUMBER if exponent
             next_char
-            next_char if peek_char =~ /[+-]/
+            next_char if /[+-]/.match?(peek_char)
           else break
           end
         end

--- a/lib/elastic_apm/trace_context/traceparent.rb
+++ b/lib/elastic_apm/trace_context/traceparent.rb
@@ -56,8 +56,8 @@ module ElasticAPM
               values[-1] = Util.hex_to_bits(values[-1])
             end
 
-          raise_invalid(header) if HEX_REGEX =~ t.trace_id
-          raise_invalid(header) if HEX_REGEX =~ t.parent_id
+          raise_invalid(header) if HEX_REGEX.match?(t.trace_id)
+          raise_invalid(header) if HEX_REGEX.match?(t.parent_id)
         end
       end
 

--- a/lib/elastic_apm/transport/serializers/metricset_serializer.rb
+++ b/lib/elastic_apm/transport/serializers/metricset_serializer.rb
@@ -46,8 +46,8 @@ module ElasticAPM
         private
 
         def build_samples(samples)
-          samples.each_with_object({}) do |(key, value), hsh|
-            hsh[key] = { value: value }
+          samples.transform_values do |value|
+            { value: value }
           end
         end
       end


### PR DESCRIPTION
- Use `transform_values` instead of `each_with_object`
- Use `match?` instead of `=~`
- Remove ruby 2.3 from Jenkins test matrices
- Remove jruby-9.1 from Jenkins test matrices

Note that jruby-9.1 supports ruby 2.3 so we must remove support for that as well.