### PR TITLE
Split hostname into detected_ and configured_

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -44,6 +44,16 @@ endif::[]
 
 - Azure App Services instance metadata {pull}1007[#1007]
 
+[float]
+===== Changed
+
+- `hostname` is now reported split by `configured_hostname` and `detected_hostname` {pull}1009[#1009]
+
+[float]
+===== Fixed
+
+- `service_node_name` is now correctly reported as `service.node.configured_name` {pull}1009[#1009]
+
 [[release-notes-4.0.0]]
 ==== 4.0.0
 

--- a/lib/elastic_apm/metadata/system_info.rb
+++ b/lib/elastic_apm/metadata/system_info.rb
@@ -24,7 +24,8 @@ module ElasticAPM
       def initialize(config)
         @config = config
 
-        @hostname = @config.hostname || self.class.system_hostname
+        @configured_hostname = @config.hostname
+        @detected_hostname = detect_hostname
         @architecture = gem_platform.cpu
         @platform = gem_platform.os
 
@@ -33,14 +34,23 @@ module ElasticAPM
         @kubernetes = container_info.kubernetes
       end
 
-      attr_reader :hostname, :architecture, :platform, :container, :kubernetes
+      attr_reader(
+        :detected_hostname,
+        :configured_hostname,
+        :architecture,
+        :platform,
+        :container,
+        :kubernetes
+      )
 
       def gem_platform
         @gem_platform ||= Gem::Platform.local
       end
 
-      def self.system_hostname
-        @system_hostname ||= `hostname`.chomp
+      private
+
+      def detect_hostname
+        `hostname`.chomp
       end
     end
   end

--- a/lib/elastic_apm/transport/serializers/metadata_serializer.rb
+++ b/lib/elastic_apm/transport/serializers/metadata_serializer.rb
@@ -81,7 +81,8 @@ module ElasticAPM
 
         def build_system(system)
           {
-            hostname: keyword_field(system.hostname),
+            detected_hostname: keyword_field(system.detected_hostname),
+            configured_hostname: keyword_field(system.configured_hostname),
             architecture: keyword_field(system.architecture),
             platform: keyword_field(system.platform),
             kubernetes: keyword_object(system.kubernetes),

--- a/lib/elastic_apm/transport/serializers/metadata_serializer.rb
+++ b/lib/elastic_apm/transport/serializers/metadata_serializer.rb
@@ -65,7 +65,7 @@ module ElasticAPM
             }
 
           if (node_name = service.node_name)
-            base[:node] = { name: keyword_field(node_name) }
+            base[:node] = { configured_name: keyword_field(node_name) }
           end
 
           base

--- a/spec/elastic_apm/metadata/system_info_spec.rb
+++ b/spec/elastic_apm/metadata/system_info_spec.rb
@@ -25,14 +25,14 @@ module ElasticAPM
       subject { described_class.new(Config.new) }
 
       it 'has values' do
-        %i[hostname architecture platform].each do |key|
+        %i[detected_hostname architecture platform].each do |key|
           expect(subject.send(key)).to_not be_nil
         end
       end
 
       context 'hostname' do
         it 'has no newline at the end' do
-          expect(subject.hostname).not_to match(/\n\z/)
+          expect(subject.detected_hostname).not_to match(/\n\z/)
         end
       end
     end

--- a/spec/elastic_apm/transport/serializers/metadata_serializer_spec.rb
+++ b/spec/elastic_apm/transport/serializers/metadata_serializer_spec.rb
@@ -43,7 +43,7 @@ module ElasticAPM
             let(:config) { Config.new(service_node_name: 'a') }
 
             it 'has a node obj' do
-              expect(result.dig(:metadata, :service, :node, :name)).to eq 'a'
+              expect(result.dig(:metadata, :service, :node, :configured_name)).to eq 'a'
             end
           end
 


### PR DESCRIPTION
* `hostname` is deprecated.
* `service_node_name` should be `configured_name` field.

Fixes #972