### PR TITLE
Initial pass at only adding tracestate header when a tracestate exists

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -48,6 +48,7 @@ endif::[]
 - Expanded filtering to sanitize any key that contains the string 'auth' {pull}1266[#1266]
 - Rename `log_ecs_formatting` option to `log_ecs_reformatting`, deprecate old option name {pull}1248[#1248]
 - When the configuration value for `log_path` is set, override the `logger` to point to that path instead of using e.g. Rails logger {pull}1247[#1247]
+- Only send tracestate header for distributed tracing when it has content {pull}1277[#1277]
 
 [[release-notes-4.5.1]]
 ==== 4.5.1

--- a/lib/elastic_apm/trace_context.rb
+++ b/lib/elastic_apm/trace_context.rb
@@ -96,7 +96,7 @@ module ElasticAPM
     def apply_headers
       yield 'Traceparent', traceparent.to_header
 
-      if tracestate
+      if tracestate && !tracestate.to_header.empty?
         yield 'Tracestate', tracestate.to_header
       end
 

--- a/lib/elastic_apm/trace_context/tracestate.rb
+++ b/lib/elastic_apm/trace_context/tracestate.rb
@@ -107,7 +107,7 @@ module ElasticAPM
           split_by_nl_and_comma(header)
           .each_with_object({}) do |entry, hsh|
             k, v = entry.split('=')
-
+            next unless k && v && !k.empty? && !v.empty?
             hsh[k] =
               case k
               when 'es' then EsEntry.new(v)

--- a/spec/elastic_apm/trace_context_spec.rb
+++ b/spec/elastic_apm/trace_context_spec.rb
@@ -70,6 +70,23 @@ module ElasticAPM
         its(:tracestate) { is_expected.to be_a TraceContext::Tracestate }
       end
 
+      context 'with traceparent and an empty tracestate' do
+        let(:env) do
+          Rack::MockRequest.env_for(
+            '/',
+            'HTTP_ELASTIC_APM_TRACEPARENT' =>
+            '00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-00',
+            'HTTP_TRACESTATE' => ''
+          )
+        end
+
+        its(:traceparent) { is_expected.to be_a TraceContext::Traceparent }
+        its(:tracestate) { is_expected.to be_a TraceContext::Tracestate }
+        it 'generates no tracestate header' do
+          expect(subject.tracestate.to_header).to eq ""
+        end
+      end
+
       context 'with neither' do
         let(:env) do
           Rack::MockRequest.env_for('/')
@@ -125,10 +142,9 @@ module ElasticAPM
           end
 
           expect(calls).to match(
-            'Traceparent' => String,
-            'Tracestate' => String
+            'Traceparent' => String
           )
-          expect(calls.length).to be 2
+          expect(calls.length).to eq 1
         end
       end
 
@@ -143,10 +159,9 @@ module ElasticAPM
 
           expect(calls).to match(
             'Traceparent' => String,
-            'Elastic-Apm-Traceparent' => String,
-            'Tracestate' => String
+            'Elastic-Apm-Traceparent' => String
           )
-          expect(calls.values.uniq.length).to be 2
+          expect(calls.values.uniq.length).to eq 1
         end
       end
 


### PR DESCRIPTION
<!--
A few suggestions about filling out this PR

1. Use a descriptive title for the PR.
2. If this pull request is work in progress, create a draft PR instead of prefixing the title with WIP.
3. Please label this PR at least one of the following labels, depending on the scope of your change:
- feature request, which adds new behavior
- bug fix
- enhancement, which modifies existing behavior
- breaking change
4. Remove those recommended/optional sections if you don't need them. Only "What does this PR do", "Why is it important?" and "Checklist" are mandatory.
5. Generally, we require that you test any code you are adding or modifying.
Once your changes are ready to submit for review:
6. Submit the pull request: Push your local changes to your forked copy of the repository and submit a pull request (https://help.github.com/articles/using-pull-requests).
7. Please be patient. We might not be able to review your code as fast as we would like to, but we'll do our best to dedicate to it the attention it deserves. Your effort is much appreciated!
-->

## What does this pull request do?

Ensures that the tracestate header (for distributed tracing) is not set unless there is a real value for the header (i.e. not the empty string)
<!--
Use this space to describe what the proposed code _does_, ie. what precisely will be done differently from this change.
-->

## Why is it important?

elastic/apm#648 and elastic/apm-agent-rum-js#1232

<!--
Optionally provide an explanation of why this is important.
-->

## Checklist
<!--
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] I have signed the [Contributor License Agreement](https://www.elastic.co/contributor-agreement/).
- [x] My code follows the style guidelines of this project (See `.rubocop.yml`)
- [x] I have rebased my changes on top of the latest main branch
<!--
Update your local repository with the most recent code from the main repo, and rebase your branch on top of the latest main branch. We prefer your initial changes to be squashed into a single commit. Later, if we ask you to make changes, add them as separate commits. This makes them easier to review.
-->
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing [**unit** tests](https://github.com/elastic/apm-agent-ruby/blob/main/CONTRIBUTING.md#testing) pass locally with my changes
<!--
Run the test suite to make sure that nothing is broken. See https://github.com/elastic/apm-agent-ruby/blob/main/CONTRIBUTING.md#testing for details.
-->
- [x] I have made corresponding changes to the documentation
- [x] I have updated [CHANGELOG.asciidoc](CHANGELOG.asciidoc)
- [x] I have updated [supported-technologies.asciidoc](docs/supported-technologies.asciidoc)
- [x] Added an API method or config option? Document in which version this will be introduced

## Related issues
<!--
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.
- Closes #ISSUE_ID
- Relates #ISSUE_ID
- Requires #ISSUE_ID
- Superseds #ISSUE_ID
-->
