### PR TITLE
synchronize schema spec

### DIFF
--- a/spec/fixtures/error.json
+++ b/spec/fixtures/error.json
@@ -147,6 +147,13 @@
                   "maxLength": 1024
                 }
               }
+            },
+            "routing_key": {
+              "description": "RoutingKey holds the optional routing key of the received message as set on the queuing system, such as in RabbitMQ.",
+              "type": [
+                "null",
+                "string"
+              ]
             }
           }
         },

--- a/spec/fixtures/span.json
+++ b/spec/fixtures/span.json
@@ -320,6 +320,13 @@
                   "maxLength": 1024
                 }
               }
+            },
+            "routing_key": {
+              "description": "RoutingKey holds the optional routing key of the received message as set on the queuing system, such as in RabbitMQ.",
+              "type": [
+                "null",
+                "string"
+              ]
             }
           }
         },

--- a/spec/fixtures/transaction.json
+++ b/spec/fixtures/transaction.json
@@ -146,6 +146,13 @@
                   "maxLength": 1024
                 }
               }
+            },
+            "routing_key": {
+              "description": "RoutingKey holds the optional routing key of the received message as set on the queuing system, such as in RabbitMQ.",
+              "type": [
+                "null",
+                "string"
+              ]
             }
           }
         },


### PR DESCRIPTION
### What
  APM agent json schema automatic sync

  ### Why
  *Changeset*
* https://github.com/elastic/apm-server/commit/527987315 intake: Add `context.message.routing_key` to API (https://github.com/elastic/apm-server/pull/6177)