### PR TITLE
Only support auto Sinatra app configuration via ElasticAPM::Sinatra.start

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -53,6 +53,7 @@ _ Config option `ignore_url_patterns`, see `transaction_ignore_urls` {pull}900[#
 
 - The secrets filter no longer filters based on values, see `sanitize_field_names` {pull}900[#900]
 - The secrets filter is aligned with other agents, see `sanitize_field_names` {pull}900[#900]
+- Support configuring Sinatra app only via `ElasticAPM::Sinatra.start` {pull}906[#906]
 
 [float]
 ===== Fixed

--- a/docs/configuration.asciidoc
+++ b/docs/configuration.asciidoc
@@ -59,19 +59,8 @@ config.elastic_apm.service_name = 'MyApp'
 [float]
 === Sinatra and Rack
 
-When using Sinatra and Rack, you can configure when starting
-the agent:
-
-[source,ruby]
-----
-# config.ru or similar
-ElasticAPM.start(
-  app: MyApp,
-  service_name: 'SomeOtherName'
-)
-----
-
-Alternatively, you can use the `ElasticAPM::Sinatra.start` API:
+When using Sinatra and Rack, you can configure when using
+`ElasticAPM::Sinatra.start`:
 
 [source,ruby]
 ----

--- a/docs/getting-started-rack.asciidoc
+++ b/docs/getting-started-rack.asciidoc
@@ -62,10 +62,7 @@ class MySinatraApp < Sinatra::Base
 end
 
 # Takes optional ElasticAPM::Config values
-ElasticAPM.start(app: MySinatraApp, ...)
-
-# You can also do the following, which is equivalent to the above:
-# ElasticAPM::Sinatra.start(MySinatraApp, ...)
+ElasticAPM::Sinatra.start(MySinatraApp, ...)
 
 run MySinatraApp
 

--- a/lib/elastic_apm/config.rb
+++ b/lib/elastic_apm/config.rb
@@ -170,8 +170,6 @@ module ElasticAPM
 
     def app=(app)
       case app_type?(app)
-      when :sinatra
-        set_sinatra(app)
       when :rails
         set_rails(app)
       else
@@ -253,18 +251,7 @@ module ElasticAPM
         return :rails
       end
 
-      if app.is_a?(Class) && app.superclass.to_s == 'Sinatra::Base'
-        return :sinatra
-      end
-
       nil
-    end
-
-    def set_sinatra(app)
-      self.service_name = format_name(service_name || app.to_s)
-      self.framework_name = framework_name || 'Sinatra'
-      self.framework_version = framework_version || ::Sinatra::VERSION
-      self.__root_path = Dir.pwd
     end
 
     def set_rails(app)

--- a/spec/integration/sinatra_spec.rb
+++ b/spec/integration/sinatra_spec.rb
@@ -79,7 +79,7 @@ if enabled
       end
 
       MockIntake.stub!
-      ElasticAPM.start(app: SinatraTestApp, api_request_time: '200ms')
+      ElasticAPM::Sinatra.start(SinatraTestApp, api_request_time: '200ms')
     end
 
     after(:all) do


### PR DESCRIPTION
Use `ElasticAPM::Sinatra.start(MySinatraApp, ...)` instead of `ElasticAPM.start(app: MySintraApp, ...)`