### PR TITLE
Faraday response can be nil

### DIFF
--- a/lib/elastic_apm/spies/faraday.rb
+++ b/lib/elastic_apm/spies/faraday.rb
@@ -109,7 +109,7 @@ module ElasticAPM
                   yield req if block
                 end
               rescue Faraday::ClientError, Faraday::ServerError => e # Faraday::Response::RaiseError
-                status = e.response[:status]
+                status = e.response_status
                 http = span&.context&.http
                 if http && status
                   http.status_code = status.to_s

--- a/spec/elastic_apm/spies/faraday_spec.rb
+++ b/spec/elastic_apm/spies/faraday_spec.rb
@@ -216,6 +216,25 @@ module ElasticAPM
         http = span.context.http
         expect(http.status_code).to match('404')
       end
+
+      it 'should handle a nil response' do
+        WebMock.stub_request(:get, 'http://example.com')
+          .to_raise(Faraday::ClientError)
+
+        with_agent do
+          begin
+            ElasticAPM.with_transaction 'Faraday Middleware test' do
+              client.get('http://example.com')
+            end
+          rescue Faraday::ClientError
+          end
+        end
+        span, = @intercepted.spans
+
+        http = span.context.http
+        expect(http.status_code).to be nil
+      end
+
     end
   end
 end


### PR DESCRIPTION
This bug came up in production for us.

`NoMethodError · undefined method '[]' for nil:NilClass` since  `e.response` can be nil. There is a `response_status` method which will work regardless of if response is nil.