### PR TITLE
Make Intercept event submission thread-safe and improve mongo spy

### DIFF
--- a/lib/elastic_apm/spies/mongo.rb
+++ b/lib/elastic_apm/spies/mongo.rb
@@ -37,14 +37,8 @@ module ElasticAPM
 
         EVENT_KEY = :__elastic_instrumenter_mongo_events_key
 
-        class Collection
-          def events
-            Thread.current[EVENT_KEY] ||= {}
-          end
-        end
-
-        def initialize
-          @collection = Collection.new
+        def events
+          Thread.current[EVENT_KEY] ||= {}
         end
 
         def started(event)
@@ -97,11 +91,11 @@ module ElasticAPM
               context: build_context(event)
             )
 
-          @collection.events[event.operation_id] = span
+          events[event.operation_id] = span
         end
 
         def pop_event(event)
-          span = @collection.events.delete(event.operation_id)
+          span = events.delete(event.operation_id)
           return unless (curr = ElasticAPM.current_span)
 
           curr == span && ElasticAPM.end_span

--- a/spec/support/intercept.rb
+++ b/spec/support/intercept.rb
@@ -20,10 +20,10 @@
 RSpec.configure do |config|
   class Intercept
     def initialize
-      @transactions = []
-      @spans = []
-      @errors = []
-      @metricsets = []
+      @transactions = Concurrent::Array.new
+      @spans = Concurrent::Array.new
+      @errors = Concurrent::Array.new
+      @metricsets = Concurrent::Array.new
 
       @span_types = JSON.parse(File.read('./spec/fixtures/span_types.json'))
     end


### PR DESCRIPTION
This PR fixes some thread safety issues with the way we test using Intercept and improves the MongoSpy:

The Intercept event arrays (`@transactions`, `@spans`, `@errors`, `@metricsets`) were not thread-safe so submitting events to them from multiple threads would inevitably end up causing event loss on JRuby.

I've removed the unnecessary `@collection` object in the Mongo Spy. That object is shared amongst threads. Even though it wouldn't be a problem with the `events` object being a thread local object, I'm wary of leaving an object shared amongst threads in the spy.

Lastly, the test didn't need to create 1000 threads to test the thread safety of the code and it created identical events in each thread. I've changed the test to give a unique operation id to each event and to test only using 50 threads, as that is sufficient.

Resolve #1207 