### PR TITLE
fix: don't fail on unpullable images

### DIFF
--- a/.ci/packer_cache.sh
+++ b/.ci/packer_cache.sh
@@ -10,7 +10,10 @@ if [ -x "$(command -v docker)" ]; then
       transformedVersion=$(echo "${version}" | cut -d":" -f2)
       imageName="apm-agent-ruby"
       registryImageName="docker.elastic.co/observability-ci/${imageName}:${transformedName}"
-      (retry 2 docker pull "${registryImageName}")
-      docker tag "${registryImageName}" "${imageName}:${transformedVersion}"
+      if retry 2 docker pull "${registryImageName}"; then
+        docker tag "${registryImageName}" "${imageName}:${transformedVersion}"
+      else
+        printf "Could not pull image %s\n" "${registryImageName}"
+      fi
   done
 fi


### PR DESCRIPTION

## What does this pull request do?

Ignores failures pulling images in `.ci/packer_cache.sh`.

## Why is it important?

Not all of the images in `.ci/.jenkins-ruby.yml` are currently pullable. Some no longer exist (`ruby:3.1`), others now live in dockerhub (the `elasticobservability` images), but we shouldn't let that make the packer build fail.
