### PR TITLE
ruby: 3.1 is now available

### DIFF
--- a/.ci/.jenkins_ruby.yml
+++ b/.ci/.jenkins_ruby.yml
@@ -1,4 +1,5 @@
 RUBY_VERSION:
+  - ruby:3.1
   - ruby:3.0
   - ruby:2.7
   - ruby:2.6


### PR DESCRIPTION
## What does this pull request do?

Add 3.1 ruby in the CI

## Why is it important?

3.1 has been just released