### PR TITLE
Warn that starting the agent for a Sintra app using app config arg is deprecated

### DIFF
--- a/lib/elastic_apm/config.rb
+++ b/lib/elastic_apm/config.rb
@@ -344,6 +344,11 @@ module ElasticAPM
     end
 
     def set_sinatra(app)
+      warn '[DEPRECATED] Starting the agent for a Sinatra app via ' \
+           'ElasticAPM.start(app: MySinatraApp, ...) is deprecated and ' \
+           'will be removed in version 4.0. ' \
+           'Please use the ElasticAPM::Sinatra.start(MySinatraApp, ...) ' \
+           'API instead.'
       self.service_name = format_name(service_name || app.to_s)
       self.framework_name = framework_name || 'Sinatra'
       self.framework_version = framework_version || ::Sinatra::VERSION

--- a/spec/integration/sinatra_spec.rb
+++ b/spec/integration/sinatra_spec.rb
@@ -79,7 +79,7 @@ if enabled
       end
 
       MockIntake.stub!
-      ElasticAPM.start(app: SinatraTestApp, api_request_time: '200ms')
+      ElasticAPM::Sinatra.start(SinatraTestApp, api_request_time: '200ms')
     end
 
     after(:all) do


### PR DESCRIPTION
Resolves #909