### PR TITLE
Fix benchmarks reporting to an ES 8.x

### DIFF
--- a/bench/report.rb
+++ b/bench/report.rb
@@ -11,7 +11,7 @@ git_date = `git log -n 1 --pretty="format:%ai"`
 platform = Gem::Platform.local
 
 def doc(payload)
-  puts({ index: { _index: "benchmark-ruby", _type: "_doc" } }.to_json)
+  puts({ index: { _index: "benchmark-ruby" } }.to_json)
   puts(payload.to_json)
 end
 


### PR DESCRIPTION
Our benchmarks deployment was updated from 7.x to 8.x, which means no
mapping types, which means no `_type` field.
https://www.elastic.co/guide/en/elasticsearch/reference/7.17/removal-of-types.html

* * *

Ruby APM agent benchmarks reporting started failing recently, e.g. https://apm-ci.elastic.co/blue/organizations/jenkins/apm-agent-ruby%2Fapm-agent-ruby-mbp/detail/main/28/pipeline

This is the same issue that the Java and [Node.js](https://github.com/elastic/apm-agent-nodejs/pull/2835) APM agents hit.

@jaggederest I haven't tested this yet. I was hoping we could trigger a Benchmarks run on this PR to test it.