### PR TITLE
.ci: remove Integration Tests stage

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -21,8 +21,6 @@ pipeline {
     CODECOV_SECRET = 'secret/apm-team/ci/apm-agent-ruby-codecov'
     DOCKER_REGISTRY = 'docker.elastic.co'
     DOCKER_SECRET = 'secret/apm-team/ci/docker-registry/prod'
-    GITHUB_CHECK_ITS_NAME = 'Integration Tests'
-    ITS_PIPELINE = 'apm-integration-tests-selector-mbp/main'
     RELEASE_SECRET = 'secret/apm-team/ci/apm-agent-ruby-rubygems-release'
     OPBEANS_REPO = 'opbeans-ruby'
     REFERENCE_REPO = '/var/lib/jenkins/.git-references/apm-agent-ruby.git'
@@ -121,25 +119,6 @@ pipeline {
             catchError(buildResult: 'SUCCESS', stageResult: 'UNSTABLE', message: "The tests for the main framework have failed. Let's warn instead.") {
               runTests('.ci/.jenkins_main_framework.yml')
             }
-          }
-        }
-        stage('Integration Tests') {
-          agent none
-          when {
-            beforeAgent true
-            anyOf {
-              changeRequest()
-              expression { return !params.Run_As_Main_Branch }
-            }
-          }
-          steps {
-            githubNotify(context: "${env.GITHUB_CHECK_ITS_NAME}", description: "${env.GITHUB_CHECK_ITS_NAME} ...", status: 'PENDING', targetUrl: "${env.JENKINS_URL}search/?q=${env.ITS_PIPELINE.replaceAll('/','+')}")
-            build(job: env.ITS_PIPELINE, propagate: false, wait: true,
-                  parameters: [ string(name: 'INTEGRATION_TEST', value: 'Ruby'),
-                                string(name: 'BUILD_OPTS', value: "--ruby-agent-version ${env.GIT_BASE_COMMIT} --ruby-agent-version-state ${env.GIT_BUILD_CAUSE} --ruby-agent-repo ${env.CHANGE_FORK?.trim() ?: 'elastic'}/${env.REPO} --opbeans-ruby-agent-branch ${env.GIT_BASE_COMMIT}"),
-                                string(name: 'GITHUB_CHECK_NAME', value: env.GITHUB_CHECK_ITS_NAME),
-                                string(name: 'GITHUB_CHECK_REPO', value: env.REPO),
-                                string(name: 'GITHUB_CHECK_SHA1', value: env.GIT_BASE_COMMIT) ])
           }
         }
       }


### PR DESCRIPTION
## What does this pull request do?

Remove the integration tests stage from CI.

## Why is it important?

See See https://github.com/elastic/apm-integration-testing/issues/1523

## Checklist

~- [ ] I have signed the [Contributor License Agreement](https://www.elastic.co/contributor-agreement/).~
~- [ ] My code follows the style guidelines of this project (See `.rubocop.yml`)~
- [x] I have rebased my changes on top of the latest main branch
~- [ ] I have added tests that prove my fix is effective or that my feature works~
~- [ ] New and existing [**unit** tests](https://github.com/elastic/apm-agent-ruby/blob/main/CONTRIBUTING.md#testing) pass locally with my changes~
~- [ ] I have made corresponding changes to the documentation~
~- [ ] I have updated [CHANGELOG.asciidoc](CHANGELOG.asciidoc)~
~- [ ] I have updated [supported-technologies.asciidoc](docs/supported-technologies.asciidoc)~
~- [ ] Added an API method or config option? Document in which version this will be introduced~

## Related issues

https://github.com/elastic/apm-integration-testing/issues/1523