### PR TITLE
Metrics: Avoid dividing by zero

### DIFF
--- a/lib/elastic_apm/metrics/cpu_mem_set.rb
+++ b/lib/elastic_apm/metrics/cpu_mem_set.rb
@@ -116,6 +116,9 @@ module ElasticAPM
         process_cpu_usage =
           current.process_cpu_usage - previous.process_cpu_usage
 
+        # No change / avoid dividing by 0
+        return [0, 0] if system_cpu_total == 0
+
         cpu_usage_pct = system_cpu_usage.to_f / system_cpu_total
         cpu_process_pct = process_cpu_usage.to_f / system_cpu_total
 


### PR DESCRIPTION
Fixes https://github.com/elastic/apm-agent-ruby/issues/1156