### PR TITLE
Specify branch when installing rails gem from main

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -76,7 +76,7 @@ frameworks_versions.each do |framework, version|
   when 'master' # sinatra, grape
     gem framework, github: GITHUB_REPOS.fetch(framework)
   when 'main' # rails
-    gem framework, github: GITHUB_REPOS.fetch(framework)
+    gem framework, github: GITHUB_REPOS.fetch(framework), branch: 'main'
   when /.+/
     gem framework, "~> #{version}.0"
   else


### PR DESCRIPTION
When installing the rails gem from `main`, we were getting this error:
`Git error: command 'git rev-parse --verify master' in directory`

So I've added `branch: 'main'` to the Gemfile when we are installing rails from main.