### PR TITLE
latest sqlite3 does not support < ruby v2.7

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -114,10 +114,8 @@ if RUBY_PLATFORM == 'java'
   else
     gem 'activerecord-jdbcsqlite3-adapter', "~> #{rails.tr('.', '')}.0"
   end
-elsif frameworks_versions['rails'] =~ /^(4|5)/
+elsif frameworks_versions['rails'] =~ /^(4|5)/ || RUBY_VERSION < '2.7'
   gem 'sqlite3', '~> 1.3.6'
-elsif RUBY_VERSION < '2.7'
-  gem 'sqlite3', '~> 1.5.4'
 else
   gem 'sqlite3'
 end

--- a/Gemfile
+++ b/Gemfile
@@ -114,7 +114,7 @@ if RUBY_PLATFORM == 'java'
   else
     gem 'activerecord-jdbcsqlite3-adapter', "~> #{rails.tr('.', '')}.0"
   end
-elsif frameworks_versions['rails'] =~ /^(4|5)/
+elsif frameworks_versions['rails'] =~ /^(4|5)/ || RUBY_VERSION < '2.7'
   gem 'sqlite3', '~> 1.3.6'
 else
   gem 'sqlite3'

--- a/Gemfile
+++ b/Gemfile
@@ -116,8 +116,8 @@ if RUBY_PLATFORM == 'java'
   end
 elsif frameworks_versions['rails'] =~ /^(4|5)/
   gem 'sqlite3', '~> 1.3.6'
-elsif frameworks_versions['rails'] && RUBY_VERSION < '2.7' # rails 6.0 tested with ruby 2.6
-  gem 'sqlite3', '~> 1.3.6'
+elsif RUBY_VERSION < '2.7'
+  gem 'sqlite3', '~> 1.5.4'
 else
   gem 'sqlite3'
 end

--- a/Gemfile
+++ b/Gemfile
@@ -114,8 +114,10 @@ if RUBY_PLATFORM == 'java'
   else
     gem 'activerecord-jdbcsqlite3-adapter', "~> #{rails.tr('.', '')}.0"
   end
-elsif frameworks_versions['rails'] =~ /^(4|5)/ || RUBY_VERSION < '2.7'
+elsif frameworks_versions['rails'] =~ /^(4|5)/
   gem 'sqlite3', '~> 1.3.6'
+elsif RUBY_VERSION < '2.7'
+  gem 'sqlite3', '~> 1.4.4'
 else
   gem 'sqlite3'
 end

--- a/Gemfile
+++ b/Gemfile
@@ -114,7 +114,9 @@ if RUBY_PLATFORM == 'java'
   else
     gem 'activerecord-jdbcsqlite3-adapter', "~> #{rails.tr('.', '')}.0"
   end
-elsif frameworks_versions['rails'] =~ /^(4|5)/ || RUBY_VERSION < '2.7'
+elsif frameworks_versions['rails'] =~ /^(4|5)/
+  gem 'sqlite3', '~> 1.3.6'
+elsif frameworks_versions['rails'] && RUBY_VERSION < '2.7' # rails 6.0 tested with ruby 2.6
   gem 'sqlite3', '~> 1.3.6'
 else
   gem 'sqlite3'

--- a/spec/scripts/features.sh
+++ b/spec/scripts/features.sh
@@ -43,6 +43,7 @@ IMAGE_NAME=${IMAGE_NAME} RUBY_VERSION=${VERSION} USER_ID="$(id -u):$(id -g)" \
   -e INCLUDE_SCHEMA_SPECS=1 \
   -e JDK_JAVA_OPTIONS="${JDK_JAVA_OPTIONS}" \
   -e JRUBY_OPTS="${JRUBY_OPTS}" \
+  -e FRAMEWORKS="${FRAMEWORKS}" \
   -e HOME="/tmp" \
   -v "$(dirname "$(pwd)"):/app" \
   -w /app \


### PR DESCRIPTION
The latest test failures show that the most recent release of [sqlite3 (1.6.0)](https://rubygems.org/gems/sqlite3/versions/1.6.0-x86_64-linux) doesn't support < ruby v2.7