### PR TITLE
Fix CpuMem metrics on Alpine

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -44,6 +44,10 @@ endif::[]
 - Optional span to be ended instead of current span {pull}1039[#1039]
 - Config option `log_ecs_formatting` {pull}1053[#1053]
 
+[float]
+===== Fixed
+- Fixed detecting Linux on Alpine for CPU/MEM metrics {pull}1057[#1057]
+
 [[release-notes-4.3.0]]
 ==== 4.3.0
 

--- a/lib/elastic_apm/metrics.rb
+++ b/lib/elastic_apm/metrics.rb
@@ -29,7 +29,7 @@ module ElasticAPM
     end
 
     def self.os
-      @platform ||= RbConfig::CONFIG.fetch('host_os', 'unknown').to_sym
+      @os ||= RbConfig::CONFIG.fetch('host_os', 'unknown').to_sym
     end
 
     # @api private

--- a/lib/elastic_apm/metrics/cpu_mem_set.rb
+++ b/lib/elastic_apm/metrics/cpu_mem_set.rb
@@ -77,7 +77,7 @@ module ElasticAPM
 
       def sampler_for_os(os)
         case os
-        when :linux then Linux.new
+        when /^linux/ then Linux.new
         else
           warn "Disabling system metrics, unsupported host OS '#{os}'"
           disable!

--- a/spec/elastic_apm/metrics/cpu_mem_set_spec.rb
+++ b/spec/elastic_apm/metrics/cpu_mem_set_spec.rb
@@ -26,7 +26,7 @@ module ElasticAPM
       subject { described_class.new config }
 
       context 'Linux' do
-        before { allow(Metrics).to receive(:os) { :linux } }
+        before { allow(Metrics).to receive(:os) { 'linux-musl' } }
 
         describe 'collect' do
           it 'collects all metrics' do


### PR DESCRIPTION
Fixes #1055

Alpine reports as `linux-musl`:

```sh
$ docker run --rm ruby ruby -e "puts Gem::Platform.local.os; puts RbConfig::CONFIG.fetch('host_os')"
linux
linux
$ docker run --rm jruby ruby -e "puts Gem::Platform.local.os; puts RbConfig::CONFIG.fetch('host_os')"
java
linux
$ docker run --rm ruby:alpine ruby -e "puts Gem::Platform.local.os; puts RbConfig::CONFIG.fetch('host_os')"
linux
linux-musl
```
