### PR TITLE
Decrease CentralConfig 304 log level to debug

### DIFF
--- a/lib/elastic_apm/central_config.rb
+++ b/lib/elastic_apm/central_config.rb
@@ -119,7 +119,7 @@ module ElasticAPM
       end
 
       if resp.status == 304
-        info 'Received 304 Not Modified'
+        debug 'Received 304 Not Modified'
       else
         if resp.body && !resp.body.empty?
           update = JSON.parse(resp.body.to_s)


### PR DESCRIPTION
As nothing really changed, logging a message on each succesful, not-changed update from CC was maybe a bit too spammy. Let's decrease the level to DEBUG instead.