### PR TITLE
Update reference to sinatra main

### DIFF
--- a/.ci/.jenkins_exclude.yml
+++ b/.ci/.jenkins_exclude.yml
@@ -18,7 +18,7 @@ exclude:
   - RUBY_VERSION: ruby:2.4
     FRAMEWORK: rails-main
   - RUBY_VERSION: ruby:2.4
-    FRAMEWORK: sinatra-master
+    FRAMEWORK: sinatra-main
   - RUBY_VERSION: ruby:2.4
     FRAMEWORK: grape-master
 
@@ -61,7 +61,7 @@ exclude:
   - RUBY_VERSION: ruby:2.4
     FRAMEWORK: rails-6.0
 
-  # Only test rails master on ruby 3.1
+  # Only test rails main on ruby 3.1
   - RUBY_VERSION: ruby:3.0
     FRAMEWORK: rails-main
   - RUBY_VERSION: ruby:2.7
@@ -97,23 +97,23 @@ exclude:
   - RUBY_VERSION: docker.elastic.co/observability-ci/jruby:9.2-8-jdk
     FRAMEWORK: rails-7.0
 
-  # Only test sinatra master on ruby 2.7 and ruby 3.1
+  # Only test sinatra main on ruby 2.7 and ruby 3.1
   - RUBY_VERSION: ruby:3.0
-    FRAMEWORK: sinatra-master
+    FRAMEWORK: sinatra-main
   - RUBY_VERSION: ruby:2.6
-    FRAMEWORK: sinatra-master
+    FRAMEWORK: sinatra-main
   - RUBY_VERSION: ruby:2.5
-    FRAMEWORK: sinatra-master
+    FRAMEWORK: sinatra-main
   - RUBY_VERSION: ruby:2.4
-    FRAMEWORK: sinatra-master
+    FRAMEWORK: sinatra-main
   - RUBY_VERSION: jruby:9.2
-    FRAMEWORK: sinatra-master
+    FRAMEWORK: sinatra-main
   - RUBY_VERSION: docker.elastic.co/observability-ci/jruby:9.2-13-jdk
-    FRAMEWORK: sinatra-master
+    FRAMEWORK: sinatra-main
   - RUBY_VERSION: docker.elastic.co/observability-ci/jruby:9.2-11-jdk
-    FRAMEWORK: sinatra-master
+    FRAMEWORK: sinatra-main
   - RUBY_VERSION: docker.elastic.co/observability-ci/jruby:9.2-8-jdk
-    FRAMEWORK: sinatra-master
+    FRAMEWORK: sinatra-main
 
   # Only test grape master on ruby 2.7 and ruby 3.0
   - RUBY_VERSION: ruby:2.6

--- a/.ci/.jenkins_main_framework.yml
+++ b/.ci/.jenkins_main_framework.yml
@@ -1,4 +1,4 @@
 FRAMEWORK:
-  - rails-main
+  #- rails-main
   - sinatra-main
   - grape-master

--- a/.ci/.jenkins_main_framework.yml
+++ b/.ci/.jenkins_main_framework.yml
@@ -1,4 +1,4 @@
 FRAMEWORK:
   - rails-main
-  - sinatra-master
+  - sinatra-main
   - grape-master

--- a/Gemfile
+++ b/Gemfile
@@ -83,9 +83,9 @@ frameworks_versions.each do |framework, version|
   end
 
   case version
-  when 'master' # sinatra, grape
+  when 'master' # grape
     gem framework, github: GITHUB_REPOS.fetch(framework)
-  when 'main' # rails
+  when 'main' # sinatra, rails
     gem framework, github: GITHUB_REPOS.fetch(framework), branch: 'main'
   when /.+/
     gem framework, "~> #{version}.0"


### PR DESCRIPTION
Sinatra now uses the reference `main`