### PR TITLE
synchronize schema spec

### DIFF
--- a/spec/fixtures/span.json
+++ b/spec/fixtures/span.json
@@ -22,6 +22,34 @@
       },
       "minItems": 0
     },
+    "composite": {
+      "description": "Composite holds details on a group of spans represented by a single one.",
+      "type": [
+        "null",
+        "object"
+      ],
+      "properties": {
+        "compression_strategy": {
+          "description": "A string value indicating which compression strategy was used. The valid values are `exact_match` and `same_kind`.",
+          "type": "string"
+        },
+        "count": {
+          "description": "Count is the number of compressed spans the composite span represents. The minimum count is 2, as a composite span represents at least two spans.",
+          "type": "integer",
+          "minimum": 2
+        },
+        "sum": {
+          "description": "Sum is the durations of all compressed spans this composite span represents in milliseconds.",
+          "type": "number",
+          "minimum": 0
+        }
+      },
+      "required": [
+        "count",
+        "sum",
+        "compression_strategy"
+      ]
+    },
     "context": {
       "description": "Context holds arbitrary contextual information for the event.",
       "type": [
@@ -476,7 +504,7 @@
       }
     },
     "duration": {
-      "description": "Duration of the span in milliseconds",
+      "description": "Duration of the span in milliseconds. When the span is a composite one, duration is the gross duration, including \"whitespace\" in between spans.",
       "type": "number",
       "minimum": 0
     },


### PR DESCRIPTION
### What
  APM agent json schema automatic sync

  ### Why
  *Changeset*
* https://github.com/elastic/apm-server/commit/24284d8a1 Update description of span duration and composite sum
* https://github.com/elastic/apm-server/commit/d0310d1b2 Support composite spans in the intake API