### PR TITLE
Update ElasticAPM::SpanHelpers to use ruby2_keywords for argument delegation

### DIFF
--- a/elastic-apm.gemspec
+++ b/elastic-apm.gemspec
@@ -37,6 +37,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency('concurrent-ruby', '~> 1.0')
   spec.add_dependency('http', '>= 3.0')
+  spec.add_runtime_dependency('ruby2_keywords')
 
   spec.require_paths = ['lib']
 end

--- a/lib/elastic_apm.rb
+++ b/lib/elastic_apm.rb
@@ -26,6 +26,7 @@ require 'logger'
 require 'concurrent'
 require 'forwardable'
 require 'securerandom'
+require 'ruby2_keywords'
 
 require 'elastic_apm/version'
 require 'elastic_apm/internal_error'

--- a/lib/elastic_apm/span_helpers.rb
+++ b/lib/elastic_apm/span_helpers.rb
@@ -37,7 +37,7 @@ module ElasticAPM
         type ||= Span::DEFAULT_TYPE
 
         klass.prepend(Module.new do
-          define_method(method) do |*args, &block|
+          ruby2_keywords(define_method(method) do |*args, &block|
             unless ElasticAPM.current_transaction
               return super(*args, &block)
             end
@@ -45,7 +45,7 @@ module ElasticAPM
             ElasticAPM.with_span name.to_s, type.to_s do
               super(*args, &block)
             end
-          end
+          end)
         end)
       end
     end

--- a/spec/elastic_apm/span_helpers_spec.rb
+++ b/spec/elastic_apm/span_helpers_spec.rb
@@ -38,6 +38,11 @@ module ElasticAPM
         block.call
       end
       span_method :do_the_block_thing
+
+      def do_mixed_args_thing(one, two, three: nil)
+        [one, two, three]
+      end
+      span_method :do_mixed_args_thing
     end
 
     context 'on class methods', :intercept do
@@ -78,6 +83,19 @@ module ElasticAPM
 
         expect(@intercepted.spans.length).to be 1
         expect(@intercepted.spans.last.name).to eq 'do_the_block_thing'
+      end
+
+      it 'handles mixed positional and keyword arguments' do
+        thing = Thing.new
+
+        with_agent do
+          ElasticAPM.with_transaction do
+            thing.do_mixed_args_thing('one', 'two', three: 'three')
+          end
+        end
+
+        expect(@intercepted.spans.length).to be 1
+        expect(@intercepted.spans.last.name).to eq 'do_mixed_args_thing'
       end
     end
   end


### PR DESCRIPTION
## What does this pull request do?

This code updates ElasticAPM::SpanHelpers to use ruby2_keywords to properly delegate method arguments in a way that's compatible with all supported versions of ruby.

The included test will raise an ArgumentError in ruby >=3 without these changes.

I've also added the ruby2_keywords gem to the Gemfile for ruby versions <2.7, as the method is not included in those older versions of ruby. The gem is already pulled in by multiple other gems that depend on it, so this isn't effectively adding anything, it's just making it explicit since this project now explicitly depends on it.

## Why is it important?

ElasticAPM::SpanHelpers was previously broken with ruby >=3.0 because it uses the legacy format of delegating arguments. In ruby 3, if a method has a mixture of keyword arguments and positional arguments, any methods spanned would raise an ArgumentError. See [here](https://www.ruby-lang.org/en/news/2019/12/12/separation-of-positional-and-keyword-arguments-in-ruby-3-0/) and [here](https://eregon.me/blog/2021/02/13/correct-delegation-in-ruby-2-27-3.html) for more details. Switching to the new argument delegation format in ruby 3, which would be `(*args, **kwargs, &block)` instead of `(*args, &block)`, would also fix the issue, but that wouldn't be backwards compatible with ruby versions before 3.0.

## Checklist
<!--
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] I have signed the [Contributor License Agreement](https://www.elastic.co/contributor-agreement/).
- [x] My code follows the style guidelines of this project (See `.rubocop.yml`)
- [x] I have rebased my changes on top of the latest main branch
<!--
Update your local repository with the most recent code from the main repo, and rebase your branch on top of the latest main branch. We prefer your initial changes to be squashed into a single commit. Later, if we ask you to make changes, add them as separate commits. This makes them easier to review.
-->
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing [**unit** tests](https://github.com/elastic/apm-agent-ruby/blob/main/CONTRIBUTING.md#testing) pass locally with my changes
<!--
Run the test suite to make sure that nothing is broken. See https://github.com/elastic/apm-agent-ruby/blob/main/CONTRIBUTING.md#testing for details.
-->
- [ ] ~~I have made corresponding changes to the documentation~~
- [ ] ~~I have updated [CHANGELOG.asciidoc](CHANGELOG.asciidoc)~~
- [ ] ~~I have updated [supported-technologies.asciidoc](docs/supported-technologies.asciidoc)~~
- [ ] ~~Added an API method or config option? Document in which version this will be introduced~~