### PR TITLE
Add experimental config option log_ecs_formatting and document it

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -37,6 +37,7 @@ gem 'aws-sdk-s3', require: nil
 gem 'aws-sdk-sqs', require: nil
 gem 'aws-sdk-sns', require: nil
 gem 'azure-storage-table', require: nil if RUBY_VERSION < '3.0'
+gem 'ecs-logging', require: 'ecs_logging/logger'
 gem 'elasticsearch', require: nil
 gem 'fakeredis', require: nil
 gem 'faraday', require: nil

--- a/docs/configuration.asciidoc
+++ b/docs/configuration.asciidoc
@@ -517,13 +517,16 @@ Elastic APM can instrument your Rake tasks. Theis is an opt-in field, as they ar
 This is an experimental option that configures the agent to use the logger from the `ecs-logging` gem. The two
 valid options are `off` and `override`.
 
-The ecs-logging gem must be installed before the agent is started. The agent will attempt to require the gem and if
-it cannot be loaded, it will fall back to using the standard Ruby ::Logger and log the load error.
-
 Setting this option to `override` will set the agent logger to a `EcsLogging::Logger` instance and all logged output
 will be in ECS-compatible json.
 
-Note that if you're using Rails, the agent will use the Rails logger and not a `EcsLogging::Logger`.
+The `ecs-logging` gem must be installed before the agent is started. If `log_ecs_formatting` is set to `override`,
+the agent will attempt to require the gem and if it cannot be loaded, it will fall back to using the standard Ruby
+`::Logger` and log the load error.
+
+Note that if you're using Rails, the agent will ignore this option and use the Rails logger. If you want to use a
+`EcsLogging::Logger` when using Rails, set the agent's logger config option explicitly to a `EcsLogging::Logger`
+instance.
 
 [float]
 [[config-log-level]]

--- a/docs/configuration.asciidoc
+++ b/docs/configuration.asciidoc
@@ -502,7 +502,28 @@ Use this option to ignore certain URL patterns such as healthchecks or admin sec
 | `ELASTIC_APM_INSTRUMENTED_RAKE_TASKS` | `instrumented_rake_tasks` | `[]`    | `['my_task']`
 |============
 
-Elastic APM can instrument your Rake tasks. Theis is an opt-in field, as they are used are for a multitude of things. 
+Elastic APM can instrument your Rake tasks. Theis is an opt-in field, as they are used are for a multitude of things.
+
+[float]
+[[config-log-ecs-formatting]]
+==== `log_ecs_formatting`
+
+[options="header"]
+|============
+| Environment             | `Config` key | Default
+| `ELASTIC_APM_LOG_ECS_FORMATTING` | `log_ecs_formatting`  | `off`
+|============
+
+This is an experimental option that configures the agent to use the logger from the `ecs-logging` gem. The two
+valid options are `off` and `override`.
+
+The ecs-logging gem must be installed before the agent is started. The agent will attempt to require the gem and if
+it cannot be loaded, it will fall back to using the standard Ruby ::Logger and log the load error.
+
+Setting this option to `override` will set the agent logger to a `EcsLogging::Logger` instance and all logged output
+will be in ECS-compatible json.
+
+Note that if you're using Rails, the agent will use the Rails logger and not a `EcsLogging::Logger`.
 
 [float]
 [[config-log-level]]

--- a/spec/elastic_apm/config_spec.rb
+++ b/spec/elastic_apm/config_spec.rb
@@ -199,6 +199,25 @@ module ElasticAPM
           expect(config.log_level).to eq(Logger::FATAL)
         end
       end
+
+      describe 'ecs logging' do
+        context "when log_ecs_formatting is 'override'" do
+          it 'builds an EcsLogging::Logger' do
+            config = Config.new log_ecs_formatting: 'override'
+            expect(config.logger).to be_a(::EcsLogging::Logger)
+          end
+        end
+
+        context "when the log_ecs_formatting value is not valid" do
+          it 'builds a ::Logger' do
+            config = Config.new log_ecs_formatting: 'invalid_option'
+            # Using be_a(::Logger) would be true even if the logger were
+            # a EcsLogging::Logger because the class inherits from ::Logger.
+            # So we test the negative:
+            expect(config.logger).not_to be_a(::EcsLogging::Logger)
+          end
+        end
+      end
     end
 
     describe 'unknown options' do

--- a/spec/integration/rails_ecs_logger_spec.rb
+++ b/spec/integration/rails_ecs_logger_spec.rb
@@ -1,0 +1,49 @@
+# Licensed to Elasticsearch B.V. under one or more contributor
+# license agreements. See the NOTICE file distributed with
+# this work for additional information regarding copyright
+# ownership. Elasticsearch B.V. licenses this file to you under
+# the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# frozen_string_literal: true
+
+require 'integration_helper'
+
+if defined?(Rails)
+  require 'action_controller/railtie'
+
+  RSpec.describe 'Rails logger with Ecs logging option', :allow_running_agent, :mock_intake do
+    before :all do
+      module RailsTestAppEcsLogger
+        class Application < Rails::Application
+          RailsTestHelpers.setup_rails_test_config(config)
+
+          config.disable_send = true
+
+          config.elastic_apm.log_ecs_formatting = 'override'
+        end
+      end
+
+      class ApplicationController < ActionController::Base
+      end
+
+      MockIntake.stub!
+
+      RailsTestAppEcsLogger::Application.initialize!
+    end
+
+    it 'uses the Rails logger' do
+      expect(Rails.logger).to be(ElasticAPM.agent.config.logger)
+    end
+  end
+end

--- a/spec/integration/rails_logger_ecs_spec.rb
+++ b/spec/integration/rails_logger_ecs_spec.rb
@@ -22,7 +22,7 @@ require 'integration_helper'
 if defined?(Rails)
   require 'action_controller/railtie'
 
-  RSpec.describe 'Rails logger with Ecs logging option', :allow_running_agent, :mock_intake do
+  RSpec.describe 'Rails logger with Ecs logging option', :allow_running_agent do
     before :all do
       module RailsTestAppEcsLogger
         class Application < Rails::Application


### PR DESCRIPTION
This PR adds a config option to the agent, `log_ecs_formatting`. If this option is set to "`override`", the agent will attempt to load the `ecs-logging` gem and create a `EcsLogging::Logger` instance for the agent to use. 

The `ecs-logging` gem must be installed before the agent is started. If `log_ecs_formatting` is set to "`override`", the agent will attempt to require the gem and if it cannot be loaded, it will fall back to using the standard Ruby `::Logger` and log the load error.

When using Rails, the agent will not use a `EcsLogging::Logger` instance and instead use the Rails logger. The only way for the agent to use a `EcsLogging::Logger` instance when on Rails, is to set the `logger` attribute on the `config`.

Closes #931 
