### PR TITLE
Don't send unsampled transactions to APM server >= 8.0

### DIFF
--- a/lib/elastic_apm/config/server_info.rb
+++ b/lib/elastic_apm/config/server_info.rb
@@ -23,6 +23,9 @@ module ElasticAPM
     class ServerInfo
       attr_reader :payload, :config, :http
 
+      VERSION_8_0 = '8.0'
+      VERSION_0 = '0'
+
       def initialize(config)
         @config = config
         @http = Transport::Connection::Http.new(config)
@@ -32,12 +35,14 @@ module ElasticAPM
         resp = http.get(config.server_url)
         @payload = JSON.parse(resp.body)
       rescue
-        @payload = {"version" => nil}
+        @payload = {"version" => '0'}
       end
 
       def version
-        execute unless payload
-        payload["version"]
+        @version ||= begin
+          execute
+          payload["version"] ? payload["version"].to_s : VERSION_0
+        end
       end
     end
   end

--- a/lib/elastic_apm/instrumenter.rb
+++ b/lib/elastic_apm/instrumenter.rb
@@ -150,7 +150,9 @@ module ElasticAPM
 
       transaction.done result
 
-      enqueue.call transaction
+      if transaction.sampled? || @config.version < Config::ServerInfo::VERSION_8_0
+        enqueue.call transaction
+      end
 
       update_transaction_metrics(transaction)
 

--- a/spec/elastic_apm/config/server_info_spec.rb
+++ b/spec/elastic_apm/config/server_info_spec.rb
@@ -1,0 +1,54 @@
+# Licensed to Elasticsearch B.V. under one or more contributor
+# license agreements. See the NOTICE file distributed with
+# this work for additional information regarding copyright
+# ownership. Elasticsearch B.V. licenses this file to you under
+# the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# frozen_string_literal: true
+
+require "spec_helper"
+
+module ElasticAPM
+  class Config
+    RSpec.describe ServerInfo do
+      subject { described_class.new(Config.new) }
+
+      context 'when the request is successful' do
+        context 'when the version is in the response' do
+          it 'sets the version' do
+            WebMock.stub_request(:get, %r{^http://localhost:8200/$}).
+              to_return(body: '{"version":"7.17.4"}')
+            expect(subject.version).to eq('7.17.4')
+          end
+        end
+
+        context 'when the version is not in the response' do
+          it 'sets the version to 0' do
+            WebMock.stub_request(:get, %r{^http://localhost:8200/$}).
+              to_return(body: nil)
+            expect(subject.version).to eq('0')
+          end
+        end
+      end
+
+      context 'when the request is not successful' do
+        it 'sets the version to 0' do
+          WebMock.stub_request(:get, %r{^http://localhost:8200/$}).
+            to_raise(StandardError)
+            expect(subject.version).to eq('0')
+        end
+      end
+    end
+  end
+end

--- a/spec/elastic_apm/config_spec.rb
+++ b/spec/elastic_apm/config_spec.rb
@@ -296,16 +296,16 @@ module ElasticAPM
     end
 
     describe "#version" do
-      it "has no version if the server does not respond" do
+      it "has version 0 if the server does not respond" do
         WebMock.stub_request(:get, "http://localhost:8200/")
           .to_return(status: 404, body: "")
-        expect(Config.new.version).to be_nil
+        expect(Config.new.version).to eq '0'
       end
 
       it "returns the version from the server" do
         WebMock.stub_request(:get, "http://localhost:8200/")
-          .to_return(status: 200, body: '{"version": 8.0}')
-        expect(Config.new.version).to eq 8.0
+          .to_return(status: 200, body: '{"version": 8.5}')
+        expect(Config.new.version).to eq '8.5'
       end
     end
   end

--- a/spec/elastic_apm/middleware_spec.rb
+++ b/spec/elastic_apm/middleware_spec.rb
@@ -115,6 +115,11 @@ module ElasticAPM
       context 'with valid header' do
         it 'recognizes trace_context' do
           with_agent do
+            # The apm server version must be < 8.0 in order for a transaction
+            # to be enqueued when it's unsampled.
+            # See issue https://github.com/elastic/apm-agent-ruby/issues/1340
+            WebMock.stub_request(:get, %r{^http://localhost:8200/$}).
+              to_return(body: '{"version":"7.17.4"}')
             app.call(
               Rack::MockRequest.env_for(
                 '/',
@@ -136,6 +141,11 @@ module ElasticAPM
       context 'with tracestate' do
         it 'recognizes trace_context' do
           with_agent do
+            # The apm server version must be < 8.0 in order for a transaction
+            # to be enqueued when it's unsampled.
+            # See issue https://github.com/elastic/apm-agent-ruby/issues/1340
+            WebMock.stub_request(:get, %r{^http://localhost:8200/$}).
+              to_return(body: '{"version":"7.17.4"}')
             app.call(
               Rack::MockRequest.env_for(
                 '/',
@@ -191,6 +201,11 @@ module ElasticAPM
       context 'with a prefix-less header' do
         it 'recognizes trace_context' do
           with_agent do
+            # The apm server version must be < 8.0 in order for a transaction
+            # to be enqueued when it's unsampled.
+            # See issue https://github.com/elastic/apm-agent-ruby/issues/1340
+            WebMock.stub_request(:get, %r{^http://localhost:8200/$}).
+              to_return(body: '{"version":"7.17.4"}')
             app.call(
               Rack::MockRequest.env_for(
                 '/',
@@ -212,6 +227,11 @@ module ElasticAPM
       context 'with both types of headers' do
         it 'picks the prefixed' do
           with_agent do
+            # The apm server version must be < 8.0 in order for a transaction
+            # to be enqueued when it's unsampled.
+            # See issue https://github.com/elastic/apm-agent-ruby/issues/1340
+            WebMock.stub_request(:get, %r{^http://localhost:8200/$}).
+              to_return(body: '{"version":"7.17.4"}')
             app.call(
               Rack::MockRequest.env_for(
                 '/',

--- a/spec/support/with_agent.rb
+++ b/spec/support/with_agent.rb
@@ -30,7 +30,7 @@ module WithAgent
 
     @server_version_stub =
       WebMock.stub_request(:get, %r{^http://localhost:8200/$}).
-      to_return(body: '{"version":8.0}')
+      to_return(body: '{"version":"8.0"}')
 
     klass.start(*args, **config)
     yield


### PR DESCRIPTION
Unsampled transactions should not be sent to the APM server when the server version is at least 8.0.

Resolves #1340 

