### PR TITLE
Fix `ActionDispatchSpy#render_exception` for Rails 7.1

### DIFF
--- a/lib/elastic_apm/spies/action_dispatch.rb
+++ b/lib/elastic_apm/spies/action_dispatch.rb
@@ -24,11 +24,19 @@ module ElasticAPM
     class ActionDispatchSpy
       # @api private
       module Ext
-        def render_exception(env, exception)
-          context = ElasticAPM.build_context(rack_env: env, for_type: :error)
+        def render_exception(request, exception_or_wrapper)
+          context = ElasticAPM.build_context(
+            rack_env: request, for_type: :error
+          )
+          exception =
+            if exception_or_wrapper.is_a?(ActionDispatch::ExceptionWrapper)
+              exception_or_wrapper.exception
+            else
+              exception_or_wrapper
+            end
           ElasticAPM.report(exception, context: context, handled: false)
 
-          super(env, exception)
+          super(request, exception_or_wrapper)
         end
       end
 


### PR DESCRIPTION
In Rails 7.1 `render_exception` was changed to take an ActionDispatch::ExceptionWrapper instead of an Exception. I've added support for the new way while keeping support for pre 7.1.