### PR TITLE
Pin version of bigdecimal for ruby 2.4

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -132,7 +132,7 @@ if Gem::Version.create(RUBY_VERSION) >= Gem::Version.create('2.5.0') && !defined
 end
 
 if Gem::Version.create(RUBY_VERSION) <= Gem::Version.create('2.5.0')
-  gem 'bigdecimal', '~> 1.3'
+  gem 'bigdecimal', '1.3.5'
 end
 
 group :bench do

--- a/Gemfile
+++ b/Gemfile
@@ -131,6 +131,10 @@ if Gem::Version.create(RUBY_VERSION) >= Gem::Version.create('2.5.0') && !defined
   gem 'sneakers', github: 'jondot/sneakers', ref: 'd761dfe1493', require: nil
 end
 
+if Gem::Version.create(RUBY_VERSION) <= Gem::Version.create('2.5.0')
+  gem 'bigdecimal', '~> 1.3'
+end
+
 group :bench do
   gem 'ruby-prof', require: nil, platforms: %i[ruby]
   gem 'stackprof', require: nil, platforms: %i[ruby]


### PR DESCRIPTION
ruby 2.4 and rails 4.2 tests are failing because the version of bigdecimal installed is too high. The `#new` method is not defined for versions > 1.3.5.
This PR pins the bigdecimal gem version to 1.3.5 for ruby 2.4 as per the documentation for BigDecimal [here](https://github.com/ruby/bigdecimal#which-version-should-you-select)