### PR TITLE
Use stack for mongo spy spans

### DIFF
--- a/lib/elastic_apm/spies/mongo.rb
+++ b/lib/elastic_apm/spies/mongo.rb
@@ -41,10 +41,6 @@ module ElasticAPM
           Thread.current[EVENT_KEY] ||= []
         end
 
-        def initialize
-          @mutex = Mutex.new
-        end
-
         def started(event)
           push_event(event)
         end
@@ -87,13 +83,13 @@ module ElasticAPM
                   event.command_name].compact.join('.')
 
           span =
-              ElasticAPM.start_span(
-                name,
-                TYPE,
-                subtype: SUBTYPE,
-                action: ACTION,
-                context: build_context(event)
-              )
+            ElasticAPM.start_span(
+              name,
+              TYPE,
+              subtype: SUBTYPE,
+              action: ACTION,
+              context: build_context(event)
+            )
 
           events << span
         end

--- a/lib/elastic_apm/spies/mongo.rb
+++ b/lib/elastic_apm/spies/mongo.rb
@@ -38,7 +38,7 @@ module ElasticAPM
         EVENT_KEY = :__elastic_instrumenter_mongo_events_key
 
         def events
-          Thread.current[EVENT_KEY] ||= {}
+          Thread.current[EVENT_KEY] ||= []
         end
 
         def started(event)
@@ -91,14 +91,13 @@ module ElasticAPM
               context: build_context(event)
             )
 
-          events[event.operation_id] = span
+          events << span
         end
 
         def pop_event(event)
-          span = events.delete(event.operation_id)
           return unless (curr = ElasticAPM.current_span)
 
-          curr == span && ElasticAPM.end_span
+          curr == events[-1] && ElasticAPM.end_span(events.pop)
         end
 
         def build_context(event)


### PR DESCRIPTION
Instead of relying on the operation id, let's just use a stack to keep track of mongo spy spans.