### PR TITLE
Racecar consumer instrumentation improvements

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -22,6 +22,7 @@ endif::[]
 [float]
 ===== Changed
 - Change {pull}2526[#2526]
+- Racecar consumer instrumentation improvements {pull}
 
 [float]
 ===== Fixed

--- a/lib/elastic_apm/spies/racecar.rb
+++ b/lib/elastic_apm/spies/racecar.rb
@@ -47,7 +47,7 @@ require 'active_support/subscriber'
           private # only public methods will be subscribed
 
           def start_process_transaction(event:, kind:)
-            ElasticAPM.start_transaction(kind, TYPE)
+            ElasticAPM.start_transaction("#{event.payload[:consumer_class]}##{kind}", TYPE)
             ElasticAPM.current_transaction.context.set_service(framework_name: 'racecar', framework_version: Racecar::VERSION)
           end
         end
@@ -74,4 +74,5 @@ require 'active_support/subscriber'
 
 rescue LoadError
   # no active support available
+  STDERR.puts "ActiveSupport not found."
 end

--- a/lib/elastic_apm/spies/racecar.rb
+++ b/lib/elastic_apm/spies/racecar.rb
@@ -33,14 +33,24 @@ require 'active_support/subscriber'
           def start_process_message(event)
             start_process_transaction(event: event, kind: 'process_message')
           end
-          def process_message(_event)
+          def process_message(event)
+            transaction = ElasticAPM.current_transaction
+            error_present = !event.payload[:unrecoverable_delivery_error].nil?
+            transaction.outcome = error_present ? Transaction::Outcome::FAILURE : Transaction::Outcome::SUCCESS
+            transaction.done(error_present ? :error : :success)
+
             ElasticAPM.end_transaction
           end
 
           def start_process_batch(event)
             start_process_transaction(event: event, kind: 'process_batch')
           end
-          def process_batch(_event)
+          def process_batch(event)
+            transaction = ElasticAPM.current_transaction
+            error_present = !event.payload[:unrecoverable_delivery_error].nil?
+            transaction.outcome = error_present ? Transaction::Outcome::FAILURE : Transaction::Outcome::SUCCESS
+            transaction.done(error_present ? :error : :success)
+
             ElasticAPM.end_transaction
           end
 

--- a/lib/elastic_apm/spies/racecar.rb
+++ b/lib/elastic_apm/spies/racecar.rb
@@ -16,8 +16,8 @@
 # under the License.
 
 begin
-require 'active_support/notifications'
-require 'active_support/subscriber'
+  require 'active_support/notifications'
+  require 'active_support/subscriber'
 
   # frozen_string_literal: true
   module ElasticAPM
@@ -25,14 +25,15 @@ require 'active_support/subscriber'
     module Spies
       # @api private
       class RacecarSpy
-        TYPE = 'kafka'
-        SUBTYPE = 'racecar'
+        TYPE = 'kafka'.freeze
+        SUBTYPE = 'racecar'.freeze
 
         # @api private
         class ConsumerSubscriber < ActiveSupport::Subscriber
           def start_process_message(event)
             start_process_transaction(event: event, kind: 'process_message')
           end
+
           def process_message(event)
             record_outcome(event: event)
             ElasticAPM.end_transaction
@@ -41,6 +42,7 @@ require 'active_support/subscriber'
           def start_process_batch(event)
             start_process_transaction(event: event, kind: 'process_batch')
           end
+
           def process_batch(event)
             record_outcome(event: event)
             ElasticAPM.end_transaction
@@ -50,7 +52,8 @@ require 'active_support/subscriber'
 
           def start_process_transaction(event:, kind:)
             ElasticAPM.start_transaction("#{event.payload[:consumer_class]}##{kind}", TYPE)
-            ElasticAPM.current_transaction.context.set_service(framework_name: 'racecar', framework_version: Racecar::VERSION)
+            ElasticAPM.current_transaction.context.set_service(framework_name: 'racecar',
+              framework_version: Racecar::VERSION)
           end
 
           def record_outcome(event:)
@@ -61,10 +64,12 @@ require 'active_support/subscriber'
           end
         end
 
+        # @api private
         class ProducerSubscriber < ActiveSupport::Subscriber
-          def start_deliver_message(event)
-            ElasticAPM.start_transaction('deliver_message',TYPE)
-            ElasticAPM.current_transaction.context.set_service(framework_name: 'racecar', framework_version: Racecar::VERSION)
+          def start_deliver_message(_event)
+            ElasticAPM.start_transaction('deliver_message', TYPE)
+            ElasticAPM.current_transaction.context.set_service(framework_name: 'racecar',
+              framework_version: Racecar::VERSION)
           end
 
           def deliver_message(_event)
@@ -80,8 +85,7 @@ require 'active_support/subscriber'
       register 'Racecar', 'racecar', RacecarSpy.new
     end
   end
-
 rescue LoadError
   # no active support available
-  STDERR.puts "ActiveSupport not found."
+  warn "ActiveSupport not found."
 end

--- a/spec/elastic_apm/spies/racecar_spec.rb
+++ b/spec/elastic_apm/spies/racecar_spec.rb
@@ -24,16 +24,16 @@ begin
   require 'racecar'
   module ElasticAPM
     RSpec.describe 'Spy: Racecar', :intercept do
-      let(:instrumentation_payload) {
+      let(:instrumentation_payload) do
         { consumer_class: 'SpecConsumer',
-          topic:          'spec_topic',
-          partition:      '0',
-          offset:         '1',
-          create_time:    Time.now,
-          key:            '1',
-          value:          {key: 'value'},
-          headers:        {key: 'value'} }
-      }
+          topic: 'spec_topic',
+          partition: '0',
+          offset: '1',
+          create_time: Time.now,
+          key: '1',
+          value: { key: 'value' },
+          headers: { key: 'value' } }
+      end
       it 'captures the instrumentation' do
         with_agent do
           ActiveSupport::Notifications.instrument('start_process_message.racecar', instrumentation_payload)
@@ -84,7 +84,6 @@ begin
       end
     end
   end
-
 rescue LoadError # in case we don't have ActiveSupport
-  STDERR.puts "ActiveSupport not found, skipping."
+  warn "ActiveSupport not found, skipping."
 end


### PR DESCRIPTION
## What does this pull request do?

This PR adds better context to Racecar consumer transactions.

1. Transaction naming now includes the consumer class, in a format that is similar to the current Rails instrumentation i.e.: `ConsumerClass#method`
2. Transaction success/failure based on [Racecar's exception handling](https://github.com/zendesk/racecar/blob/a5173bee89c9ac646ed318c12d2e0dd1bc15cdee/lib/racecar/runner.rb#L190)

## Why is it important?

Right now there's only the `process.args` to differ transactions happening in different consumers, which could be problematic since it isn't the default visualization grouping from other libraries. Error handling is also not recorded, what makes transactions be stored with an unknown status.

## Checklist
<!--
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] I have signed the [Contributor License Agreement](https://www.elastic.co/contributor-agreement/).
- [x] My code follows the style guidelines of this project (See `.rubocop.yml`)
- [x] I have rebased my changes on top of the latest main branch
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing [**unit** tests](https://github.com/elastic/apm-agent-ruby/blob/main/CONTRIBUTING.md#testing) pass locally with my changes
- [ ] ~~I have made corresponding changes to the documentation~~
- [x] I have updated [CHANGELOG.asciidoc](CHANGELOG.asciidoc)
- [ ] ~~I have updated [supported-technologies.asciidoc](docs/supported-technologies.asciidoc)~~
- [ ] ~~Added an API method or config option? Document in which version this will be introduced~~

## Related issues

Relates https://github.com/elastic/apm-agent-ruby/pull/1284
