### PR TITLE
Update DynamoDB Spy to match AWS services spec

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -48,6 +48,7 @@ endif::[]
 - Fixed setting outcome in Mongo spy when not traced {pull}937[#937]
 - Fixed missing container metadata in payloads {pull}942[#942]
 - Fixed outgoing HTTP request spans with no Host {pull}962[#962]
+- Fixed DynamoDB instrumentation to match spec {pull}976[#976]
 
 [[release-notes-3.13.0]]
 ==== 3.13.0 (2020-12-22)

--- a/lib/elastic_apm/spies/dynamo_db.rb
+++ b/lib/elastic_apm/spies/dynamo_db.rb
@@ -39,10 +39,9 @@ module ElasticAPM
       end
 
       def self.span_name(operation_name, params)
-        ['DynamoDB',
-         formatted_op_name(operation_name),
-         params[:table_name]
-        ].compact.join(' ')
+        params[:table_name] ?
+          "DynamoDB #{formatted_op_name(operation_name)} #{params[:table_name]}" :
+          "DynamoDB #{formatted_op_name(operation_name)}"
       end
 
       def self.formatted_op_name(operation_name)


### PR DESCRIPTION
See [the spec here](https://github.com/elastic/apm/blob/master/specs/agents/tracing-instrumentation-aws.md)

Closes #943 