### PR TITLE
racecar is only available for MRI

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -51,7 +51,7 @@ gem 'json-schema', require: nil
 gem 'mongo', require: nil
 gem 'opentracing', require: nil
 gem 'rake', '>= 13.0', require: nil
-gem 'racecar', require: nil
+gem 'racecar', require: nil if !defined?(JRUBY_VERSION)
 gem 'resque', require: nil
 gem 'sequel', require: nil
 gem 'shoryuken', require: nil


### PR DESCRIPTION
racecar depends on [rdkafka](https://github.com/appsignal/rdkafka-ruby), which [depends on `librdkafka` C library](https://github.com/appsignal/rdkafka-ruby/tree/main/ext) so it should not be tested with JRuby.