### PR TITLE
jjbb: enable tags from => v4.5 and branches >= 3.x

### DIFF
--- a/.ci/jobs/apm-agent-ruby-mbp.yml
+++ b/.ci/jobs/apm-agent-ruby-mbp.yml
@@ -15,7 +15,7 @@
         repo: apm-agent-ruby
         repo-owner: elastic
         credentials-id: 2a9602aa-ab9f-4e52-baf3-b71ca88469c7-UserAndToken
-        head-filter-regex: '^(main|PR-.*|[3-4]\.x)$'
+        head-filter-regex: '^(main|PR-.*|[3-9]\.x|v4\.[5-9]+.*|v[5-9]+.*)$'
         ssh-checkout:
           credentials: f6c7695a-671e-4f4f-a331-acdce44ff9ba
         build-strategies:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,5 @@
 repos:
--   repo: git://github.com/pre-commit/pre-commit-hooks
+-   repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v2.2.3
     hooks:
     -   id: check-case-conflict
@@ -9,7 +9,7 @@ repos:
     -   id: check-yaml
     -   id: check-xml
 
--   repo: git@github.com:elastic/apm-pipeline-library
+-   repo: https://github.com/elastic/apm-pipeline-library
     rev: current
     hooks:
     -   id: check-bash-syntax


### PR DESCRIPTION
## What does this pull request do?

1) Enable builds in the CI for tags.
2) Enable builds in the CI for branches greater than 2. (including 5, 6... for the future)

## Why is it important?

The release process for the Ruby agent relies on the tags, so by enabling them we will be able to run the release automatically 


## Further details

I tried to reduce the chances to rerun builds for old tags which were released, therefore only tags from `v4.5` will be listed.are not older than 30 days.