### PR TITLE
Fix missing ActiveRecord connection object in notification payload

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -39,6 +39,9 @@ endif::[]
 [[unreleased]]
 ==== Unreleased
 
+===== Added
+- Expanded support for extracting ActiveRecord adapter name from notification payload when using ActiveRecord versions before 6.0 {pull}953[#953]
+
 [float]
 ===== Fixed
 

--- a/lib/elastic_apm/normalizers/rails/active_record.rb
+++ b/lib/elastic_apm/normalizers/rails/active_record.rb
@@ -57,22 +57,17 @@ module ElasticAPM
         private
 
         def subtype_for(payload)
-          if payload[:connection_id]
-            payload[:connection] ||= begin
-              loaded_object = ObjectSpace._id2ref(payload[:connection_id])
+          return cached_adapter_name(payload[:connection].adapter_name) if payload[:connection]
 
-              if loaded_object.respond_to?(:adapter_name)
-                loaded_object
-              end
+          if payload[:connection_id]
+            begin
+              loaded_object = ObjectSpace._id2ref(payload[:connection_id])
+              return cached_adapter_name(loaded_object.adapter_name) if loaded_object.respond_to?(:adapter_name)
             rescue RangeError # if connection object has somehow been garbage collected
-              nil
             end
           end
 
-          cached_adapter_name(
-            payload[:connection]&.adapter_name ||
-              ::ActiveRecord::Base.connection_config[:adapter]
-          )
+          cached_adapter_name(nil)
         end
 
         def summarize(sql)

--- a/lib/elastic_apm/normalizers/rails/active_record.rb
+++ b/lib/elastic_apm/normalizers/rails/active_record.rb
@@ -57,6 +57,18 @@ module ElasticAPM
         private
 
         def subtype_for(payload)
+          if payload[:connection_id]
+            payload[:connection] ||= begin
+              loaded_object = ObjectSpace._id2ref(payload[:connection_id])
+
+              if loaded_object.respond_to?(:adapter_name)
+                loaded_object
+              end
+            rescue RangeError # if connection object has somehow been garbage collected
+              nil
+            end
+          end
+
           cached_adapter_name(
             payload[:connection]&.adapter_name ||
               ::ActiveRecord::Base.connection_config[:adapter]

--- a/spec/elastic_apm/normalizers/active_record_spec.rb
+++ b/spec/elastic_apm/normalizers/active_record_spec.rb
@@ -83,12 +83,6 @@ module ElasticAPM
               connection: double(adapter_name: 'MySQL')
             )
             expect(subtype).to eq 'mysql'
-
-            _name, _type, subtype, = normalize_payload(
-              sql: sql,
-              connection: double(adapter_name: 'Postgres')
-            )
-            expect(subtype).to eq 'postgres'
           end
           
           it 'resolves the connection_id object id to a connection if the full connection is missing' do
@@ -100,12 +94,6 @@ module ElasticAPM
               connection_id: double(adapter_name: 'MySQL').object_id
             )
             expect(subtype).to eq 'mysql'
-
-            _name, _type, subtype, = normalize_payload(
-              sql: sql,
-              connection_id: double(adapter_name: 'Postgres').object_id
-            )
-            expect(subtype).to eq 'postgres'
           end
           
           it 'handles a failure to load the connection object by connection_id' do
@@ -134,13 +122,6 @@ module ElasticAPM
               connection_id: double(adapter_name: 'wrong_db').object_id
             )
             expect(subtype).to eq 'mysql'
-
-            _name, _type, subtype, = normalize_payload(
-              sql: sql,
-              connection: double(adapter_name: 'Postgres'),
-              connection_id: double(adapter_name: 'wrong_db').object_id
-            )
-            expect(subtype).to eq 'postgres'
           end
 
           it 'uses ActiveRecord::Base when payload is not available' do

--- a/spec/elastic_apm/normalizers/active_record_spec.rb
+++ b/spec/elastic_apm/normalizers/active_record_spec.rb
@@ -32,26 +32,6 @@ module ElasticAPM
           expect(subject).to be_a SqlNormalizer
         end
 
-        describe '#initialize' do
-          unless defined? ::ActiveRecord::Base
-            class ::ActiveRecord
-              class Base; end
-            end
-          end
-
-          it 'knows the AR adapter' do
-            allow(::ActiveRecord::Base)
-              .to receive(:connection_config) { { adapter: 'MySQL' } }
-
-            subject = SqlNormalizer.new nil
-
-            _, _, subtype, =
-              subject.normalize(nil, nil, sql: 'DROP * FROM users')
-
-            expect(subtype).to eq 'mysql'
-          end
-        end
-
         describe '#normalize' do
           let(:key) { 'sql.active_record' }
           subject { SqlNormalizer.new nil }
@@ -61,12 +41,13 @@ module ElasticAPM
           end
 
           it 'normalizes queries' do
-            allow(::ActiveRecord::Base)
-              .to receive(:connection_config) { { adapter: nil } }
             sql = 'SELECT  "hotdogs".* FROM "hotdogs" ' \
               'WHERE "hotdogs"."topping" = $1 LIMIT 1'
 
-            name, type, subtype, action, context_ = normalize_payload(sql: sql)
+            name, type, subtype, action, context_ = normalize_payload(
+              sql: sql,
+              connection: double(adapter_name: '')
+            )
             expect(name).to eq 'SELECT FROM hotdogs'
             expect(type).to eq 'db'
             expect(subtype).to eq 'unknown'
@@ -84,7 +65,7 @@ module ElasticAPM
             )
             expect(subtype).to eq 'mysql'
           end
-          
+
           it 'resolves the connection_id object id to a connection if the full connection is missing' do
             sql = 'SELECT  "burgers".* FROM "burgers" ' \
               'WHERE "burgers"."cheese" = $1 LIMIT 1'
@@ -94,22 +75,6 @@ module ElasticAPM
               connection_id: double(adapter_name: 'MySQL').object_id
             )
             expect(subtype).to eq 'mysql'
-          end
-          
-          it 'handles a failure to load the connection object by connection_id' do
-            sql = 'SELECT  "burgers".* FROM "burgers" ' \
-              'WHERE "burgers"."cheese" = $1 LIMIT 1'
-
-            allow(::ActiveRecord::Base)
-              .to receive(:connection_config) { { adapter: 'Postgres' } }
-
-            _name, _type, subtype, = normalize_payload(
-              sql: sql,
-              connection_id: 999_999_999 # invalid object_id
-            )
-
-            expect(subtype).to eq 'postgres'
-            expect(::ActiveRecord::Base).to have_received(:connection_config)
           end
 
           it 'uses the connection from payload even if the connection_id is available' do
@@ -122,29 +87,6 @@ module ElasticAPM
               connection_id: double(adapter_name: 'wrong_db').object_id
             )
             expect(subtype).to eq 'mysql'
-          end
-
-          it 'uses ActiveRecord::Base when payload is not available' do
-            sql = 'SELECT  "burgers".* FROM "burgers" ' \
-              'WHERE "burgers"."cheese" = $1 LIMIT 1'
-
-            allow(::ActiveRecord::Base)
-              .to receive(:connection_config) { { adapter: 'Postgres' } }
-            _name, _type, subtype, = normalize_payload(sql: sql)
-
-            expect(subtype).to eq 'postgres'
-
-            allow(::ActiveRecord::Base)
-              .to receive(:connection_config) { { adapter: '' } }
-            _name, _type, subtype, = normalize_payload(sql: sql)
-
-            expect(subtype).to eq 'unknown'
-
-            allow(::ActiveRecord::Base)
-              .to receive(:connection_config) { { adapter: nil } }
-            _name, _type, subtype, = normalize_payload(sql: sql)
-
-            expect(subtype).to eq 'unknown'
           end
 
           it 'skips cache queries' do

--- a/spec/elastic_apm/normalizers/active_record_spec.rb
+++ b/spec/elastic_apm/normalizers/active_record_spec.rb
@@ -89,7 +89,7 @@ module ElasticAPM
             expect(subtype).to eq 'mysql'
           end
 
-          it "handles a connection_id which loads an object that isn't a connection" do
+          it 'handles a connection_id which loads an object that is not a connection' do
             sql = 'SELECT  "burgers".* FROM "burgers" ' \
             'WHERE "burgers"."cheese" = $1 LIMIT 1'
 
@@ -101,7 +101,7 @@ module ElasticAPM
             expect(subtype).to eq "unknown"
           end
 
-          it "handles a missing connection and connection_id value" do
+          it 'handles a missing connection and connection_id value' do
             sql = 'SELECT  "burgers".* FROM "burgers" ' \
             'WHERE "burgers"."cheese" = $1 LIMIT 1'
 

--- a/spec/elastic_apm/normalizers/active_record_spec.rb
+++ b/spec/elastic_apm/normalizers/active_record_spec.rb
@@ -131,14 +131,14 @@ module ElasticAPM
             _name, _type, subtype, = normalize_payload(
               sql: sql,
               connection: double(adapter_name: 'MySQL'),
-              connection_id: 'wrong object'.object_id
+              connection_id: double(adapter_name: 'wrong_db').object_id
             )
             expect(subtype).to eq 'mysql'
 
             _name, _type, subtype, = normalize_payload(
               sql: sql,
               connection: double(adapter_name: 'Postgres'),
-              connection_id: 'wrong object'.object_id
+              connection_id: double(adapter_name: 'wrong_db').object_id
             )
             expect(subtype).to eq 'postgres'
           end

--- a/spec/elastic_apm/normalizers/active_record_spec.rb
+++ b/spec/elastic_apm/normalizers/active_record_spec.rb
@@ -89,6 +89,27 @@ module ElasticAPM
             expect(subtype).to eq 'mysql'
           end
 
+          it "handles a connection_id which loads an object that isn't a connection" do
+            sql = 'SELECT  "burgers".* FROM "burgers" ' \
+            'WHERE "burgers"."cheese" = $1 LIMIT 1'
+
+            _name, _type, subtype, = normalize_payload(
+              sql: sql,
+              connection_id: double("not a connection").object_id # this doesn't respond to #adapter_name
+            )
+
+            expect(subtype).to eq "unknown"
+          end
+
+          it "handles a missing connection and connection_id value" do
+            sql = 'SELECT  "burgers".* FROM "burgers" ' \
+            'WHERE "burgers"."cheese" = $1 LIMIT 1'
+
+            _name, _type, subtype, = normalize_payload(sql: sql)
+
+            expect(subtype).to eq "unknown"
+          end
+
           it 'skips cache queries' do
             result =
               normalize_payload(name: 'CACHE', sql: 'DROP * FROM users')

--- a/spec/elastic_apm/normalizers/active_record_spec.rb
+++ b/spec/elastic_apm/normalizers/active_record_spec.rb
@@ -33,6 +33,8 @@ module ElasticAPM
             end
           end
         end
+        
+        mri_skip_check = RUBY_ENGINE == "ruby" ? nil : "only relevant on MRI"
 
         it 'registers for name' do
           normalizers = Normalizers.build nil
@@ -87,7 +89,7 @@ module ElasticAPM
             expect(subtype).to eq 'mysql'
           end
 
-          it 'resolves the connection_id object id to a connection if the full connection is missing' do
+          it 'resolves the connection_id object id to a connection if the full connection is missing', skip: mri_skip_check do
             sql = 'SELECT  "burgers".* FROM "burgers" ' \
               'WHERE "burgers"."cheese" = $1 LIMIT 1'
 
@@ -110,7 +112,7 @@ module ElasticAPM
             expect(subtype).to eq 'mysql'
           end
 
-          it 'handles a connection_id which loads an object that is not a connection' do
+          it 'handles a connection_id which loads an object that is not a connection', skip: mri_skip_check do
             allow(::ActiveRecord::Base)
               .to receive(:connection_config) { { adapter: nil } }
             sql = 'SELECT  "burgers".* FROM "burgers" ' \
@@ -118,7 +120,7 @@ module ElasticAPM
 
             _name, _type, subtype, = normalize_payload(
               sql: sql,
-              connection_id: double("not a connection").object_id # this doesn't respond to #adapter_name
+              connection_id: double("this string does not respond to #adapter_name").object_id
             )
 
             expect(::ActiveRecord::Base)

--- a/spec/elastic_apm/spies/shoryuken_spec.rb
+++ b/spec/elastic_apm/spies/shoryuken_spec.rb
@@ -64,6 +64,12 @@ module ElasticAPM
     end
 
     before do
+      unless defined? ::ActiveRecord::Base
+        class ::ActiveRecord
+          class Base; end
+        end
+      end
+
       # Mock this function used in the middleware chain
       allow(::ActiveRecord::Base)
         .to receive(:clear_active_connections!)


### PR DESCRIPTION
## What does this pull request do?

ActiveRecord's notification subscription system is leveraged in order to instrument SQL queries. This notification system passes a `payload` hash containing arbitrary notification information about the event that has occurred. `apm-agent-ruby` parses this notification payload and determines the adapter name by looking for the connection object stored in `payload[:connection]`.

This value is _not_ set in any ActiveRecord version before 6.0. In https://github.com/rails/rails/commit/6d1c9a9b23579d13b7cbdd3217ed2cfcc300e06e, it can be seen that the `connection` key is added to the payload, and this change is included in ActiveRecord 6.0 and newer. Earlier versions of ActiveRecord include a `:connection_id` payload key/value pair which includes the ActiveRecord connection object's `#object_id`.

This pull request adds functionality which loads the connection object in the event that `:connection_id` has a value, and `:connection` does not. Because we're loading the object from an `object_id`, proper error handling is included in the event that the object referred to by the `:connection_id` value has been garbage collected (`RangeError` will be raised). The nature of fetching an object by an `object_id` in this way is that we cannot guarantee that the same ID will still match to the object we expect (though we can be reasonably sure). To give ourselves a little more assurance I make sure the resulting object responds to `:adapter_name` as we expect.

It should also be noted that the `:connection_id` key/value pair was removed from the notification payload in https://github.com/rails/rails/commit/d140ab073f296a2a689a4dbd58cf9434c6b2a484#diff-460f4e7973c5dd945c51d24df5b0173961190d3645f4e2585fd3003fa1fc0ff7 (included in ActiveRecord releases 6.1.0 and later), and the included code change is robust enough to handle this key being absent.

## Why is it important?

Currently, if the `payload[:connection]` value is missing (which it will be in AR < 6.0), the fallback adapter value is the result of calling `::ActiveRecord::Base.connection_config[:adapter]`. This is fine if the connection in question uses the base `ActiveRecord::Base` class, but in the apps I'm working on, that isn't a safe assumption. Multiple database connections use multiple base classes which come from various Ruby gems which define their own base connection classes that inherit from `ActiveRecord::Base`.

This change makes things a little more flexible, and we can trust that ActiveRecord will provide us with the correct `object_id` reference to the connection.

One side-effect of this change would be that the aforementioned fallback adapter code path will probably never be reached anymore - The likelihood of the payload missing a value for both `:connection` and `:connection_id` is slim to none. That said, I don't necessarily see the harm in removing it.

## Checklist

- [X] I have signed the [Contributor License Agreement](https://www.elastic.co/contributor-agreement/).
- [X] My code follows the style guidelines of this project (See `.rubocop.yml`)
- [X] I have rebased my changes on top of the latest master branch
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing [**unit** tests](https://github.com/elastic/apm-agent-ruby/blob/master/CONTRIBUTING.md#testing) pass locally with my changes
- [ ] ~~I have made corresponding changes to the documentation~~
- [X] I have updated [CHANGELOG.asciidoc](CHANGELOG.asciidoc)
- [ ] ~~I have updated [supported-technologies.asciidoc](docs/supported-technologies.asciidoc)~~
- [ ] ~~Added an API method or config option? Document in which version this will be introduced~~

## Related issues