### PR TITLE
Jruby versions

### DIFF
--- a/.ci/docker/jruby/8-jdk/Dockerfile
+++ b/.ci/docker/jruby/8-jdk/Dockerfile
@@ -5,7 +5,7 @@ RUN apt-get update \
     && apt-get install -y gcc \
     && rm -rf /var/lib/apt/lists/*
 
-ENV JRUBY_VERSION 9.3.1.0
+ENV JRUBY_VERSION 9.2.14.0
 ENV JRUBY_SHA256 9199707712c683c525252ccb1de5cb8e75f53b790c5b57a18f6367039ec79553
 
 RUN mkdir -p /opt/jruby \

--- a/Gemfile
+++ b/Gemfile
@@ -62,10 +62,6 @@ gem 'sucker_punch', '~> 2.0', require: nil
 gem 'yard', require: nil
 gem 'yarjuf'
 
-# See issue #6547 in the JRuby repo. When that bug is fixed,
-# we can use the latest version of the i18n gem.
-gem 'i18n', '< 1.8.8'
-
 ## Install Framework
 GITHUB_REPOS = {
   'grape' => 'ruby-grape/grape',
@@ -101,6 +97,9 @@ if frameworks_versions.key?('rails')
 end
 
 if RUBY_PLATFORM == 'java'
+# See issue #6547 in the JRuby repo. It is fixed in JRuby 9.3
+gem 'i18n', '< 1.8.8' if JRUBY_VERSION < '9.3'
+
   case rails = frameworks_versions['rails']
   when 'main'
     gem 'activerecord-jdbcsqlite3-adapter', git: 'https://github.com/jruby/activerecord-jdbc-adapter', glob: 'activerecord-jdbcsqlite3-adapter/*.gemspec'


### PR DESCRIPTION
This PR defines the docker image with jdk8 to use jruby 9.2.14.0 for enterprise search.

The Gemfile only installs the specific version of i18n exposing the jruby bug if the jruby version is < 9.3. The bug is fixed in jruby 9.3.