### PR TITLE
Only set outcome in Mongo spy if span is present

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -39,6 +39,7 @@ endif::[]
 [[unreleased]]
 ==== Unreleased
 
+[float]
 ===== Fixed
 
 - Fixed setting outcome in Mongo spy when not traced {pull}937[#937]

--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -35,6 +35,14 @@ endif::[]
 [[release-notes-3.x]]
 === Ruby Agent version 3.x
 
+[float]
+[[unreleased]]
+==== Unreleased
+
+===== Fixed
+
+- Fixed setting outcome in Mongo spy when not traced {pull}937[#937]
+
 [[release-notes-3.13.0]]
 ==== 3.13.0 (2020-12-22)
 

--- a/lib/elastic_apm/spies/mongo.rb
+++ b/lib/elastic_apm/spies/mongo.rb
@@ -44,14 +44,18 @@ module ElasticAPM
         end
 
         def failed(event)
-          span = pop_event(event)
-          span&.outcome = Span::Outcome::FAILURE
+          if (span = pop_event(event))
+            span.outcome = Span::Outcome::FAILURE
+          end
+
           span
         end
 
         def succeeded(event)
-          span = pop_event(event)
-          span&.outcome = Span::Outcome::SUCCESS
+          if span = pop_event(event)
+            span.outcome = Span::Outcome::SUCCESS
+          end
+
           span
         end
 


### PR DESCRIPTION
Fixes #936 