### PR TITLE
Define separate method for creating sets for use in tests

### DIFF
--- a/lib/elastic_apm/metrics.rb
+++ b/lib/elastic_apm/metrics.rb
@@ -50,27 +50,9 @@ module ElasticAPM
           return
         end
 
+        define_sets
+
         debug 'Starting metrics'
-
-        # Only set the @sets once, in case we stop
-        # and start again.
-        if @sets.nil?
-          sets = {
-            system: CpuMemSet,
-            vm: VMSet,
-            breakdown: BreakdownSet,
-            transaction: TransactionSet
-          }
-          if defined?(JVMSet)
-            debug "Enabling JVM metrics collection"
-            sets[:jvm] = JVMSet
-          end
-
-          @sets = sets.each_with_object({}) do |(key, kls), _sets_|
-            debug "Adding metrics collector '#{kls}'"
-            _sets_[key] = kls.new(config)
-          end
-        end
 
         @timer_task = Concurrent::TimerTask.execute(
           run_now: true,
@@ -133,6 +115,28 @@ module ElasticAPM
           samples = set.collect
           next unless samples
           arr.concat(samples)
+        end
+      end
+
+      def define_sets
+        # Only set the @sets once, in case we stop
+        # and start again.
+        if @sets.nil?
+          sets = {
+            system: CpuMemSet,
+            vm: VMSet,
+            breakdown: BreakdownSet,
+            transaction: TransactionSet
+          }
+          if defined?(JVMSet)
+            debug "Enabling JVM metrics collection"
+            sets[:jvm] = JVMSet
+          end
+
+          @sets = sets.each_with_object({}) do |(key, kls), _sets_|
+            debug "Adding metrics collector '#{kls}'"
+            _sets_[key] = kls.new(config)
+          end
         end
       end
     end

--- a/lib/elastic_apm/metrics.rb
+++ b/lib/elastic_apm/metrics.rb
@@ -121,22 +121,22 @@ module ElasticAPM
       def define_sets
         # Only set the @sets once, in case we stop
         # and start again.
-        if @sets.nil?
-          sets = {
-            system: CpuMemSet,
-            vm: VMSet,
-            breakdown: BreakdownSet,
-            transaction: TransactionSet
-          }
-          if defined?(JVMSet)
-            debug "Enabling JVM metrics collection"
-            sets[:jvm] = JVMSet
-          end
+        return unless @sets.nil?
 
-          @sets = sets.each_with_object({}) do |(key, kls), _sets_|
-            debug "Adding metrics collector '#{kls}'"
-            _sets_[key] = kls.new(config)
-          end
+        sets = {
+          system: CpuMemSet,
+          vm: VMSet,
+          breakdown: BreakdownSet,
+          transaction: TransactionSet
+        }
+        if defined?(JVMSet)
+          debug "Enabling JVM metrics collection"
+          sets[:jvm] = JVMSet
+        end
+
+        @sets = sets.each_with_object({}) do |(key, kls), _sets_|
+          debug "Adding metrics collector '#{kls}'"
+          _sets_[key] = kls.new(config)
         end
       end
     end

--- a/spec/elastic_apm/metrics_spec.rb
+++ b/spec/elastic_apm/metrics_spec.rb
@@ -75,10 +75,11 @@ module ElasticAPM
       after { subject.stop }
 
       it 'samples all samplers' do
-        subject.start
+        subject.define_sets
         subject.sets.each_value do |sampler|
           expect(sampler).to receive(:collect).at_least(:once)
         end
+        subject.start
         subject.collect
       end
     end
@@ -103,10 +104,11 @@ module ElasticAPM
         it 'calls callback' do
           callback = ->(_) {}
           subject = described_class.new(config, &callback)
-          subject.start
+          subject.define_sets
           subject.sets.each_value do |sampler|
             expect(sampler).to receive(:collect).at_least(:once) { nil }
           end
+          subject.start
           expect(callback).to_not receive(:call)
 
           subject.collect_and_send


### PR DESCRIPTION
The tests sometimes fail because the `collect` method is called on the metrics sets before the method is mocked. This happens only on JRuby presumably because it's faster than MRI. This PR extracts the metrics sets definition into another method so it can be called in a test without the collecting timer task being started.