### PR TITLE
Central Config header key is 'If-None-Match' for the Etag

### DIFF
--- a/lib/elastic_apm/central_config.rb
+++ b/lib/elastic_apm/central_config.rb
@@ -169,7 +169,7 @@ module ElasticAPM
     end
 
     def headers
-      { 'Etag': @etag }
+      { 'If-None-Match': @etag }
     end
 
     def schedule_next_fetch(resp = nil)

--- a/spec/elastic_apm/central_config_spec.rb
+++ b/spec/elastic_apm/central_config_spec.rb
@@ -192,6 +192,7 @@ module ElasticAPM
             request: { headers: { 'Etag': '___etag___' } }
           )
 
+          expect(subject.send(:headers)).to eq('If-None-Match': '___etag___')
           subject.fetch_and_apply_config
           subject.promise.wait
         end

--- a/spec/elastic_apm/central_config_spec.rb
+++ b/spec/elastic_apm/central_config_spec.rb
@@ -189,10 +189,10 @@ module ElasticAPM
 
           stub_response(
             nil,
-            request: { headers: { 'Etag': '___etag___' } }
+            request: { headers: { 'If-None-Match': '___etag___' } },
+            response: { headers: { 'Etag': '___etag___' } }
           )
 
-          expect(subject.send(:headers)).to eq('If-None-Match': '___etag___')
           subject.fetch_and_apply_config
           subject.promise.wait
         end


### PR DESCRIPTION
Resolves #1011 

We were using the wrong header key when making requests for the central config updates. It should be `If-None-Match`, not `Etag`. The symptom of this bug was that Kibana was never marking the config update as having been applied (the grey dot stayed grey and never turned to green).