### PR TITLE
changes/fixes to metadata.cloud.* fields collected for GCP

### DIFF
--- a/lib/elastic_apm/metadata/cloud_info.rb
+++ b/lib/elastic_apm/metadata/cloud_info.rb
@@ -102,7 +102,7 @@ module ElasticAPM
         self.project_id = metadata["project"]["projectId"]
         self.availability_zone = zone
         self.region = zone.split("-")[0..-2].join("-")
-        self.machine_type = metadata["instance"]["machineType"].split("/")&.at(-1)
+        self.machine_type = metadata["instance"]["machineType"].split("/")[-1]
       rescue HTTP::TimeoutError, HTTP::ConnectionError
         nil
       end

--- a/lib/elastic_apm/metadata/cloud_info.rb
+++ b/lib/elastic_apm/metadata/cloud_info.rb
@@ -97,13 +97,12 @@ module ElasticAPM
         zone = metadata["instance"]["zone"]&.split("/")&.at(-1)
 
         self.provider = "gcp"
-        self.instance_id = metadata["instance"]["id"]
+        self.instance_id = metadata["instance"]["id"].to_s
         self.instance_name = metadata["instance"]["name"]
-        self.project_id = metadata["project"]["numericProjectId"]
-        self.project_name = metadata["project"]["projectId"]
+        self.project_id = metadata["project"]["projectId"]
         self.availability_zone = zone
         self.region = zone.split("-")[0..-2].join("-")
-        self.machine_type = metadata["instance"]["machineType"]
+        self.machine_type = metadata["instance"]["machineType"].split("/")&.at(-1)
       rescue HTTP::TimeoutError, HTTP::ConnectionError
         nil
       end

--- a/spec/elastic_apm/metadata/cloud_info_spec.rb
+++ b/spec/elastic_apm/metadata/cloud_info_spec.rb
@@ -107,16 +107,12 @@ module ElasticAPM
           subject.fetch!
 
           expect(subject.provider).to eq('gcp')
-          # rubocop:disable Style/NumericLiterals
-          expect(subject.instance_id).to eq(4306570268266786072)
+          expect(subject.instance_id).to eq("4306570268266786072")
           expect(subject.instance_name).to eq("basepi-test")
-          expect(subject.project_id).to eq(513326162531)
-          # rubocop:enable Style/NumericLiterals
-          expect(subject.instance_name).to eq('basepi-test')
-          expect(subject.project_name).to eq('elastic-apm')
+          expect(subject.project_id).to eq('elastic-apm')
           expect(subject.availability_zone).to eq('us-west3-a')
           expect(subject.region).to eq('us-west3')
-          expect(subject.machine_type).to eq('projects/513326162531/machineTypes/n1-standard-1')
+          expect(subject.machine_type).to eq('n1-standard-1')
 
           expect(@gcp_mock).to have_been_requested
         end


### PR DESCRIPTION
- cloud.instance.id must be a string
- change cloud.project.id to be the 'projectId' (per spec change)
- drop cloud.project.name
- fix cloud.machine.type

Closes: https://github.com/elastic/apm-agent-ruby/issues/1414
