### PR TITLE
Fix for redis.call breaking when given an array

### DIFF
--- a/lib/elastic_apm/spies/redis.rb
+++ b/lib/elastic_apm/spies/redis.rb
@@ -25,7 +25,7 @@ module ElasticAPM
       # @api private
       module Ext
         def call(command, &block)
-          name = command[0].upcase
+          name = command[0].to_s.upcase
 
           return super(command, &block) if command[0] == :auth
 


### PR DESCRIPTION
The redis.call method can take an array. I came across this in while debugging this [issue](https://github.com/MiniProfiler/rack-mini-profiler/issues/513) with Rack Mini Profiler. Calling `.to_s` before we call `.upcase` seems to be the best way to go about this.