### PR TITLE
synchronize schema spec

### DIFF
--- a/spec/fixtures/error.json
+++ b/spec/fixtures/error.json
@@ -622,7 +622,29 @@
                     "string"
                   ]
                 }
-              }
+              },
+              "anyOf": [
+                {
+                  "properties": {
+                    "type": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "type"
+                  ]
+                },
+                {
+                  "properties": {
+                    "name": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "name"
+                  ]
+                }
+              ]
             },
             "version": {
               "description": "Version of the monitored service.",

--- a/spec/fixtures/span.json
+++ b/spec/fixtures/span.json
@@ -537,7 +537,29 @@
                     "string"
                   ]
                 }
-              }
+              },
+              "anyOf": [
+                {
+                  "properties": {
+                    "type": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "type"
+                  ]
+                },
+                {
+                  "properties": {
+                    "name": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "name"
+                  ]
+                }
+              ]
             },
             "version": {
               "description": "Version of the monitored service.",

--- a/spec/fixtures/transaction.json
+++ b/spec/fixtures/transaction.json
@@ -621,7 +621,29 @@
                     "string"
                   ]
                 }
-              }
+              },
+              "anyOf": [
+                {
+                  "properties": {
+                    "type": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "type"
+                  ]
+                },
+                {
+                  "properties": {
+                    "name": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "name"
+                  ]
+                }
+              ]
             },
             "version": {
               "description": "Version of the monitored service.",


### PR DESCRIPTION
### What
  APM agent json schema automatic sync

  ### Why
  *Changeset*
* https://github.com/elastic/apm-server/commit/72d58a75c Allow indexing of empty service.type (https://github.com/elastic/apm-server/pull/8155)