### PR TITLE
Skip capturing cookie header when it's set separately

### DIFF
--- a/lib/elastic_apm/context_builder.rb
+++ b/lib/elastic_apm/context_builder.rb
@@ -55,6 +55,9 @@ module ElasticAPM
       request.env = env if config.capture_env?
 
       request.cookies = req.cookies.dup
+      unless request.cookies.empty?
+        request.headers['Cookie'] = SKIPPED if request.headers.has_key?('Cookie')
+      end
 
       context
     end

--- a/spec/elastic_apm/context_builder_spec.rb
+++ b/spec/elastic_apm/context_builder_spec.rb
@@ -54,7 +54,7 @@ module ElasticAPM
 
         expect(request.headers).to eq(
           'Content-Type' => 'application/json',
-          'Cookie' => 'things=1'
+          'Cookie' => '[SKIPPED]'
         )
       end
 


### PR DESCRIPTION
Resolves #1402 

When there are cookies set at `Cookie` in the header and they're captured in the request cookies context field, set the context header value to `[SKIPPED]`.

See https://github.com/elastic/apm-agent-nodejs/pull/3322 for more context.