### PR TITLE
Resque activejob

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -20,6 +20,10 @@ endif::[]
 - Feature {pull}2526[#2526]
 
 [float]
+===== Fixed
+- Fix Resque class names when used through ActiveJob {pull}1233[#1233]
+
+[float]
 ===== Changed
 - Change {pull}2526[#2526]
 

--- a/lib/elastic_apm/spies/resque.rb
+++ b/lib/elastic_apm/spies/resque.rb
@@ -28,6 +28,7 @@ module ElasticAPM
       module Ext
         def perform
           name = @payload && @payload['class']&.to_s
+          name = @payload['args'].first['job_class'] if name == 'ActiveJob::QueueAdapters::ResqueAdapter::JobWrapper'
           transaction = ElasticAPM.start_transaction(name, TYPE)
           super
           transaction&.done 'success'


### PR DESCRIPTION
## What does this pull request do?

Add recognition of resque jobs wrapped by ActiveJob

## Why is it important?

All jobs are reported with the same `ActiveJob::QueueAdapters::ResqueAdapter::JobWrapper` name otherwise.

## Checklist
- [x] I have signed the [Contributor License Agreement](https://www.elastic.co/contributor-agreement/).
- [x] My code follows the style guidelines of this project (See `.rubocop.yml`)
- [x] I have rebased my changes on top of the latest main branch
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing [**unit** tests](https://github.com/elastic/apm-agent-ruby/blob/main/CONTRIBUTING.md#testing) pass locally with my changes
- [ ] I have made corresponding changes to the documentation
- [x] I have updated [CHANGELOG.asciidoc](CHANGELOG.asciidoc)
- [ ] I have updated [supported-technologies.asciidoc](docs/supported-technologies.asciidoc)
- [ ] Added an API method or config option? Document in which version this will be introduced
