### PR TITLE
Fix broken doc links in APM ruby agent docs

### DIFF
--- a/docs/api.asciidoc
+++ b/docs/api.asciidoc
@@ -334,7 +334,7 @@ Labels are basic key-value pairs that are indexed in your Elasticsearch database
 The value can be a string, nil, numeric or boolean.
 
 TIP: Before using custom labels, ensure you understand the different types of
-{apm-overview-ref-v}/metadata.html[metadata] that are available.
+{apm-guide-ref}/data-model-metadata.html[metadata] that are available.
 
 [source,ruby]
 ----
@@ -361,7 +361,7 @@ Use this to further specify a context that will help you track or diagnose what'
 going on inside your app.
 
 TIP: Before using custom context, ensure you understand the different types of
-{apm-overview-ref-v}/metadata.html[metadata] that are available.
+{apm-guide-ref}/data-model-metadata.html[metadata] that are available.
 
 If called several times during a transaction the custom context will be destructively
 merged with `merge!`.

--- a/docs/configuration.asciidoc
+++ b/docs/configuration.asciidoc
@@ -170,7 +170,7 @@ WARNING: Secret tokens only provide any real security if your APM server uses TL
 |============
 
 This base64-encoded string is used to ensure that only your agents can send data to your APM server.
-The API key must be created using the {apm-server-ref-v}/api-key.html[APM server command-line tool]. 
+The API key must be created using the {apm-guide-ref}/api-key.html[APM server command-line tool]. 
 
 WARNING: API keys only provide any real security if your APM server uses TLS.
 

--- a/docs/introduction.asciidoc
+++ b/docs/introduction.asciidoc
@@ -31,6 +31,6 @@ You can then use the APM app in Kibana to gain insight into latency issues and e
 [[additional-components]]
 === Additional Components
 
-APM Agents work in conjunction with the {apm-server-ref-v}/index.html[APM Server], {ref}/index.html[Elasticsearch], and {kibana-ref}/index.html[Kibana].
-The {apm-guide-ref}/index.html	[APM Overview] provides details on how these components work together,
+APM Agents work in conjunction with the {apm-guide-ref}/index.html[APM Server], {ref}/index.html[Elasticsearch], and {kibana-ref}/index.html[Kibana].
+The {apm-guide-ref}/index.html[APM Guide] provides details on how these components work together,
 and provides a matrix outlining {apm-guide-ref}/agent-server-compatibility.html[Agent and Server compatibility].

--- a/docs/introduction.asciidoc
+++ b/docs/introduction.asciidoc
@@ -32,5 +32,5 @@ You can then use the APM app in Kibana to gain insight into latency issues and e
 === Additional Components
 
 APM Agents work in conjunction with the {apm-server-ref-v}/index.html[APM Server], {ref}/index.html[Elasticsearch], and {kibana-ref}/index.html[Kibana].
-The {apm-overview-ref-v}/index.html[APM Overview] provides details on how these components work together,
-and provides a matrix outlining {apm-overview-ref-v}/agent-server-compatibility.html[Agent and Server compatibility].
+The {apm-guide-ref}/index.html	[APM Overview] provides details on how these components work together,
+and provides a matrix outlining {apm-guide-ref}/agent-server-compatibility.html[Agent and Server compatibility].

--- a/docs/log-correlation.asciidoc
+++ b/docs/log-correlation.asciidoc
@@ -118,4 +118,4 @@ PUT _ingest/pipeline/extract_trace_id
 }
 ----
 
-Please see {apm-overview-ref-v}/observability-integrations.html[Observability integrations] for more information.
+Please see {apm-guide-ref}/log-correlation.html[Observability integrations] for more information.

--- a/docs/upgrading.asciidoc
+++ b/docs/upgrading.asciidoc
@@ -6,7 +6,7 @@ Upgrades that involve a major version bump often come with some backwards incomp
 Before upgrading the agent, be sure to review the:
 
 * <<release-notes,Agent release notes>>
-* {apm-overview-ref-v}/agent-server-compatibility.html[Agent and Server compatibility chart]
+* {apm-guide-ref}/agent-server-compatibility.html[Agent and Server compatibility chart]
 
 [float]
 [[end-of-life-dates]]


### PR DESCRIPTION
Closes https://github.com/elastic/observability-docs/issues/1220

Fixes broken doc links in preparation for 7.17. and 8.0.

Related to https://github.com/elastic/observability-docs/issues/1385

This PR and all backports must be merged before the 7.17 stack release.

### Backports

- [ ] 4.x: https://github.com/elastic/apm-agent-ruby/pull/1225
- [ ] 3.x: https://github.com/elastic/apm-agent-ruby/pull/1226
- [ ] 2.x: https://github.com/elastic/apm-agent-ruby/pull/1227