### PR TITLE
Limit version of i18n gem because of JRuby refinements bug

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -56,6 +56,10 @@ gem 'sucker_punch', '~> 2.0', require: nil
 gem 'yard', require: nil
 gem 'yarjuf'
 
+# See issue #6547 in the JRuby repo. When that bug is fixed,
+# we can use the latest version of the i18n gem.
+gem 'i18n', '< 1.8.8'
+
 ## Install Framework
 GITHUB_REPOS = {
   'grape' => 'ruby-grape/grape',


### PR DESCRIPTION
See https://github.com/jruby/jruby/issues/6547
There is a bug with refinements in JRuby that is exposed via version 1.8.8 of the i18n gem.
So I've limited the version of the gem to < 1.8.8 in the Gemfile.