### PR TITLE
Don't test rails main on Ruby 2.7, only 3.0 and higher

### DIFF
--- a/.ci/.jenkins_exclude.yml
+++ b/.ci/.jenkins_exclude.yml
@@ -61,8 +61,10 @@ exclude:
   - RUBY_VERSION: ruby:2.4
     FRAMEWORK: rails-6.0
 
-  # Only test rails master on ruby 2.7 and ruby 3.1
+  # Only test rails master on ruby 3.1
   - RUBY_VERSION: ruby:3.0
+    FRAMEWORK: rails-main
+  - RUBY_VERSION: ruby:2.7
     FRAMEWORK: rails-main
   - RUBY_VERSION: ruby:2.6
     FRAMEWORK: rails-main


### PR DESCRIPTION
Seeing this error in ci:

> [2023-01-09T10:31:04.670Z] rails-7.1.0.alpha requires rubygems version >= 3.3.13, which is incompatible
> [2023-01-09T10:31:04.670Z] with the current version, 3.1.6