### PR TITLE
Add span compression

### DIFF
--- a/lib/elastic_apm.rb
+++ b/lib/elastic_apm.rb
@@ -211,6 +211,7 @@ module ElasticAPM
     # @param parent [Transaction,Span] The parent transaction or span.
     #   Relevant when the span is created in another thread.
     # @param sync [Boolean] Whether the span is created synchronously or not.
+    # @param exit_span [Boolean] Whether the span is an exit span.
     # @return [Span]
     def start_span(
       name,
@@ -221,7 +222,8 @@ module ElasticAPM
       include_stacktrace: true,
       trace_context: nil,
       parent: nil,
-      sync: nil
+      sync: nil,
+      exit_span: false
     )
       agent&.start_span(
         name,
@@ -231,7 +233,8 @@ module ElasticAPM
         context: context,
         trace_context: trace_context,
         parent: parent,
-        sync: sync
+        sync: sync,
+        exit_span: exit_span
       ).tap do |span|
         break unless span && include_stacktrace
         break unless agent.config.span_frames_min_duration?
@@ -265,6 +268,7 @@ module ElasticAPM
     # @param parent [Transaction,Span] The parent transaction or span.
     #   Relevant when the span is created in another thread.
     # @param sync [Boolean] Whether the span is created synchronously or not.
+    # @param exit_span [Boolean] Whether the span is an exit span.
     # @yield [Span]
     # @return Result of block
     def with_span(
@@ -276,7 +280,8 @@ module ElasticAPM
       include_stacktrace: true,
       trace_context: nil,
       parent: nil,
-      sync: nil
+      sync: nil,
+      exit_span: false
     )
       unless block_given?
         raise ArgumentError,
@@ -296,7 +301,8 @@ module ElasticAPM
             include_stacktrace: include_stacktrace,
             trace_context: trace_context,
             parent: parent,
-            sync: sync
+            sync: sync,
+            exit_span: exit_span
           )
         result = yield span
         span&.outcome ||= Span::Outcome::SUCCESS

--- a/lib/elastic_apm/agent.rb
+++ b/lib/elastic_apm/agent.rb
@@ -189,7 +189,8 @@ module ElasticAPM
       context: nil,
       trace_context: nil,
       parent: nil,
-      sync: nil
+      sync: nil,
+      exit_span: nil
     )
       detect_forking!
 
@@ -206,7 +207,8 @@ module ElasticAPM
         context: context,
         trace_context: trace_context,
         parent: parent,
-        sync: sync
+        sync: sync,
+        exit_span: exit_span
       )
     end
     # rubocop:enable Metrics/ParameterLists

--- a/lib/elastic_apm/config.rb
+++ b/lib/elastic_apm/config.rb
@@ -90,8 +90,8 @@ module ElasticAPM
     option :source_lines_error_library_frames,       type: :int,    default: 0
     option :source_lines_span_app_frames,            type: :int,    default: 5
     option :source_lines_span_library_frames,        type: :int,    default: 0
-    option :span_compression_exact_match_duration,   type: :int,    default: '5ms', converter: Duration.new(default_unit: 'ms')
-    option :span_compression_same_kind_max_duration, type: :int,    default: '5ms', converter: Duration.new(default_unit: 'ms')
+    option :span_compression_exact_match_duration,   type: :float,  default: '5ms', converter: Duration.new(default_unit: 'ms')
+    option :span_compression_same_kind_max_duration, type: :float,  default: '5ms', converter: Duration.new(default_unit: 'ms')
     option :span_frames_min_duration,                type: :float,  default: '5ms', converter: Duration.new(default_unit: 'ms')
     option :stack_trace_limit,                       type: :int,    default: 999_999
     option :transaction_ignore_urls,                 type: :list,   default: [], converter: WildcardPatternList.new

--- a/lib/elastic_apm/config.rb
+++ b/lib/elastic_apm/config.rb
@@ -34,69 +34,71 @@ module ElasticAPM
       %w[password passwd pwd secret *key *token* *session* *credit* *card* authorization set-cookie].freeze
 
     # rubocop:disable Layout/LineLength, Layout/ExtraSpacing
-    option :config_file,                       type: :string, default: 'config/elastic_apm.yml'
-    option :server_url,                        type: :url,    default: 'http://localhost:8200'
-    option :secret_token,                      type: :string
-    option :api_key,                           type: :string
+    option :config_file,                           type: :string, default: 'config/elastic_apm.yml'
+    option :server_url,                            type: :url,    default: 'http://localhost:8200'
+    option :secret_token,                          type: :string
+    option :api_key,                               type: :string
 
-    option :api_buffer_size,                   type: :int,    default: 256
-    option :api_request_size,                  type: :bytes,  default: '750kb', converter: Bytes.new
-    option :api_request_time,                  type: :float,  default: '10s',   converter: Duration.new
-    option :breakdown_metrics,                 type: :bool,   default: true
-    option :capture_body,                      type: :string, default: 'off'
-    option :capture_headers,                   type: :bool,   default: true
-    option :capture_elasticsearch_queries,     type: :bool,   default: false
-    option :capture_env,                       type: :bool,   default: true
-    option :central_config,                    type: :bool,   default: true
-    option :cloud_provider,                    type: :string, default: 'auto'
-    option :current_user_email_method,         type: :string, default: 'email'
-    option :current_user_id_method,            type: :string, default: 'id'
-    option :current_user_username_method,      type: :string, default: 'username'
-    option :custom_key_filters,                type: :list,   default: [],      converter: RegexpList.new
-    option :default_labels,                    type: :dict,   default: {}
-    option :disable_metrics,                   type: :list,   default: [],      converter: WildcardPatternList.new
-    option :disable_send,                      type: :bool,   default: false
-    option :disable_start_message,             type: :bool,   default: false
-    option :disable_instrumentations,          type: :list,   default: %w[json]
-    option :disabled_spies,                    type: :list,   default: []
-    option :enabled,                           type: :bool,   default: true
-    option :environment,                       type: :string, default: ENV['RAILS_ENV'] || ENV['RACK_ENV']
-    option :framework_name,                    type: :string
-    option :framework_version,                 type: :string
-    option :filter_exception_types,            type: :list,   default: []
-    option :global_labels,                     type: :dict
-    option :hostname,                          type: :string
-    option :http_compression,                  type: :bool,   default: true
-    option :ignore_url_patterns,               type: :list,   default: [],      converter: RegexpList.new
-    option :instrument,                        type: :bool,   default: true
-    option :instrumented_rake_tasks,           type: :list,   default: []
-    option :log_ecs_formatting,                type: :string, default: 'off'
-    option :log_level,                         type: :int,    default: Logger::INFO, converter: LogLevelMap.new
-    option :log_path,                          type: :string
-    option :metrics_interval,                  type: :int,    default: '30s',   converter: Duration.new
-    option :pool_size,                         type: :int,    default: 1
-    option :proxy_address,                     type: :string
-    option :proxy_headers,                     type: :dict
-    option :proxy_password,                    type: :string
-    option :proxy_port,                        type: :int
-    option :proxy_username,                    type: :string
-    option :recording,                         type: :bool,   default: true
-    option :sanitize_field_names,              type: :list,   default: SANITIZE_FIELD_NAMES_DEFAULT, converter: WildcardPatternList.new
-    option :server_ca_cert_file,               type: :string
-    option :service_name,                      type: :string
-    option :service_node_name,                 type: :string
-    option :service_version,                   type: :string
-    option :source_lines_error_app_frames,     type: :int,    default: 5
-    option :source_lines_error_library_frames, type: :int,    default: 0
-    option :source_lines_span_app_frames,      type: :int,    default: 5
-    option :source_lines_span_library_frames,  type: :int,    default: 0
-    option :span_frames_min_duration,          type: :float,  default: '5ms',   converter: Duration.new(default_unit: 'ms')
-    option :stack_trace_limit,                 type: :int,    default: 999_999
-    option :transaction_ignore_urls,           type: :list,   default: [],      converter: WildcardPatternList.new
-    option :transaction_max_spans,             type: :int,    default: 500
-    option :transaction_sample_rate,           type: :float,  default: 1.0,     converter: RoundFloat.new
-    option :use_elastic_traceparent_header,    type: :bool,   default: true
-    option :verify_server_cert,                type: :bool,   default: true
+    option :api_buffer_size,                         type: :int,    default: 256
+    option :api_request_size,                        type: :bytes,  default: '750kb', converter: Bytes.new
+    option :api_request_time,                        type: :float,  default: '10s', converter: Duration.new
+    option :breakdown_metrics,                       type: :bool,   default: true
+    option :capture_body,                            type: :string, default: 'off'
+    option :capture_headers,                         type: :bool,   default: true
+    option :capture_elasticsearch_queries,           type: :bool,   default: false
+    option :capture_env,                             type: :bool,   default: true
+    option :central_config,                          type: :bool,   default: true
+    option :cloud_provider,                          type: :string, default: 'auto'
+    option :current_user_email_method,               type: :string, default: 'email'
+    option :current_user_id_method,                  type: :string, default: 'id'
+    option :current_user_username_method,            type: :string, default: 'username'
+    option :custom_key_filters,                      type: :list,   default: [], converter: RegexpList.new
+    option :default_labels,                          type: :dict,   default: {}
+    option :disable_metrics,                         type: :list,   default: [], converter: WildcardPatternList.new
+    option :disable_send,                            type: :bool,   default: false
+    option :disable_start_message,                   type: :bool,   default: false
+    option :disable_instrumentations,                type: :list,   default: %w[json]
+    option :disabled_spies,                          type: :list,   default: []
+    option :enabled,                                 type: :bool,   default: true
+    option :environment,                             type: :string, default: ENV['RAILS_ENV'] || ENV['RACK_ENV']
+    option :framework_name,                          type: :string
+    option :framework_version,                       type: :string
+    option :filter_exception_types,                  type: :list,   default: []
+    option :global_labels,                           type: :dict
+    option :hostname,                                type: :string
+    option :http_compression,                        type: :bool,   default: true
+    option :ignore_url_patterns,                     type: :list,   default: [], converter: RegexpList.new
+    option :instrument,                              type: :bool,   default: true
+    option :instrumented_rake_tasks,                 type: :list,   default: []
+    option :log_ecs_formatting,                      type: :string, default: 'off'
+    option :log_level,                               type: :int,    default: Logger::INFO, converter: LogLevelMap.new
+    option :log_path,                                type: :string
+    option :metrics_interval,                        type: :int,    default: '30s', converter: Duration.new
+    option :pool_size,                               type: :int,    default: 1
+    option :proxy_address,                           type: :string
+    option :proxy_headers,                           type: :dict
+    option :proxy_password,                          type: :string
+    option :proxy_port,                              type: :int
+    option :proxy_username,                          type: :string
+    option :recording,                               type: :bool,   default: true
+    option :sanitize_field_names,                    type: :list,   default: SANITIZE_FIELD_NAMES_DEFAULT, converter: WildcardPatternList.new
+    option :server_ca_cert_file,                     type: :string
+    option :service_name,                            type: :string
+    option :service_node_name,                       type: :string
+    option :service_version,                         type: :string
+    option :source_lines_error_app_frames,           type: :int,    default: 5
+    option :source_lines_error_library_frames,       type: :int,    default: 0
+    option :source_lines_span_app_frames,            type: :int,    default: 5
+    option :source_lines_span_library_frames,        type: :int,    default: 0
+    option :span_compression_exact_match_duration,   type: :int,    default: '5ms', converter: Duration.new(default_unit: 'ms')
+    option :span_compression_same_kind_max_duration, type: :int,    default: '5ms', converter: Duration.new(default_unit: 'ms')
+    option :span_frames_min_duration,                type: :float,  default: '5ms', converter: Duration.new(default_unit: 'ms')
+    option :stack_trace_limit,                       type: :int,    default: 999_999
+    option :transaction_ignore_urls,                 type: :list,   default: [], converter: WildcardPatternList.new
+    option :transaction_max_spans,                   type: :int,    default: 500
+    option :transaction_sample_rate,                 type: :float,  default: 1.0, converter: RoundFloat.new
+    option :use_elastic_traceparent_header,          type: :bool,   default: true
+    option :verify_server_cert,                      type: :bool,   default: true
 
     # rubocop:enable Layout/LineLength, Layout/ExtraSpacing
     def initialize(options = {})

--- a/lib/elastic_apm/instrumenter.rb
+++ b/lib/elastic_apm/instrumenter.rb
@@ -151,6 +151,10 @@ module ElasticAPM
 
       transaction.done(result)
 
+      if child = transaction.compression_buffer
+        enqueue.call(child)
+      end
+
       enqueue.call(transaction)
 
       update_transaction_metrics(transaction)
@@ -245,11 +249,12 @@ module ElasticAPM
 
       span.done
 
-      enqueue.call(span) unless span.compression_buffered?
+      enqueue.call(span) unless span.parent.compression_buffer
 
-      if child = span.compression_buffer
-        enqueue.call(child)
-      end
+      # if child = span.compression_buffer
+      #   asdf
+      #   enqueue.call(child)
+      # end
 
       update_span_metrics(span)
 

--- a/lib/elastic_apm/instrumenter.rb
+++ b/lib/elastic_apm/instrumenter.rb
@@ -247,9 +247,9 @@ module ElasticAPM
 
       enqueue.call(span) unless span.compression_buffered?
 
-      # if child = span.compression_buffered_child
-      #   enqueue.call(child)
-      # end
+      if child = span.compression_buffer
+        enqueue.call(child)
+      end
 
       update_span_metrics(span)
 

--- a/lib/elastic_apm/instrumenter.rb
+++ b/lib/elastic_apm/instrumenter.rb
@@ -251,10 +251,9 @@ module ElasticAPM
 
       enqueue.call(span) unless span.parent.compression_buffer
 
-      # if child = span.compression_buffer
-      #   asdf
-      #   enqueue.call(child)
-      # end
+      if child = span.compression_buffer
+        enqueue.call(child)
+      end
 
       update_span_metrics(span)
 

--- a/lib/elastic_apm/instrumenter.rb
+++ b/lib/elastic_apm/instrumenter.rb
@@ -19,6 +19,7 @@
 
 require 'elastic_apm/trace_context'
 require 'elastic_apm/child_durations'
+require 'elastic_apm/compression_buffer'
 require 'elastic_apm/span'
 require 'elastic_apm/transaction'
 require 'elastic_apm/span_helpers'
@@ -148,9 +149,9 @@ module ElasticAPM
 
       self.current_transaction = nil
 
-      transaction.done result
+      transaction.done(result)
 
-      enqueue.call transaction
+      enqueue.call(transaction)
 
       update_transaction_metrics(transaction)
 
@@ -244,7 +245,11 @@ module ElasticAPM
 
       span.done
 
-      enqueue.call span
+      enqueue.call(span) unless span.compression_buffered?
+
+      # if child = span.compression_buffered_child
+      #   enqueue.call(child)
+      # end
 
       update_span_metrics(span)
 

--- a/lib/elastic_apm/span.rb
+++ b/lib/elastic_apm/span.rb
@@ -37,20 +37,6 @@ module ElasticAPM
       end
     end
 
-    # @api private
-    class Composite
-      EXACT_MATCH = 'exact_match'
-      SAME_KIND = 'same_kind'
-
-      def initialize(count: 0, sum: 0, compression_strategy: nil)
-        @count = count
-        @sum = sum
-        @compression_strategy = compression_strategy
-      end
-
-      attr_accessor :count, :sum, :compression_strategy
-    end
-
     DEFAULT_TYPE = 'custom'
 
     # rubocop:disable Metrics/ParameterLists

--- a/lib/elastic_apm/span.rb
+++ b/lib/elastic_apm/span.rb
@@ -37,6 +37,20 @@ module ElasticAPM
       end
     end
 
+    # @api private
+    class Composite
+      EXACT_MATCH = 'exact_match'
+      SAME_KIND = 'same_kind'
+
+      def initialize(count: 0, sum: 0, compression_strategy: nil)
+        @count = count
+        @sum = sum
+        @compression_strategy = compression_strategy
+      end
+
+      attr_accessor :count, :sum, :compression_strategy
+    end
+
     DEFAULT_TYPE = 'custom'
 
     # rubocop:disable Metrics/ParameterLists
@@ -79,6 +93,7 @@ module ElasticAPM
 
     attr_accessor(
       :action,
+      :composite,
       :exit_span,
       :name,
       :original_backtrace,
@@ -153,6 +168,10 @@ module ElasticAPM
 
     def compression_eligible?
       exit_span && !context.has_propagated? && (outcome.nil? || outcome == Outcome::SUCCESS)
+    end
+
+    def composite?
+      !!@composite
     end
 
     def inspect

--- a/lib/elastic_apm/span/context.rb
+++ b/lib/elastic_apm/span/context.rb
@@ -43,6 +43,7 @@ module ElasticAPM
           when Hash then Message.new(**message)
           end
         @labels = labels
+        @has_propagated = false
       end
 
       attr_reader(
@@ -54,6 +55,9 @@ module ElasticAPM
       )
 
       attr_accessor :destination
+      attr_accessor :has_propagated
+
+      alias :has_propagated? :has_propagated
     end
   end
 end

--- a/lib/elastic_apm/transaction.rb
+++ b/lib/elastic_apm/transaction.rb
@@ -32,7 +32,8 @@ module ElasticAPM
     end
 
     extend Forwardable
-    include ChildDurations::Methods
+    prepend ChildDurations::Methods
+    prepend CompressionBuffer
 
     def_delegators :@trace_context,
       :trace_id, :parent_id, :id, :ensure_parent_id
@@ -108,6 +109,9 @@ module ElasticAPM
 
     alias :collect_metrics? :collect_metrics
 
+    def child_started(_); end
+    def child_stopped(_); end
+
     def sampled?
       @sampled
     end
@@ -149,6 +153,14 @@ module ElasticAPM
         end
       end
       true
+    end
+
+    # api
+
+    def child_started(child)
+    end
+
+    def child_stopped(child)
     end
 
     # context

--- a/lib/elastic_apm/transaction.rb
+++ b/lib/elastic_apm/transaction.rb
@@ -63,6 +63,8 @@ module ElasticAPM
       @framework_name = config.framework_name
       @transaction_max_spans = config.transaction_max_spans
       @default_labels = config.default_labels
+      @span_compression_exact_match_duration = config.span_compression_exact_match_duration
+      @span_compression_same_kind_max_duration = config.span_compression_same_kind_max_duration
 
       @sampled = sampled
       @sample_rate = sample_rate
@@ -104,7 +106,9 @@ module ElasticAPM
       :started_spans,
       :timestamp,
       :trace_context,
-      :transaction_max_spans
+      :transaction_max_spans,
+      :span_compression_exact_match_duration,
+      :span_compression_same_kind_max_duration
     )
 
     alias :collect_metrics? :collect_metrics

--- a/spec/elastic_apm/instrumenter_spec.rb
+++ b/spec/elastic_apm/instrumenter_spec.rb
@@ -462,6 +462,11 @@ module ElasticAPM
           end
 
           expect(@intercepted.spans.count).to be(1)
+
+          span, = @intercepted.spans
+          expect(span.composite.count).to eq(2)
+          expect(span.composite.sum).to eq(5)
+          expect(span.composite.compression_strategy).to eq('exact_match')
         end
       end
     end

--- a/spec/support/intercept.rb
+++ b/spec/support/intercept.rb
@@ -67,7 +67,7 @@ RSpec.configure do |config|
 
       allowed_subtypes.fetch(subtype) unless info['allow_unlisted_subtype']
     rescue KeyError
-      raise "Unknown span.subtype `#{span.type}'\nPossible subtypes: #{allowed_subtypes}"
+      raise "Unknown span.subtype `#{span.subtype}'\nPossible subtypes: #{allowed_subtypes.keys}"
     end
   end
 

--- a/spec/support/mock_time.rb
+++ b/spec/support/mock_time.rb
@@ -23,7 +23,7 @@ RSpec.configure do |config|
     @mocked_clock = 123_000
 
     def travel(us)
-      Timecop.freeze(@mocked_time += (us / 1_000_000.0))
+      Timecop.freeze(@mocked_time += (us.to_f / 1_000_000.0))
       @mocked_clock += us
     end
 


### PR DESCRIPTION
See #1021 

Currently passing all tests but one, which is concerning this part from the spec:

```ruby
    if (!child.isCompressionEligible()) {
        if (buffered != null) {
            report(buffered) # <-- reporting buffered from sibling
            buffered = null  # <-- resetting buffer
        }
        report(child)
        return
    }
```

Keeping track of children and buffers and such is very difficult and the fact that we use the instrumenter to _report_ instead of letting the spans themselves do it doesn't make it easier.