### PR TITLE
Fix JSON parsing when using yajl-ruby

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -8,6 +8,10 @@ endif::[]
 ==== x.x.x (YYYY-MM-DD)
 
 [float]
+===== Fixed
+- Fix JSON parsing when using yajl-ruby
+
+[float]
 ===== Breaking changes
 - Breaking change
 

--- a/lib/elastic_apm/metadata/cloud_info.rb
+++ b/lib/elastic_apm/metadata/cloud_info.rb
@@ -76,7 +76,7 @@ module ElasticAPM
         resp = @client.get(AWS_URI)
 
         return unless resp.status == 200
-        return unless (metadata = JSON.parse(resp.body))
+        return unless (metadata = JSON.parse(resp.body.to_s))
 
         self.provider = "aws"
         self.account_id = metadata["accountId"]
@@ -92,7 +92,7 @@ module ElasticAPM
         resp = @client.headers("Metadata-Flavor" => "Google").get(GCP_URI)
 
         return unless resp.status == 200
-        return unless (metadata = JSON.parse(resp.body))
+        return unless (metadata = JSON.parse(resp.body.to_s))
 
         zone = metadata["instance"]["zone"]&.split("/")&.at(-1)
 
@@ -112,7 +112,7 @@ module ElasticAPM
         resp = @client.headers("Metadata" => "true").get(AZURE_URI)
 
         return unless resp.status == 200
-        return unless (metadata = JSON.parse(resp.body))
+        return unless (metadata = JSON.parse(resp.body.to_s))
 
         self.provider = 'azure'
         self.account_id = metadata["subscriptionId"]


### PR DESCRIPTION
## What does this pull request do?

This will fix a problem when the `yajl-ruby` gem is used for JSON parsing
because it throws this exception when we pass an object to be
parsed: `Yajl::ParseError: input must be a string or IO`. `to_s` is already
called in `lib/elastic_apm/central_config.rb:125`, for example, so I don't
think it will hurt to call it here.


## Checklist
<!--
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] I have signed the [Contributor License Agreement](https://www.elastic.co/contributor-agreement/). 
- [x] My code follows the style guidelines of this project (See `.rubocop.yml`)
- [x] I have rebased my changes on top of the latest master branch
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing [**unit** tests](https://github.com/elastic/apm-agent-ruby/blob/master/CONTRIBUTING.md#testing) pass locally with my changes
<!--
Run the test suite to make sure that nothing is broken. See https://github.com/elastic/apm-agent-ruby/blob/master/CONTRIBUTING.md#testing for details.
-->
- [x] I have made corresponding changes to the documentation
- [x] I have updated [CHANGELOG.asciidoc](CHANGELOG.asciidoc)
- [x] I have updated [supported-technologies.asciidoc](docs/supported-technologies.asciidoc)
- [ ] Added an API method or config option? Document in which version this will be introduced
