### PR TITLE
Fix AWS S3 spy, update AWS SNS spy

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -35,6 +35,16 @@ endif::[]
 [[release-notes-4.x]]
 === Ruby Agent version 4.x
 
+[float]
+[[unreleased]]
+==== Unreleased
+
+[float]
+===== Fixed
+
+- AWS S3 spy accepts symbol bucket names {pull}998[#998]
+- AWS S3 spy passing on blocks {pull}998[#998]
+
 [[release-notes-4.0.0]]
 ==== 4.0.0.beta.1
 

--- a/lib/elastic_apm/spies/s3.rb
+++ b/lib/elastic_apm/spies/s3.rb
@@ -84,7 +84,7 @@ module ElasticAPM
         def self.prepended(mod)
           # Alias all available operations
           mod.api.operation_names.each do |operation_name|
-            define_method(operation_name) do |params = {}, options = {}|
+            define_method(operation_name) do |params = {}, options = {}, &block|
               bucket_name = ElasticAPM::Spies::S3Spy.bucket_name(params)
               cloud = ElasticAPM::Span::Context::Destination::Cloud.new(
                 region: ElasticAPM::Spies::S3Spy.accesspoint_region(params) || config.region
@@ -107,7 +107,7 @@ module ElasticAPM
                 context: context
               ) do
                 ElasticAPM::Spies::S3Spy.without_net_http do
-                  super(params, options)
+                  super(params, options, &block)
                 end
               end
             end

--- a/lib/elastic_apm/spies/s3.rb
+++ b/lib/elastic_apm/spies/s3.rb
@@ -41,13 +41,10 @@ module ElasticAPM
       end
 
       def self.bucket_name(params)
-        if params[:bucket]
-          if index = params[:bucket].rindex(AP_REGEX)
-            params[:bucket][index+1..-1]
-          else
-            params[:bucket]
-          end
-        end
+        return unless (bucket = params[:bucket]&.to_s)
+        return bucket unless (index = bucket.rindex(AP_REGEX))
+
+        bucket[index+1..-1]
       end
 
       def self.accesspoint_region(params)

--- a/lib/elastic_apm/transport/user_agent.rb
+++ b/lib/elastic_apm/transport/user_agent.rb
@@ -21,7 +21,8 @@ module ElasticAPM
   module Transport
     # @api private
     class UserAgent
-      def initialize(config)
+      def initialize(config, version: VERSION)
+        @version = version
         @built = build(config)
       end
 
@@ -35,7 +36,7 @@ module ElasticAPM
         service = Metadata::ServiceInfo.new(config)
 
         [
-          "elastic-apm-ruby/#{VERSION}",
+          "elastic-apm-ruby/#{@version}",
           HTTP::Request::USER_AGENT,
           [
             service.runtime.name,

--- a/spec/elastic_apm/spies/s3_spec.rb
+++ b/spec/elastic_apm/spies/s3_spec.rb
@@ -48,6 +48,21 @@ module ElasticAPM
       expect(span.context.destination.cloud.region).to eq('us-west-1')
     end
 
+    context 'when bucket name is a symbol' do
+      it 'sets bucket name', :intercept do
+        with_agent do
+          ElasticAPM.with_transaction do
+            s3_client.create_bucket(bucket: :mybucket)
+          end
+        end
+
+        span = @intercepted.spans.first
+
+        expect(span.name).to eq('S3 CreateBucket mybucket')
+        expect(span.context.destination.resource).to eq('mybucket')
+      end
+    end
+
     context 'when there is no bucket name' do
       it 'does not include a bucket in the span name', :intercept do
         with_agent do

--- a/spec/elastic_apm/spies/sns_spec.rb
+++ b/spec/elastic_apm/spies/sns_spec.rb
@@ -183,7 +183,8 @@ module ElasticAPM
       end
 
       it 'adds trace context to the message attributes', :intercept do
-        allow(client).to receive(:publish_without_apm)
+        allow(client).to receive(:build_request).and_call_original
+
         with_agent do
           ElasticAPM.with_transaction do
             client.publish(
@@ -193,7 +194,7 @@ module ElasticAPM
           end
         end
 
-        expect(client).to have_received(:publish_without_apm) do |args|
+        expect(client).to have_received(:build_request) do |_, args|
           expect(args[:message_attributes]).to include(
             "Traceparent" => hash_including(data_type: "String")
           )

--- a/spec/elastic_apm/transport/connection_spec.rb
+++ b/spec/elastic_apm/transport/connection_spec.rb
@@ -78,11 +78,12 @@ module ElasticAPM
       it 'has a fitting user agent' do
         stub = build_stub(
           headers: {
-            'User-Agent' => %r{
-              \Aelastic-apm-ruby/(\d+\.)+\d+\s
-              http.rb/(\d+\.)+\d+\s
-              j?ruby/(\d+\.)+\d+\z
-            }x
+            'User-Agent' =>
+              %r{
+                \Aelastic-apm-ruby/(\d+\.)+\d([a-z0-9\.]+)?+\s
+                http.rb/(\d+\.)+\d+\s
+                j?ruby/(\d+\.)+\d+\z
+              }x
           }
         )
         subject.write('{}')

--- a/spec/elastic_apm/transport/user_agent_spec.rb
+++ b/spec/elastic_apm/transport/user_agent_spec.rb
@@ -22,18 +22,24 @@ require 'spec_helper'
 module ElasticAPM
   module Transport
     RSpec.describe UserAgent do
+      REGEXP =
+        %r{
+          \Aelastic-apm-ruby/(\d+\.)+\d([a-z0-9\.]+)?+\s
+          http.rb/(\d+\.)+\d+\s
+          j?ruby/(\d+\.)+\d+\z
+        }x
+
       let(:config) { Config.new }
       subject { described_class.new(config) }
 
       describe 'to_s' do
         it 'builds a string' do
-          expect(subject.to_s).to match(
-            %r{
-              \Aelastic-apm-ruby/(\d+\.)+\d+\s
-              http.rb/(\d+\.)+\d+\s
-              j?ruby/(\d+\.)+\d+\z
-            }x
-          )
+          expect(subject.to_s).to match(REGEXP)
+        end
+
+        it 'handles beta versions' do
+          subject = described_class.new(config, version: '12.13.14.beta.20')
+          expect(subject.to_s).to match(REGEXP)
         end
       end
     end


### PR DESCRIPTION
Fixes #997 
Fixes #995 

Also updates SNS spy to new `Module#prepend` strategy.