### PR TITLE
Add support for net/http path to be a uri or path

### DIFF
--- a/lib/elastic_apm/spies/net_http.rb
+++ b/lib/elastic_apm/spies/net_http.rb
@@ -60,7 +60,12 @@ module ElasticAPM
 
           host = req['host']&.split(':')&.first || address || 'localhost'
           method = req.method.to_s.upcase
-          path, query = req.path.split('?')
+          uri_or_path = URI.parse(req.path)
+          if uri_or_path.host.nil?
+            path, query = req.path.split('?')
+          else
+            path, query = uri_or_path.path.split('?')
+          end
 
           url = use_ssl? ? +'https://' : +'http://'
           url << host

--- a/spec/elastic_apm/spies/net_http_spec.rb
+++ b/spec/elastic_apm/spies/net_http_spec.rb
@@ -265,5 +265,20 @@ module ElasticAPM
       expect(@intercepted.transactions.length).to be 1
       expect(@intercepted.spans.length).to be 1
     end
+
+    it 'supports path being a uri' do
+      WebMock.stub_request(:any, %r{http://*})
+
+      with_agent do
+        ElasticAPM.with_transaction 'Net::HTTP test' do
+          Net::HTTP.start(nil) do |http|
+            http.get 'https://www.foo.bar/test'
+          end
+        end
+      end
+
+      expect(@intercepted.transactions.length).to be 1
+      expect(@intercepted.spans.length).to be 1
+    end
   end
 end


### PR DESCRIPTION
## What does this pull request do?

This change aligns the net/http spy with the net/http request flow by allowing the `path` within the `req` object to be a `uri` or `path`.

## Why is it important?

This comment showcases the context behind why this change is important: https://github.com/elastic/apm-agent-ruby/issues/834#issuecomment-863664381

## Checklist

- [x] I have signed the [Contributor License Agreement](https://www.elastic.co/contributor-agreement/). 
- [x] My code follows the style guidelines of this project (See `.rubocop.yml`)
- [x] I have rebased my changes on top of the latest master branch
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing [**unit** tests](https://github.com/elastic/apm-agent-ruby/blob/master/CONTRIBUTING.md#testing) pass locally with my changes
- [ ] I have made corresponding changes to the documentation
- [ ] I have updated [CHANGELOG.asciidoc](CHANGELOG.asciidoc)
- [ ] I have updated [supported-technologies.asciidoc](docs/supported-technologies.asciidoc)
- [x] Added an API method or config option? Document in which version this will be introduced

## Related issues
- Fixes https://github.com/elastic/apm-agent-ruby/issues/834