### PR TITLE
Change some log messages

### DIFF
--- a/lib/elastic_apm/agent.rb
+++ b/lib/elastic_apm/agent.rb
@@ -127,7 +127,7 @@ module ElasticAPM
     end
 
     def stop
-      debug 'Stopping agent'
+      info 'Stopping agent'
 
       central_config.stop
       metrics.stop
@@ -276,7 +276,7 @@ module ElasticAPM
     def detect_forking!
       return if @pid == Process.pid
 
-      config.logger.debug "Detected forking,
+      config.logger.debug "Forked process detected,
         restarting threads in process [PID:#{Process.pid}]"
 
       central_config.handle_forking!

--- a/lib/elastic_apm/instrumenter.rb
+++ b/lib/elastic_apm/instrumenter.rb
@@ -89,7 +89,7 @@ module ElasticAPM
     end
 
     def subscriber=(subscriber)
-      debug 'Registering subscriber'
+      debug 'Registering ActiveSupport::Notifications subscriber'
       @subscriber = subscriber
       @subscriber.register!
     end

--- a/lib/elastic_apm/metrics/cpu_mem_set.rb
+++ b/lib/elastic_apm/metrics/cpu_mem_set.rb
@@ -79,7 +79,7 @@ module ElasticAPM
         case platform
         when :linux then Linux.new
         else
-          warn "Unsupported platform '#{platform}' - Disabling system metrics"
+          warn "Disabling system metrics, unsupported platform '#{platform}'"
           disable!
           nil
         end

--- a/lib/elastic_apm/transport/connection.rb
+++ b/lib/elastic_apm/transport/connection.rb
@@ -105,7 +105,7 @@ module ElasticAPM
         @close_task&.cancel
         @close_task =
           Concurrent::ScheduledTask.execute(@config.api_request_time) do
-            flush(:timeout)
+            flush(:scheduled_flush)
           end
       end
     end

--- a/lib/elastic_apm/transport/connection/http.rb
+++ b/lib/elastic_apm/transport/connection/http.rb
@@ -74,7 +74,7 @@ module ElasticAPM
           debug '%s: Closing request with reason %s', thread_str, reason
           @closed.make_true
 
-          @wr&.close(reason)
+          @wr&.close
           return if @request.nil? || @request&.join(5)
 
           error(

--- a/lib/elastic_apm/transport/connection/proxy_pipe.rb
+++ b/lib/elastic_apm/transport/connection/proxy_pipe.rb
@@ -62,8 +62,7 @@ module ElasticAPM
             @io = Zlib::GzipWriter.new(io)
           end
 
-          def close(reason = nil)
-            debug("Closing writer with reason #{reason}")
+          def close
             io.close
           end
 

--- a/lib/elastic_apm/transport/worker.rb
+++ b/lib/elastic_apm/transport/worker.rb
@@ -58,7 +58,7 @@ module ElasticAPM
         while (msg = queue.pop)
           case msg
           when StopMessage
-            debug 'Stopping worker -- %s', self
+            debug 'Stopping worker [%s]', self
             connection.flush(:halt)
             break
           else


### PR DESCRIPTION
Users have often mistaken some of our log output for something gone awry, when the timeouts were actually completely expected and normal.