### PR TITLE
Make Subscriber compatible with rails 3

### DIFF
--- a/lib/elastic_apm/span.rb
+++ b/lib/elastic_apm/span.rb
@@ -80,7 +80,9 @@ module ElasticAPM
       :outcome,
       :subtype,
       :trace_context,
-      :type
+      :type,
+      :timestamp,
+      :clock_start
     )
     attr_reader(
       :context,
@@ -89,7 +91,6 @@ module ElasticAPM
       :sample_rate,
       :self_time,
       :stacktrace,
-      :timestamp,
       :transaction
     )
 


### PR DESCRIPTION
## What does this pull request do?

This pull requests makes the Subscriber compatible with Rails 3, so that the `elastic-apm` gem can be used in a rails 3 application.

It does this by providing a `call` method in the Subscriber, that rails 3 will call instead of `start` and `finish`.

The resulting code works both in rails 3 and modern rails versions.

## Why is it important?

We have a large application that still uses rails 3. We would like to monitor this application. 

If rails 3 support is possible with minimal changes and minimal burden of maintenance then we think it would beneficial to the rails community (that is stuck on older versions) be able to use `elastic-apm`.

## Details

Because we cannot rely on `start` to record the correct monotonic microseconds timestamp, we have to fix the times when the subscriber is called by rails 3.

Besides this change the new methods on Hash like `transform_values` are required when running on an old ruby version, like 2.3.x. We use the [backports](https://github.com/marcandre/backports) gem for that. 

## Checklist

- [ ] I have signed the [Contributor License Agreement](https://www.elastic.co/contributor-agreement/). 
- [ ] My code follows the style guidelines of this project (See `.rubocop.yml`)
- [ ] I have rebased my changes on top of the latest master branch
<!--
Update your local repository with the most recent code from the main repo, and rebase your branch on top of the latest master branch. We prefer your initial changes to be squashed into a single commit. Later, if we ask you to make changes, add them as separate commits. This makes them easier to review.
-->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing [**unit** tests](https://github.com/elastic/apm-agent-ruby/blob/master/CONTRIBUTING.md#testing) pass locally with my changes
<!--
Run the test suite to make sure that nothing is broken. See https://github.com/elastic/apm-agent-ruby/blob/master/CONTRIBUTING.md#testing for details.
-->
- [ ] I have made corresponding changes to the documentation
- [ ] I have updated [CHANGELOG.asciidoc](CHANGELOG.asciidoc)
- [ ] I have updated [supported-technologies.asciidoc](docs/supported-technologies.asciidoc)
- [ ] Added an API method or config option? Document in which version this will be introduced

