### PR TITLE
Test PR #1294 ruby2_keywords for span helper

### DIFF
--- a/elastic-apm.gemspec
+++ b/elastic-apm.gemspec
@@ -37,6 +37,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency('concurrent-ruby', '~> 1.0')
   spec.add_dependency('http', '>= 3.0')
+  spec.add_runtime_dependency('ruby2_keywords')
 
   spec.require_paths = ['lib']
 end

--- a/lib/elastic_apm.rb
+++ b/lib/elastic_apm.rb
@@ -26,6 +26,7 @@ require 'logger'
 require 'concurrent'
 require 'forwardable'
 require 'securerandom'
+require 'ruby2_keywords'
 
 require 'elastic_apm/version'
 require 'elastic_apm/internal_error'

--- a/lib/elastic_apm/span_helpers.rb
+++ b/lib/elastic_apm/span_helpers.rb
@@ -37,7 +37,7 @@ module ElasticAPM
         type ||= Span::DEFAULT_TYPE
 
         klass.prepend(Module.new do
-          define_method(method) do |*args, &block|
+          ruby2_keywords(define_method(method) do |*args, &block|
             unless ElasticAPM.current_transaction
               return super(*args, &block)
             end
@@ -45,7 +45,7 @@ module ElasticAPM
             ElasticAPM.with_span name.to_s, type.to_s do
               super(*args, &block)
             end
-          end
+          end)
         end)
       end
     end

--- a/spec/elastic_apm/span_helpers_spec.rb
+++ b/spec/elastic_apm/span_helpers_spec.rb
@@ -38,6 +38,11 @@ module ElasticAPM
         block.call
       end
       span_method :do_the_block_thing
+
+      def do_mixed_args_thing(one, two, three: nil)
+        [one, two, three]
+      end
+      span_method :do_mixed_args_thing
     end
 
     context 'on class methods', :intercept do
@@ -78,6 +83,19 @@ module ElasticAPM
 
         expect(@intercepted.spans.length).to be 1
         expect(@intercepted.spans.last.name).to eq 'do_the_block_thing'
+      end
+
+      it 'handles mixed positional and keyword arguments' do
+        thing = Thing.new
+
+        with_agent do
+          ElasticAPM.with_transaction do
+            thing.do_mixed_args_thing('one', 'two', three: 'three')
+          end
+        end
+
+        expect(@intercepted.spans.length).to be 1
+        expect(@intercepted.spans.last.name).to eq 'do_mixed_args_thing'
       end
     end
   end


### PR DESCRIPTION
This PR copies the changes in https://github.com/elastic/apm-agent-ruby/pull/1294 so I can make sure the base is up-to-date and can test on the various versions of ruby we support.
For the record, I wanted to test locally but can't test with some older versions of ruby because they can't be installed on an m1 machine.