### PR TITLE
Default to localhost when Host missing

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -44,6 +44,7 @@ endif::[]
 
 - Fixed setting outcome in Mongo spy when not traced {pull}937[#937]
 - Fixed missing container metadata in payloads {pull}942[#942]
+- Fixed outgoing HTTP request spans with no Host {pull}962[#962]
 
 [[release-notes-3.13.0]]
 ==== 3.13.0 (2020-12-22)

--- a/docs/supported-technologies.asciidoc
+++ b/docs/supported-technologies.asciidoc
@@ -77,8 +77,7 @@ requests using these libraries:
 - Http.rb (v0.6+)
 - Faraday (v0.2.1+)
 
-*Note:* Some libraries like Net/HTTP and Faraday can make requests without specifying a Host.
-When no Host is specified they, and the agent, will fall back to `localhost` as the Host.
+*Note:* These libraries usually assume `localhost` if no `Host` is specified, so the agent does as well. 
 
 [float]
 [[supported-technologies-backgroud-processing]]

--- a/docs/supported-technologies.asciidoc
+++ b/docs/supported-technologies.asciidoc
@@ -77,6 +77,9 @@ requests using these libraries:
 - Http.rb (v0.6+)
 - Faraday (v0.2.1+)
 
+*Note:* Some libraries like Net/HTTP and Faraday can make requests without specifying a Host.
+When no Host is specified they, and the agent, will fall back to `localhost` as the Host.
+
 [float]
 [[supported-technologies-backgroud-processing]]
 === Background Processing

--- a/lib/elastic_apm/span/context/http.rb
+++ b/lib/elastic_apm/span/context/http.rb
@@ -33,6 +33,8 @@ module ElasticAPM
         private
 
         def sanitize_url(uri_or_str)
+          return unless uri_or_str
+
           uri = uri_or_str.is_a?(URI) ? uri_or_str.dup : URI(uri_or_str)
           uri.password = nil
           uri.to_s

--- a/lib/elastic_apm/spies/net_http.rb
+++ b/lib/elastic_apm/spies/net_http.rb
@@ -61,7 +61,7 @@ module ElasticAPM
               return request_without_apm(req, body, &block)
             end
 
-            host = req['host']&.split(':')&.first || address
+            host = req['host']&.split(':')&.first || address || 'localhost'
             method = req.method.to_s.upcase
             path, query = req.path.split('?')
 

--- a/spec/elastic_apm/spies/faraday_spec.rb
+++ b/spec/elastic_apm/spies/faraday_spec.rb
@@ -165,5 +165,19 @@ module ElasticAPM
       expect(span).to_not be nil
       expect(span.outcome).to eq 'failure'
     end
+
+    it 'falls back to localhost when hostname not provided' do
+      WebMock.stub_request(:any, /.*/)
+
+      with_agent do
+        ElasticAPM.with_transaction 'Faraday test' do
+          Faraday.get('/test')
+        end
+      end
+
+      span, = @intercepted.spans
+
+      expect(span.name).to eq 'GET localhost'
+    end
   end
 end

--- a/spec/elastic_apm/spies/net_http_spec.rb
+++ b/spec/elastic_apm/spies/net_http_spec.rb
@@ -250,5 +250,20 @@ module ElasticAPM
 
       expect(span.outcome).to eq 'failure'
     end
+
+    it 'defaults missing host to localhost' do
+      WebMock.stub_request(:any, %r{http://*})
+
+      with_agent do
+        ElasticAPM.with_transaction 'Net::HTTP test' do
+          Net::HTTP.start(nil) do |http|
+            http.get '/bar'
+          end
+        end
+      end
+
+      expect(@intercepted.transactions.length).to be 1
+      expect(@intercepted.spans.length).to be 1
+    end
   end
 end


### PR DESCRIPTION
Some HTTP clients allow requests without specifying a `Host` to request them at.

This [must be sent with every request](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Host) but we'll just assume that the request is made at `localhost`.

Alternative solution to #960 that still captures spans. Thank you @CarlosRoque for finding and reporting this issue.

Closes #960 