### PR TITLE
Put the forking debug message on one line

### DIFF
--- a/lib/elastic_apm/agent.rb
+++ b/lib/elastic_apm/agent.rb
@@ -280,8 +280,8 @@ module ElasticAPM
     def detect_forking!
       return if @pid == Process.pid
 
-      config.logger.debug "Forked process detected,
-        restarting threads in process [PID:#{Process.pid}]"
+      config.logger.debug(
+        "Forked process detected, restarting threads in process [PID:#{Process.pid}]")
 
       central_config.handle_forking!
       transport.handle_forking!


### PR DESCRIPTION
When debugging issue #1024 I noticed the forking detected debug message was erroneously on two lines.