### PR TITLE
Set current_transaction when starting span in new thread and use current_span transaction in ErrorBuilder

### DIFF
--- a/lib/elastic_apm/error_builder.rb
+++ b/lib/elastic_apm/error_builder.rb
@@ -35,7 +35,9 @@ module ElasticAPM
         add_stacktrace error, :exception, exception.backtrace
       end
 
-      add_current_transaction_fields error, ElasticAPM.current_transaction
+      transaction = ElasticAPM.current_transaction ||
+        ElasticAPM.current_span&.transaction
+      add_current_transaction_fields error, transaction
 
       error
     end


### PR DESCRIPTION
These changes set `ElasticAPM.current_transaction` when a new span in created in a new thread using a span's transaction attribute. It also uses `current_span`'s transaction in the `ErrorBuilder`.

I've made the following changes:

- The `current` variable on an instrumenter is itself now set as a Thread current variable, instead of the `spans` and `transaction` variables. This way, a newly spawned thread will have its own `current` variable to track its current spans and a current transaction, which may be different from the parent thread's.
- The error builder uses either the current transaction or the span's transaction object to build the error.
- Set the current transaction to the transaction attribute of newly created span in `instrumenter#start_span`.

Outstanding questions
- When a span is created in a new thread, should the `transaction` of the parent object be set as the new thread's `current_transaction`? For example:

```ruby
transaction = ElasticAPM.start_transaction

Thread.new do
  ElasticAPM.with_span('job 1', parent: transaction) do |span|
    # Does ElasticAPM.current_transaction here equal `transaction` above or is it nil?
  end
end

# or when a span is the parent

span = ElasticAPM.start_span
Thread.new do
  ElasticAPM.with_span('job 2', parent: span) do |span|
    # Does ElasticAPM.current_transaction here equal the `transaction` above or is it nil?
  end
end
```
Closes #973