### PR TITLE
Use hostname as the default Kubernetes pod name

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -51,6 +51,7 @@ endif::[]
 - Rename `log_ecs_formatting` option to `log_ecs_reformatting`, deprecate old option name {pull}1248[#1248]
 - When the configuration value for `log_path` is set, override the `logger` to point to that path instead of using e.g. Rails logger {pull}1247[#1247]
 - Only send tracestate header for distributed tracing when it has content {pull}1277[#1277]
+- Use the hostname as the Kubernetes pod name in the Container Info metadata if the pod id is parsed from cgroup {pull}1314[#1314]
 
 ====== Fixed
 

--- a/lib/elastic_apm/metadata/system_info.rb
+++ b/lib/elastic_apm/metadata/system_info.rb
@@ -29,7 +29,7 @@ module ElasticAPM
         @architecture = gem_platform.cpu
         @platform = gem_platform.os
 
-        container_info = ContainerInfo.read!
+        container_info = ContainerInfo.read!(@detected_hostname)
         @container = container_info.container
         @kubernetes = container_info.kubernetes
       end

--- a/lib/elastic_apm/metadata/system_info/container_info.rb
+++ b/lib/elastic_apm/metadata/system_info/container_info.rb
@@ -33,14 +33,15 @@ module ElasticAPM
 
         attr_reader :cgroup_path
 
-        def read!
+        def read!(hostname)
           read_from_cgroup!
+          self.kubernetes_pod_name = hostname if kubernetes_pod_uid
           read_from_env!
           self
         end
 
-        def self.read!
-          new.read!
+        def self.read!(hostname)
+          new.read!(hostname)
         end
 
         def container


### PR DESCRIPTION
Use the hostname as the Kubernetes pod name in the Container Info metadata if the pod id is parsed from `/proc/self/cgroup`.
This will help solve part of https://github.com/elastic/apm-agent-ruby/issues/1292, which is partly due to a server issue and partly due to this missing usage of the hostname as the default pod name in the Ruby agent.