### PR TITLE
skips spans for http calls missing an authority segment when the call is made using Net::HTTP or Faraday

### DIFF
--- a/lib/elastic_apm/spies/faraday.rb
+++ b/lib/elastic_apm/spies/faraday.rb
@@ -55,6 +55,8 @@ module ElasticAPM
               tmp_request = build_request(method) do |req|
                 yield(req) if block_given?
               end
+
+              return run_request_without_apm(method, url, body, headers, &block) if tmp_request.path.nil?
               uri = URI(tmp_request.path)
             end
 

--- a/lib/elastic_apm/spies/net_http.rb
+++ b/lib/elastic_apm/spies/net_http.rb
@@ -65,6 +65,10 @@ module ElasticAPM
             method = req.method.to_s.upcase
             path, query = req.path.split('?')
 
+            if host.nil?
+              return request_without_apm(req, body, &block)
+            end
+
             url = use_ssl? ? +'https://' : +'http://'
             url << host
             url << ":#{port}" if port

--- a/lib/elastic_apm/spies/net_http.rb
+++ b/lib/elastic_apm/spies/net_http.rb
@@ -65,9 +65,7 @@ module ElasticAPM
             method = req.method.to_s.upcase
             path, query = req.path.split('?')
 
-            if host.nil?
-              return request_without_apm(req, body, &block)
-            end
+            return request_without_apm(req, body, &block) if host.nil?
 
             url = use_ssl? ? +'https://' : +'http://'
             url << host

--- a/spec/elastic_apm/spies/faraday_spec.rb
+++ b/spec/elastic_apm/spies/faraday_spec.rb
@@ -165,5 +165,20 @@ module ElasticAPM
       expect(span).to_not be nil
       expect(span.outcome).to eq 'failure'
     end
+
+    it 'skips spans for http calls missing an authority segment' do
+      WebMock.stub_request(:any, %r{http://*})
+
+      with_agent do
+        ElasticAPM.with_transaction 'Faraday test' do
+          Faraday.get('/page.html')
+          Faraday.post('/page.html')
+        end
+      end
+
+      expect(@intercepted.transactions.length).to be 1
+      expect(@intercepted.spans.length).to be 0
+      ElasticAPM.stop
+    end
   end
 end


### PR DESCRIPTION
## What does this pull request do?
It allows for requests missing the authority segment to be gracefully handled by the spies. This fix is for net_http and Faraday. The fix forwards the call without AMP spans when the authority is missing.

## Why is it important?
There are some situations where a gem could use Faraday incorrectly by not providing domain name in their calls. This in turn, causes APM to fail with an error that the offending gem is not expecting. The unexpected error can cause the gems to completely fail without the user being able fix the issue by means of a workaround. The only solution would be to remove APM.

## Example
The following explanation is for the RestForce gem from SalesForce. 
The gem performs calls using Faraday, it automatically configures urls and paths.
When making a call for the first time, the gem makes a call without a configured host.
Without a valid host APM fails with an invalid url from the URI:HTTP class. 
It seems RestForce does not  handle this error correctly and halts any future chain of calls. 
There is nothing the user of this gem can do to fix the issue other than to remove APM.

## Checklist
- [x] I have signed the [Contributor License Agreement](https://www.elastic.co/contributor-agreement/). 
- [x] My code follows the style guidelines of this project (See `.rubocop.yml`)
- [x] I have rebased my changes on top of the latest master branch
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing [**unit** tests](https://github.com/elastic/apm-agent-ruby/blob/master/CONTRIBUTING.md#testing) pass locally with my changes
- [ ] ~~I have made corresponding changes to the documentation~~
- [ ] ~~I have updated [CHANGELOG.asciidoc](CHANGELOG.asciidoc)~~
- [ ] ~~I have updated [supported-technologies.asciidoc](docs/supported-technologies.asciidoc)~~
- [ ] ~~Added an API method or config option? Document in which version this will be introduced~~

## Related issues

