### PR TITLE
Add compatibility for `.trace_with` in graphql-ruby 2.3+

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -34,6 +34,10 @@ endif::[]
 [[release-notes-4.x]]
 === Ruby Agent version 4.x
 
+[float]
+===== Fixed
+- Compatibility with `.trace_with` introduced in graphql-ruby 2.3+ {pull}1446[#1446]
+
 [[release-notes-4.7.2]
 ==== 4.7.2
 

--- a/docs/graphql.asciidoc
+++ b/docs/graphql.asciidoc
@@ -18,6 +18,6 @@ To enable GraphQL support, add the included Tracer to your schema:
 class MySchema < GraphQL::Schema
   # ...
 
-  tracer ElasticAPM::GraphQL # <-- include this
+  trace_with ElasticAPM::GraphQL # <-- include this
 end
 ----

--- a/lib/elastic_apm/graphql.rb
+++ b/lib/elastic_apm/graphql.rb
@@ -48,6 +48,14 @@ module ElasticAPM
       # "authorized" => "graphql.authorized",
     }.freeze
 
+    KEYS_TO_NAME.each_key do |trace_method|
+      module_eval <<-RUBY, __FILE__, __LINE__
+        def #{trace_method}(**data)
+          ::ElasticAPM::GraphQL.trace("#{trace_method}", data) { super }
+        end
+      RUBY
+    end
+
     # rubocop:disable Style/ExplicitBlockArgument
     def self.trace(key, data)
       return yield unless KEYS_TO_NAME.key?(key)

--- a/spec/integration/graphql_spec.rb
+++ b/spec/integration/graphql_spec.rb
@@ -95,7 +95,7 @@ if enabled
 
         class GraphQLTestAppSchema < GraphQL::Schema
           query QueryType
-          tracer ElasticAPM::GraphQL
+          trace_with ElasticAPM::GraphQL
         end
       end
 


### PR DESCRIPTION
## What does this pull request do?

It adds support for `.trace_with` that was added in graphql-ruby as a more performant alternative to `.tracer`. Instead of a single `.trace` method that gets called on all types of events, with the new API the trace module implements a method for each event they want to trace.

## Why is it important?

The `.tracer` API has been deprecated and will be removed in graphql-ruby 3.0.

## Checklist
<!--
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] I have signed the [Contributor License Agreement](https://www.elastic.co/contributor-agreement/).
- [x] My code follows the style guidelines of this project (See `.rubocop.yml`)
- [x] I have rebased my changes on top of the latest main branch
<!--
Update your local repository with the most recent code from the main repo, and rebase your branch on top of the latest main branch. We prefer your initial changes to be squashed into a single commit. Later, if we ask you to make changes, add them as separate commits. This makes them easier to review.
-->
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing [**unit** tests](https://github.com/elastic/apm-agent-ruby/blob/main/CONTRIBUTING.md#testing) pass locally with my changes
<!--
Run the test suite to make sure that nothing is broken. See https://github.com/elastic/apm-agent-ruby/blob/main/CONTRIBUTING.md#testing for details.
-->
- [x] I have made corresponding changes to the documentation
- [x] I have updated [CHANGELOG.asciidoc](CHANGELOG.asciidoc)
- [x] I have updated [supported-technologies.asciidoc](docs/supported-technologies.asciidoc)
- [x] Added an API method or config option? Document in which version this will be introduced
