### PR TITLE
synchronize schema spec

### DIFF
--- a/spec/fixtures/error.json
+++ b/spec/fixtures/error.json
@@ -624,6 +624,29 @@
                 }
               }
             },
+            "target": {
+              "description": "Target holds information about the outgoing service in case of an outgoing event",
+              "type": [
+                "null",
+                "object"
+              ],
+              "properties": {
+                "name": {
+                  "description": "Immutable name of the target service for the event",
+                  "type": [
+                    "null",
+                    "string"
+                  ]
+                },
+                "type": {
+                  "description": "Immutable type of the target service for the event",
+                  "type": [
+                    "null",
+                    "string"
+                  ]
+                }
+              }
+            },
             "version": {
               "description": "Version of the monitored service.",
               "type": [

--- a/spec/fixtures/span.json
+++ b/spec/fixtures/span.json
@@ -539,6 +539,29 @@
                 }
               }
             },
+            "target": {
+              "description": "Target holds information about the outgoing service in case of an outgoing event",
+              "type": [
+                "null",
+                "object"
+              ],
+              "properties": {
+                "name": {
+                  "description": "Immutable name of the target service for the event",
+                  "type": [
+                    "null",
+                    "string"
+                  ]
+                },
+                "type": {
+                  "description": "Immutable type of the target service for the event",
+                  "type": [
+                    "null",
+                    "string"
+                  ]
+                }
+              }
+            },
             "version": {
               "description": "Version of the monitored service.",
               "type": [

--- a/spec/fixtures/transaction.json
+++ b/spec/fixtures/transaction.json
@@ -623,6 +623,29 @@
                 }
               }
             },
+            "target": {
+              "description": "Target holds information about the outgoing service in case of an outgoing event",
+              "type": [
+                "null",
+                "object"
+              ],
+              "properties": {
+                "name": {
+                  "description": "Immutable name of the target service for the event",
+                  "type": [
+                    "null",
+                    "string"
+                  ]
+                },
+                "type": {
+                  "description": "Immutable type of the target service for the event",
+                  "type": [
+                    "null",
+                    "string"
+                  ]
+                }
+              }
+            },
             "version": {
               "description": "Version of the monitored service.",
               "type": [


### PR DESCRIPTION
### What
  APM agent json schema automatic sync

  ### Why
  *Changeset*
* https://github.com/elastic/apm-server/commit/d1b5503a6 Extend intake API to accept info about target service (https://github.com/elastic/apm-server/pull/7870)