### PR TITLE
Close the read pipe at the right moment

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -35,6 +35,11 @@ endif::[]
 [[release-notes-4.x]]
 === Ruby Agent version 4.x
 
+[float]
+===== Fixed
+
+- Fix growing number of open file descriptors when HTTP request to APM is never sent {pull}1351[#1351]
+
 [[release-notes-4.6.0]]
 ==== 4.6.0
 

--- a/lib/elastic_apm/transport/connection/http.rb
+++ b/lib/elastic_apm/transport/connection/http.rb
@@ -75,7 +75,15 @@ module ElasticAPM
           @closed.make_true
 
           @wr&.close
-          return if @request.nil? || @request&.join(5)
+
+          if @request&.join(5)
+            @rd&.close
+            return
+          end
+
+          @rd&.close
+
+          return if @request.nil?
 
           error(
             '%s: APM Server not responding in time, terminating request',
@@ -117,8 +125,6 @@ module ElasticAPM
               error(
                 "Couldn't establish connection to APM Server:\n%p", e.inspect
               )
-            ensure
-              @rd&.close
             end
           end
         end

--- a/spec/elastic_apm/transport/connection/http_spec.rb
+++ b/spec/elastic_apm/transport/connection/http_spec.rb
@@ -95,6 +95,26 @@ module ElasticAPM
         end
       end
 
+      describe 'when exception is raised before write' do
+        subject! { described_class.new(config) }
+
+        before do
+          allow(subject).to receive(:post).and_raise
+        end
+
+        it 'closes the connection on close' do
+          stub = build_stub(body: /{"msg": "hey!"}/, headers: headers)
+          subject.open(url)
+
+          sleep 0.2
+          subject.write('{"msg": "hey!"}')
+
+          expect(subject.closed?).to be false
+          subject.close(:scheduled_flush)
+          expect(subject.closed?).to be true
+        end
+      end
+
       context 'http compression' do
         let(:config) { Config.new }
 


### PR DESCRIPTION
## What does this pull request do?

Closes the read pipe whether the HTTP request thread was executed or not.

## Why is it important?

If we only close the read pipe after the HTTP request inside the child thread, a file descriptor leak can happen.

## Checklist
<!--
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] I have signed the [Contributor License Agreement](https://www.elastic.co/contributor-agreement/).
- [x] My code follows the style guidelines of this project (See `.rubocop.yml`)
- [x] I have rebased my changes on top of the latest main branch
<!--
Update your local repository with the most recent code from the main repo, and rebase your branch on top of the latest main branch. We prefer your initial changes to be squashed into a single commit. Later, if we ask you to make changes, add them as separate commits. This makes them easier to review.
-->
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing [**unit** tests](https://github.com/elastic/apm-agent-ruby/blob/main/CONTRIBUTING.md#testing) pass locally with my changes
- [x] I have made corresponding changes to the documentation
- [x] I have updated [CHANGELOG.asciidoc](CHANGELOG.asciidoc)
- [x] I have updated [supported-technologies.asciidoc](docs/supported-technologies.asciidoc)
- [x] Added an API method or config option? Document in which version this will be introduced

## Related issues

- Closes #1350
