### PR TITLE
Add JVM memory metrics

### DIFF
--- a/docs/metrics.asciidoc
+++ b/docs/metrics.asciidoc
@@ -141,3 +141,95 @@ The total time spent in garbage collection.
 
 **NB:** You need to enable Ruby's GC Profiler for this to get reported.
 You can do this at any time when your application boots by calling `GC::Profiler.enable`.
+
+[float]
+[[metrics-jvm-metrics]]
+=== JVM Metrics
+
+The following metrics are available when using JRuby. They use the ruby java API to gather metrics via MXBean.
+
+[float]
+[[metric-jvm.memory.heap.used]]
+==== `jvm.memory.heap.used`
+
+* *Type:* Long
+* *Format:* Bytes
+
+The amount of used heap memory in bytes.
+
+[float]
+[[metric-jvm.memory.heap.committed]]
+==== `jvm.memory.heap.committed`
+
+* *Type:* Long
+* *Format:* Bytes
+
+The amount of heap memory in bytes that is committed for the Java virtual machine to use. This amount of memory is
+guaranteed for the Java virtual machine to use.
+
+[float]
+[[metric-jvm.memory.heap.max]]
+==== `jvm.memory.heap.max`
+
+* *Type:* Long
+* *Format:* Bytes
+
+The amount of heap memory in bytes that is committed for the Java virtual machine to use. This amount of memory is
+guaranteed for the Java virtual machine to use.
+
+[float]
+[[metric-jvm.memory.non_heap.used]]
+==== `jvm.memory.non_heap.used`
+
+* *Type:* Long
+* *Format:* Bytes
+
+The amount of used non-heap memory in bytes.
+
+[float]
+[[metric-jvm.memory.non_heap.committed]]
+==== `jvm.memory.non_heap.committed`
+
+* *Type:* Long
+* *Format:* Bytes
+
+The amount of non-heap memory in bytes that is committed for the Java virtual machine to use. This amount of memory is
+guaranteed for the Java virtual machine to use.
+
+[float]
+[[metric-jvm.memory.non_heap.max]]
+==== `jvm.memory.non_heap.max`
+
+* *Type:* Long
+* *Format:* Bytes
+
+The maximum amount of non-heap memory in bytes that can be used for memory management. If the maximum memory size is
+undefined, the value is -1.
+
+[float]
+[[metric-jvm.memory.heap.pool.used]]
+==== `jvm.memory.heap.pool.used`
+
+* *Type:* Long
+* *Format:* Bytes
+
+The amount of used memory in bytes of the memory pool.
+
+[float]
+[[metric-jvm.memory.heap.pool.committed]]
+==== `jvm.memory.heap.pool.committed`
+
+* *Type:* Long
+* *Format:* Bytes
+
+The amount of memory in bytes that is committed for the memory pool. This amount of memory is guaranteed for this
+specific pool.
+
+[float]
+[[metric-jvm.memory.heap.pool.max]]
+==== `jvm.memory.heap.pool.max`
+
+* *Type:* Long
+* *Format:* Bytes
+
+The maximum amount of memory in bytes that can be used for the memory pool.

--- a/lib/elastic_apm/metrics.rb
+++ b/lib/elastic_apm/metrics.rb
@@ -63,7 +63,10 @@ module ElasticAPM
             breakdown: BreakdownSet,
             transaction: TransactionSet
           }
-          sets[:jvm] = JVMSet if defined?(JVMSet)
+          if defined?(JVMSet)
+            debug "Enabling JVM metrics collection"
+            sets[:jvm] = JVMSet
+          end
 
           @sets = sets.each_with_object({}) do |(key, kls), _sets_|
             debug "Adding metrics collector '#{kls}'"

--- a/lib/elastic_apm/metrics.rb
+++ b/lib/elastic_apm/metrics.rb
@@ -57,16 +57,17 @@ module ElasticAPM
         # Only set the @sets once, in case we stop
         # and start again.
         if @sets.nil?
-          @sets = {
+          sets = {
             system: CpuMemSet,
             vm: VMSet,
             breakdown: BreakdownSet,
             transaction: TransactionSet
           }
-          @sets[:jvm] = JVMSet if defined?(JVMSet)
-          @sets.each_with_object({}) do |(key, kls), sets|
+          sets[:jvm] = JVMSet if defined?(JVMSet)
+
+          @sets = sets.each_with_object({}) do |(key, kls), _sets_|
             debug "Adding metrics collector '#{kls}'"
-            sets[key] = kls.new(config)
+            _sets_[key] = kls.new(config)
           end
         end
 

--- a/lib/elastic_apm/metrics.rb
+++ b/lib/elastic_apm/metrics.rb
@@ -59,7 +59,9 @@ module ElasticAPM
           system: CpuMemSet,
           vm: VMSet,
           breakdown: BreakdownSet,
-          transaction: TransactionSet
+          transaction: TransactionSet,
+          # jvm: JVMSet <-- we need this, but dynamically somehow
+          # maybe they register themselves akin to how the spies do?
         }.each_with_object({}) do |(key, kls), sets|
           debug "Adding metrics collector '#{kls}'"
           sets[key] = kls.new(config)

--- a/lib/elastic_apm/metrics.rb
+++ b/lib/elastic_apm/metrics.rb
@@ -28,6 +28,10 @@ module ElasticAPM
       @platform ||= Gem::Platform.local.os.to_sym
     end
 
+    def self.os
+      @platform ||= RbConfig::CONFIG.fetch('host_os', 'unknown').to_sym
+    end
+
     # @api private
     class Registry
       include Logging
@@ -136,6 +140,7 @@ require 'elastic_apm/metrics/set'
 
 require 'elastic_apm/metrics/cpu_mem_set'
 require 'elastic_apm/metrics/vm_set'
+require 'elastic_apm/metrics/jvm_set' if defined?(JRUBY_VERSION)
 require 'elastic_apm/metrics/span_scoped_set'
 require 'elastic_apm/metrics/transaction_set'
 require 'elastic_apm/metrics/breakdown_set'

--- a/lib/elastic_apm/metrics/cpu_mem_set.rb
+++ b/lib/elastic_apm/metrics/cpu_mem_set.rb
@@ -79,7 +79,7 @@ module ElasticAPM
         case os
         when :linux then Linux.new
         else
-          warn "Disabling system metrics, unsupported host OS '#{platform}'"
+          warn "Disabling system metrics, unsupported host OS '#{os}'"
           disable!
           nil
         end

--- a/lib/elastic_apm/metrics/cpu_mem_set.rb
+++ b/lib/elastic_apm/metrics/cpu_mem_set.rb
@@ -62,8 +62,8 @@ module ElasticAPM
       def initialize(config)
         super
 
-        @sampler = sampler_for_platform(Metrics.platform)
-        read! # set @previous on boot
+        @sampler = sampler_for_os(Metrics.os)
+        read! # set initial values to calculate deltas from
       end
 
       attr_reader :config
@@ -75,11 +75,11 @@ module ElasticAPM
 
       private
 
-      def sampler_for_platform(platform)
-        case platform
+      def sampler_for_os(os)
+        case os
         when :linux then Linux.new
         else
-          warn "Disabling system metrics, unsupported platform '#{platform}'"
+          warn "Disabling system metrics, unsupported host OS '#{platform}'"
           disable!
           nil
         end

--- a/lib/elastic_apm/metrics/jvm_set.rb
+++ b/lib/elastic_apm/metrics/jvm_set.rb
@@ -1,0 +1,75 @@
+# Licensed to Elasticsearch B.V. under one or more contributor
+# license agreements. See the NOTICE file distributed with
+# this work for additional information regarding copyright
+# ownership. Elasticsearch B.V. licenses this file to you under
+# the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+# frozen_string_literal: true
+
+require 'java'
+
+module ElasticAPM
+  module Metrics
+    # @api private
+    class JVMSet < Set
+      include Logging
+
+      def collect
+        read!
+        super
+      end
+
+      def read!
+        return if disabled?
+
+        heap = platform_bean.get_heap_memory_usage
+        non_heap = platform_bean.get_non_heap_memory_usage
+
+        gauge(:"jvm.memory.heap.used").value = heap.get_used
+        gauge(:"jvm.memory.heap.committed").value = heap.get_committed
+        gauge(:"jvm.memory.heap.max").value = heap.get_max
+
+        gauge(:"jvm.memory.non_heap.used").value = non_heap.get_used
+        gauge(:"jvm.memory.non_heap.committed").value = non_heap.get_committed
+        gauge(:"jvm.memory.non_heap.max").value = non_heap.get_max
+
+        pool_beans.each do |bean|
+          next unless bean.type.name == "HEAP"
+
+          tags = { name: bean.get_name }
+
+          gauge(:"jvm.memory.heap.pool.used", tags: tags).value = bean.get_usage.get_used
+          gauge(:"jvm.memory.heap.pool.committed", tags: tags).value = bean.get_usage.get_committed
+          gauge(:"jvm.memory.heap.pool.max", tags: tags).value = bean.get_usage.get_max
+        end
+      # rescue Exception => e
+        # error("JVM metrics encountered error: %s", e)
+        # debug("Backtrace:") { e.backtrace.join("\n") }
+        # disable!
+      end
+
+      private
+
+      def platform_bean
+        @platform_bean ||= java.lang.management.ManagementFactory.getPlatformMXBean(
+          java.lang.management.MemoryMXBean.java_class
+        )
+      end
+
+      def pool_beans
+        @pool_beans ||= java.lang.management.ManagementFactory.getMemoryPoolMXBeans()
+      end
+    end
+  end
+end

--- a/spec/elastic_apm/metrics/cpu_mem_set_spec.rb
+++ b/spec/elastic_apm/metrics/cpu_mem_set_spec.rb
@@ -26,7 +26,7 @@ module ElasticAPM
       subject { described_class.new config }
 
       context 'Linux' do
-        before { allow(Metrics).to receive(:platform) { :linux } }
+        before { allow(Metrics).to receive(:os) { :linux } }
 
         describe 'collect' do
           it 'collects all metrics' do

--- a/spec/elastic_apm/metrics/cpu_mem_set_spec.rb
+++ b/spec/elastic_apm/metrics/cpu_mem_set_spec.rb
@@ -25,10 +25,6 @@ module ElasticAPM
       let(:config) { Config.new }
       subject { described_class.new config }
 
-      context 'JRuby' do
-
-      end
-
       context 'Linux' do
         before { allow(Metrics).to receive(:platform) { :linux } }
 

--- a/spec/elastic_apm/metrics/cpu_mem_set_spec.rb
+++ b/spec/elastic_apm/metrics/cpu_mem_set_spec.rb
@@ -25,6 +25,10 @@ module ElasticAPM
       let(:config) { Config.new }
       subject { described_class.new config }
 
+      context 'JRuby' do
+
+      end
+
       context 'Linux' do
         before { allow(Metrics).to receive(:platform) { :linux } }
 

--- a/spec/elastic_apm/metrics/jvm_set_spec.rb
+++ b/spec/elastic_apm/metrics/jvm_set_spec.rb
@@ -1,0 +1,62 @@
+# Licensed to Elasticsearch B.V. under one or more contributor
+# license agreements. See the NOTICE file distributed with
+# this work for additional information regarding copyright
+# ownership. Elasticsearch B.V. licenses this file to you under
+# the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+module ElasticAPM
+  module Metrics
+    RSpec.describe JVMSet, if: defined?(JRUBY_VERSION) do
+      let(:config) { Config.new }
+
+      subject { described_class.new config }
+
+      describe 'collect' do
+        context 'when disabled' do
+          it 'returns' do
+            subject.disable!
+            expect(subject.collect).to be nil
+          end
+        end
+
+        it 'collects a metric set and prefixes keys' do
+          subject.collect
+          sleep 0.2
+          sets = subject.collect
+
+          expect(sets.first.samples).to match(
+            :"jvm.memory.heap.used" => Integer,
+            :"jvm.memory.heap.committed" => Integer,
+            :"jvm.memory.heap.max" => Integer,
+            :"jvm.memory.non_heap.used" => Integer,
+            :"jvm.memory.non_heap.committed" => Integer,
+            :"jvm.memory.non_heap.max" => Integer,
+          )
+          sets[1..-1].each do |set|
+            expect(set.tags).to match(name: String)
+            expect(set.samples).to match(
+              :"jvm.memory.heap.pool.used" => Integer,
+              :"jvm.memory.heap.pool.committed" => Integer,
+              :"jvm.memory.heap.pool.max" => Integer,
+            )
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/elastic_apm/metrics/jvm_set_spec.rb
+++ b/spec/elastic_apm/metrics/jvm_set_spec.rb
@@ -19,53 +19,55 @@
 
 require 'spec_helper'
 
-module ElasticAPM
-  module Metrics
-    RSpec.describe JVMSet, if: defined?(JRUBY_VERSION) do
-      let(:config) { Config.new }
+if defined?(JRUBY_VERSION)
+  module ElasticAPM
+    module Metrics
+      RSpec.describe JVMSet do
+        let(:config) { Config.new }
 
-      subject { described_class.new config }
+        subject { described_class.new config }
 
-      describe 'collect' do
-        context 'when disabled' do
-          it 'returns' do
-            subject.disable!
-            expect(subject.collect).to be nil
+        describe 'collect' do
+          context 'when disabled' do
+            it 'returns' do
+              subject.disable!
+              expect(subject.collect).to be nil
+            end
           end
-        end
 
-        it 'disables after three errors' do
-          allow(java.lang.management.ManagementFactory).to receive(:getPlatformMXBean).and_raise(Exception)
+          it 'disables after three errors' do
+            allow(java.lang.management.ManagementFactory).to receive(:getPlatformMXBean).and_raise(Exception)
 
-          2.times do
+            2.times do
+              subject.collect
+              expect(subject).to_not be_disabled
+            end
+
             subject.collect
-            expect(subject).to_not be_disabled
+            expect(subject).to be_disabled
           end
 
-          subject.collect
-          expect(subject).to be_disabled
-        end
+          it 'collects a metric set and prefixes keys' do
+            subject.collect
+            sleep 0.2
+            sets = subject.collect
 
-        it 'collects a metric set and prefixes keys' do
-          subject.collect
-          sleep 0.2
-          sets = subject.collect
-
-          expect(sets.first.samples).to match(
-            :"jvm.memory.heap.used" => Integer,
-            :"jvm.memory.heap.committed" => Integer,
-            :"jvm.memory.heap.max" => Integer,
-            :"jvm.memory.non_heap.used" => Integer,
-            :"jvm.memory.non_heap.committed" => Integer,
-            :"jvm.memory.non_heap.max" => Integer,
-          )
-          sets[1..-1].each do |set|
-            expect(set.tags).to match(name: String)
-            expect(set.samples).to match(
-              :"jvm.memory.heap.pool.used" => Integer,
-              :"jvm.memory.heap.pool.committed" => Integer,
-              :"jvm.memory.heap.pool.max" => Integer,
+            expect(sets.first.samples).to match(
+              :"jvm.memory.heap.used" => Integer,
+              :"jvm.memory.heap.committed" => Integer,
+              :"jvm.memory.heap.max" => Integer,
+              :"jvm.memory.non_heap.used" => Integer,
+              :"jvm.memory.non_heap.committed" => Integer,
+              :"jvm.memory.non_heap.max" => Integer,
             )
+            sets[1..-1].each do |set|
+              expect(set.tags).to match(name: String)
+              expect(set.samples).to match(
+                :"jvm.memory.heap.pool.used" => Integer,
+                :"jvm.memory.heap.pool.committed" => Integer,
+                :"jvm.memory.heap.pool.max" => Integer,
+              )
+            end
           end
         end
       end

--- a/spec/elastic_apm/metrics/jvm_set_spec.rb
+++ b/spec/elastic_apm/metrics/jvm_set_spec.rb
@@ -34,6 +34,18 @@ module ElasticAPM
           end
         end
 
+        it 'disables after three errors' do
+          allow(java.lang.management.ManagementFactory).to receive(:getPlatformMXBean).and_raise(Exception)
+
+          2.times do
+            subject.collect
+            expect(subject).to_not be_disabled
+          end
+
+          subject.collect
+          expect(subject).to be_disabled
+        end
+
         it 'collects a metric set and prefixes keys' do
           subject.collect
           sleep 0.2


### PR DESCRIPTION
Closes #954

Uses the same format as https://github.com/elastic/apm-agent-java/blob/master/apm-agent-core/src/main/java/co/elastic/apm/agent/metrics/builtin/JvmMemoryMetrics.java so we can share the custom dashboards for example.

There's also the [GC metrics](https://github.com/elastic/apm-agent-java/blob/master/apm-agent-core/src/main/java/co/elastic/apm/agent/metrics/builtin/JvmGcMetrics.java). I don't if they differ from what we get from `GC.stat` [in the "vm set"](https://github.com/mikker/apm-agent-ruby/blob/805724440cbef5fc3d86c3d26254a47d83c99fb6/spec/elastic_apm/metrics/vm_set_spec.rb#L80-L83).

This also enables the OS metrics in JRuby when we're running on Linux. Turns out reading the `/proc` files are just as likely to work in JRuby when on *nix.