### PR TITLE
Fix HTTP timeout setting on Http.rb 3.x

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -44,6 +44,7 @@ endif::[]
 
 - Handle invalid utf-8 byte sequences in sql summarizer and DB statement {pull}896[#896]
 - Expand Kubernetes metadata discovery {pull}916[#916]
+- Fix fetching cloud info on Http.rb 3.x versions {pull}919[#919]
 
 [float]
 ===== Added

--- a/lib/elastic_apm/metadata/cloud_info.rb
+++ b/lib/elastic_apm/metadata/cloud_info.rb
@@ -31,7 +31,7 @@ module ElasticAPM
 
       def initialize(config)
         @config = config
-        @client = HTTP.timeout(0.1)
+        @client = HTTP.timeout(connect: 0.1, read: 0.1)
       end
 
       attr_reader :config


### PR DESCRIPTION
Fixes https://github.com/elastic/apm-agent-ruby/issues/918