### PR TITLE
[2.x] pin docs to 7.15

### DIFF
--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -1,4 +1,4 @@
-include::{asciidoc-dir}/../../shared/versions/stack/current.asciidoc[]
+include::{asciidoc-dir}/../../shared/versions/stack/7.15.asciidoc[]
 include::{asciidoc-dir}/../../shared/attributes.asciidoc[]
 
 ifdef::env-github[]


### PR DESCRIPTION
Instead of backporting https://github.com/elastic/apm-agent-ruby/pull/1224, this PR pins the 2.x version of the Ruby Agent to the 7.15 branch of the stack docs. This prevents us from ever having to worry about broken links in this version again.