### PR TITLE
Add optional span param to end_span

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -32,6 +32,10 @@ endif::[]
 ==== Unreleased
 ////
 
+[float]
+===== Added
+- Optional span to be ended instead of current span {pull}1039[#1039]
+
 [[release-notes-4.x]]
 === Ruby Agent version 4.x
 

--- a/lib/elastic_apm.rb
+++ b/lib/elastic_apm.rb
@@ -243,9 +243,12 @@ module ElasticAPM
 
     # Ends the current span
     #
+    # @param span [Span] Optional span to be ended instead of the last span
+    #   created, useful for asynchronous environments where multiple spans are created in parallel
+    #
     # @return [Span]
-    def end_span
-      agent&.end_span
+    def end_span(span = nil)
+      agent&.end_span(span)
     end
 
     # rubocop:disable Metrics/ParameterLists

--- a/lib/elastic_apm/agent.rb
+++ b/lib/elastic_apm/agent.rb
@@ -211,8 +211,8 @@ module ElasticAPM
     end
     # rubocop:enable Metrics/ParameterLists
 
-    def end_span
-      instrumenter.end_span
+    def end_span(span = nil)
+      instrumenter.end_span(span)
     end
 
     def set_label(key, value)

--- a/lib/elastic_apm/instrumenter.rb
+++ b/lib/elastic_apm/instrumenter.rb
@@ -222,8 +222,14 @@ module ElasticAPM
     # rubocop:enable Metrics/CyclomaticComplexity
     # rubocop:enable Metrics/PerceivedComplexity
 
-    def end_span
-      return unless (span = current_spans.pop)
+    def end_span(span = nil)
+      if span
+        current_spans.delete(span)
+      else
+        span = current_spans.pop
+      end
+
+      return unless span
 
       span.done
 

--- a/spec/elastic_apm/agent_spec.rb
+++ b/spec/elastic_apm/agent_spec.rb
@@ -101,7 +101,7 @@ module ElasticAPM
               sync: nil
             }
           ],
-          end_span: nil,
+          end_span: [nil],
           set_label: [nil, nil],
           set_custom_context: [nil],
           set_user: [nil]

--- a/spec/elastic_apm/instrumenter_spec.rb
+++ b/spec/elastic_apm/instrumenter_spec.rb
@@ -325,6 +325,23 @@ module ElasticAPM
             expect(subject.current_span).to be span
           end
         end
+
+        context 'when passing a span' do
+          let(:another_span) { subject.start_span 'Another Span' }
+
+          before do
+            another_span
+          end
+
+          it 'closes span, sets new current, enqueues' do
+            return_value = subject.end_span(span)
+
+            expect(return_value).to be span
+            expect(span).to be_stopped
+            expect(subject.current_span).to be another_span
+            expect(agent).to have_received(:enqueue).with(span)
+          end
+        end
       end
     end
 


### PR DESCRIPTION
## What does this pull request do?

Add optional span param to end_span

## Why is it important?

When using the gem in asynchronous systems, multiple spans will be created in parallel, and they aren't going to finish in the same order they were created. Therefore, to have spans with the correct duration, we need to pass the span we want to finish - in this case, it's the developer responsibility to hold the span created and pass it to `end_span`.

Usage example:

```ruby
require "eventmachine"
require "em-http"
require "elastic_apm"

puts "Starting..."

ElasticAPM.start

EM.run do
  ElasticAPM.start_transaction("Transaction")

  count = 0

  ["https://example.com", "https://example.org"].each do |url|
    span = ElasticAPM.start_span("GET #{url}")

    http = EventMachine::HttpRequest.new(url).get

    http.errback do
      ElasticAPM.end_span(span)
      count += 1
    end

    http.callback do
      ElasticAPM.end_span(span)
      count += 1
    end
  end

  timer = EventMachine::PeriodicTimer.new(1) do
    if count == 2
      ElasticAPM.end_transaction
      puts "Stopping..."
      EM.add_timer(5) do
        ElasticAPM.stop
        EM.stop
      end
      timer.cancel
    end
  end
end
```

## Checklist

- [x] I have signed the [Contributor License Agreement](https://www.elastic.co/contributor-agreement/). 
- [x] My code follows the style guidelines of this project (See `.rubocop.yml`)
- [x] I have rebased my changes on top of the latest master branch
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing [**unit** tests](https://github.com/elastic/apm-agent-ruby/blob/master/CONTRIBUTING.md#testing) pass locally with my changes
- [x] I have made corresponding changes to the documentation
- [x] I have updated [CHANGELOG.asciidoc](CHANGELOG.asciidoc)
- [x] I have updated [supported-technologies.asciidoc](docs/supported-technologies.asciidoc)
- [ ] Added an API method or config option? Document in which version this will be introduced
(I'm not sure on this one)
