### PR TITLE
Remove warnings about TimeTask timeouts

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -46,6 +46,7 @@ endif::[]
 ===== Fixed
 
 - Fixed dependencies to allow CI to build successfully {pull}1259[#1259]
+- Fixed warnings related to TimeTask timeouts {pull}1255[#1255]
 
 [[release-notes-4.5.0]]
 ==== 4.5.0

--- a/lib/elastic_apm/metrics.rb
+++ b/lib/elastic_apm/metrics.rb
@@ -36,8 +36,6 @@ module ElasticAPM
     class Registry
       include Logging
 
-      TIMEOUT_INTERVAL = 5 # seconds
-
       def initialize(config, &block)
         @config = config
         @callback = block
@@ -76,8 +74,7 @@ module ElasticAPM
 
         @timer_task = Concurrent::TimerTask.execute(
           run_now: true,
-          execution_interval: config.metrics_interval,
-          timeout_interval: TIMEOUT_INTERVAL
+          execution_interval: config.metrics_interval
         ) do
           begin
             debug 'Collecting metrics'

--- a/lib/elastic_apm/transport/base.rb
+++ b/lib/elastic_apm/transport/base.rb
@@ -35,7 +35,6 @@ module ElasticAPM
       include Logging
 
       WATCHER_EXECUTION_INTERVAL = 5
-      WATCHER_TIMEOUT_INTERVAL = 4
       WORKER_JOIN_TIMEOUT = 5
 
       def initialize(config)
@@ -112,8 +111,7 @@ module ElasticAPM
 
       def create_watcher
         @watcher = Concurrent::TimerTask.execute(
-          execution_interval: WATCHER_EXECUTION_INTERVAL,
-          timeout_interval: WATCHER_TIMEOUT_INTERVAL
+          execution_interval: WATCHER_EXECUTION_INTERVAL
         ) { ensure_worker_count }
       end
 


### PR DESCRIPTION
<!--
A few suggestions about filling out this PR

1. Use a descriptive title for the PR.
2. If this pull request is work in progress, create a draft PR instead of prefixing the title with WIP.
3. Please label this PR at least one of the following labels, depending on the scope of your change:
- feature request, which adds new behavior
- bug fix
- enhancement, which modifies existing behavior
- breaking change
4. Remove those recommended/optional sections if you don't need them. Only "What does this PR do", "Why is it important?" and "Checklist" are mandatory.
5. Generally, we require that you test any code you are adding or modifying.
Once your changes are ready to submit for review:
6. Submit the pull request: Push your local changes to your forked copy of the repository and submit a pull request (https://help.github.com/articles/using-pull-requests).
7. Please be patient. We might not be able to review your code as fast as we would like to, but we'll do our best to dedicate to it the attention it deserves. Your effort is much appreciated!
-->

## What does this pull request do?

Removes warnings issued when running the tests about TimeTask timeout being ignored

<!--
Use this space to describe what the proposed code _does_, ie. what precisely will be done differently from this change.
-->

## Why is it important?

Extra noise in the tests and logs can obscure other problems

<!--
Optionally provide an explanation of why this is important.
-->

## Checklist
<!--
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] I have signed the [Contributor License Agreement](https://www.elastic.co/contributor-agreement/).
- [x] My code follows the style guidelines of this project (See `.rubocop.yml`)
- [x] I have rebased my changes on top of the latest main branch
<!--
Update your local repository with the most recent code from the main repo, and rebase your branch on top of the latest main branch. We prefer your initial changes to be squashed into a single commit. Later, if we ask you to make changes, add them as separate commits. This makes them easier to review.
-->
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing [**unit** tests](https://github.com/elastic/apm-agent-ruby/blob/main/CONTRIBUTING.md#testing) pass locally with my changes
<!--
Run the test suite to make sure that nothing is broken. See https://github.com/elastic/apm-agent-ruby/blob/main/CONTRIBUTING.md#testing for details.
-->
- [x] I have made corresponding changes to the documentation
- [x] I have updated [CHANGELOG.asciidoc](CHANGELOG.asciidoc)
- [x] I have updated [supported-technologies.asciidoc](docs/supported-technologies.asciidoc)
- [x] Added an API method or config option? Document in which version this will be introduced

## Related issues
<!--
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.
- Closes #ISSUE_ID
- Relates #ISSUE_ID
- Requires #ISSUE_ID
- Superseds #ISSUE_ID
-->
