### PR TITLE
Add #flush method to ElasticAPM

### DIFF
--- a/lib/elastic_apm.rb
+++ b/lib/elastic_apm.rb
@@ -407,5 +407,9 @@ module ElasticAPM
 
       agent&.add_filter(key, block || callback)
     end
+
+    def flush
+      agent&.transport&.flush
+    end
   end
 end

--- a/lib/elastic_apm/transport/base.rb
+++ b/lib/elastic_apm/transport/base.rb
@@ -105,7 +105,6 @@ module ElasticAPM
       end
 
       def flush
-        puts "flushing connections"
         send_message_to_workers(Worker::FlushMessage.new)
         ensure_worker_count
       end

--- a/lib/elastic_apm/transport/base.rb
+++ b/lib/elastic_apm/transport/base.rb
@@ -105,6 +105,7 @@ module ElasticAPM
       end
 
       def flush
+        puts "flushing connections"
         send_message_to_workers(Worker::FlushMessage.new)
         ensure_worker_count
       end

--- a/lib/elastic_apm/transport/worker.rb
+++ b/lib/elastic_apm/transport/worker.rb
@@ -64,7 +64,6 @@ module ElasticAPM
           when FlushMessage
             debug 'Flushing connection [%s]', self
             connection.flush(:flush)
-            break
           else
             process msg
           end

--- a/lib/elastic_apm/transport/worker.rb
+++ b/lib/elastic_apm/transport/worker.rb
@@ -61,6 +61,10 @@ module ElasticAPM
             debug 'Stopping worker [%s]', self
             connection.flush(:halt)
             break
+          when FlushMessage
+            debug 'Flushing connection [%s]', self
+            connection.flush(:flush)
+            break
           else
             process msg
           end

--- a/spec/elastic_apm/transport/base_spec.rb
+++ b/spec/elastic_apm/transport/base_spec.rb
@@ -48,6 +48,26 @@ module ElasticAPM
 
           expect(subject.send(:workers)).to eq([nil, nil])
         end
+
+        describe '#flush' do
+          let(:config) { Config.new(pool_size: 2) }
+
+          it 'flush all connections', :mock_intake do
+            subject.start
+
+            subject.submit Transaction.new config: config
+            subject.submit Transaction.new config: config
+            subject.submit Transaction.new config: config
+            subject.submit Transaction.new config: config
+            subject.submit Transaction.new config: config
+            subject.submit Transaction.new config: config
+            subject.flush
+
+            wait_for transactions: 6
+
+            expect(subject.send(:workers).size).to eq(2)
+          end
+        end
       end
 
       describe '#submit' do


### PR DESCRIPTION
This PR adds a `#flush` method to `ElasticAPM` that flushes the connection of each worker.
It's necessary to have a method like this that can be called at the end of a lambda function.
TBD whether this is an internal method that we call when we instrument lambda functions or a public method.

Also, we might want to have singleton `StopMessage` and `FlushMessage` classes so we aren't creating a new object every time we want to send the message.