### PR TITLE
Add shebang to bench ruby script

### DIFF
--- a/bench/rubyprof.rb
+++ b/bench/rubyprof.rb
@@ -1,3 +1,4 @@
+#!/usr/bin/env ruby
 # frozen_string_literal: true
 
 require 'ruby-prof'


### PR DESCRIPTION
The `check-executables-have-shebangs` GitHub hook is failing because this file is missing a shebang.