### PR TITLE
Close rd pipe after sending the request

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -26,7 +26,6 @@ endif::[]
 [float]
 ===== Fixed
 - Fix {pull}2526[#2526]
-- Fix growing number of open file descriptors {pull}1033[#1033]
 
 [float]
 [[unreleased]]
@@ -45,6 +44,7 @@ endif::[]
 
 - Align HTTP span types/subtypes with spec {pull}1014[#1014]
 - Passing a full URL as a path to `Net::HTTP` {pull}1029[#1029]
+- Fix growing number of open file descriptors {pull}1033[#1033]
 
 [[release-notes-4.1.0]]
 ==== 4.1.0

--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -26,6 +26,7 @@ endif::[]
 [float]
 ===== Fixed
 - Fix {pull}2526[#2526]
+- Fix growing number of open file descriptors {pull}1033[#1033]
 
 [float]
 [[unreleased]]

--- a/lib/elastic_apm/transport/connection/http.rb
+++ b/lib/elastic_apm/transport/connection/http.rb
@@ -85,7 +85,7 @@ module ElasticAPM
         end
 
         def closed?
-          @closed.true?
+          @rd.closed? && @closed.true?
         end
 
         def inspect
@@ -117,6 +117,8 @@ module ElasticAPM
               error(
                 "Couldn't establish connection to APM Server:\n%p", e.inspect
               )
+            ensure
+              @rd&.close
             end
           end
         end


### PR DESCRIPTION
## What does this pull request do?

It closes the read pipe after sending the HTTP request.

## Why is it important?

Not closing the read pipe causes a growing number of open file descriptors.

## Observations

I've updated the `closed?` method. This way, the current tests will cover the change.

## Checklist

- [x] I have signed the [Contributor License Agreement](https://www.elastic.co/contributor-agreement/). 
- [x] My code follows the style guidelines of this project (See `.rubocop.yml`)
- [x] I have rebased my changes on top of the latest master branch
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing [**unit** tests](https://github.com/elastic/apm-agent-ruby/blob/master/CONTRIBUTING.md#testing) pass locally with my changes
- [x] I have made corresponding changes to the documentation
- [x] I have updated [CHANGELOG.asciidoc](CHANGELOG.asciidoc)
- [x] I have updated [supported-technologies.asciidoc](docs/supported-technologies.asciidoc)
- [ ] Added an API method or config option? Document in which version this will be introduced

## Related issues

- Closes #1032

