### PR TITLE
Clear thread local variables when forked

### DIFF
--- a/lib/elastic_apm/agent.rb
+++ b/lib/elastic_apm/agent.rb
@@ -288,6 +288,8 @@ module ElasticAPM
       instrumenter.handle_forking!
       metrics.handle_forking!
 
+      Spies::MongoSpy::Subscriber.handle_forking!
+
       @pid = Process.pid
     end
   end

--- a/lib/elastic_apm/instrumenter.rb
+++ b/lib/elastic_apm/instrumenter.rb
@@ -38,6 +38,11 @@ module ElasticAPM
         self.spans = []
       end
 
+      def clear!
+        Thread.current[TRANSACTION_KEY] = nil
+        Thread.current[SPAN_KEY] = nil
+      end
+
       def transaction
         Thread.current[TRANSACTION_KEY]
       end
@@ -84,6 +89,7 @@ module ElasticAPM
     end
 
     def handle_forking!
+      @current.clear!
       stop
       start
     end

--- a/lib/elastic_apm/spies/mongo.rb
+++ b/lib/elastic_apm/spies/mongo.rb
@@ -37,6 +37,10 @@ module ElasticAPM
 
         EVENT_KEY = :__elastic_instrumenter_mongo_events_key
 
+        def self.handle_forking!
+          Thread.current[EVENT_KEY] = []
+        end
+
         def events
           Thread.current[EVENT_KEY] ||= []
         end

--- a/spec/elastic_apm/spies/mongo_spec.rb
+++ b/spec/elastic_apm/spies/mongo_spec.rb
@@ -150,15 +150,16 @@ module ElasticAPM
           ElasticAPM.with_transaction do
             subscriber.started(event)
             expect(Thread.current[Spies::MongoSpy::Subscriber::EVENT_KEY][0]).to be_a(Span)
-            fork do
-              ElasticAPM.agent.detect_forking!
-              expect(Thread.current[Spies::MongoSpy::Subscriber::EVENT_KEY]).to be_empty
-            end
+
+            # Simulate the following happening in a new fork
+            allow(Process).to receive(:pid).and_return(1)
+            ElasticAPM.agent.detect_forking!
+            expect(Thread.current[Spies::MongoSpy::Subscriber::EVENT_KEY]).to be_empty
             subscriber.succeeded(event)
+
+            expect(@intercepted.spans.length).to be 0
           end
         end
-
-        expect(@intercepted.spans.size).to be 1
       end
     end
   end

--- a/spec/support/intercept.rb
+++ b/spec/support/intercept.rb
@@ -50,6 +50,8 @@ RSpec.configure do |config|
 
     def stop; end
 
+    def handle_forking!; end
+
     def validate_span!(span)
       type, subtype = [span.type, span.subtype]
 


### PR DESCRIPTION
Thread local variables are copied over when a process is forked so we should clear the MongoSpy thread locals when forked.