### PR TITLE
Add test for capture_headers in context_builder

### DIFF
--- a/lib/elastic_apm/context_builder.rb
+++ b/lib/elastic_apm/context_builder.rb
@@ -51,12 +51,14 @@ module ElasticAPM
       request.body = should_capture_body?(for_type) ? get_body(req) : SKIPPED
 
       headers, env = get_headers_and_env(rack_env)
-      request.headers = headers if config.capture_headers?
       request.env = env if config.capture_env?
-
       request.cookies = req.cookies.dup
-      unless request.cookies.empty?
-        request.headers['Cookie'] = SKIPPED if request.headers.has_key?('Cookie')
+
+      if config.capture_headers?
+        request.headers = headers
+        unless request.cookies.empty?
+          request.headers['Cookie'] = SKIPPED if request.headers.has_key?('Cookie')
+        end
       end
 
       context

--- a/spec/elastic_apm/context_builder_spec.rb
+++ b/spec/elastic_apm/context_builder_spec.rb
@@ -115,6 +115,21 @@ module ElasticAPM
           expect(result.request.body.valid_encoding?).to be true
         end
       end
+
+      context 'with capture_headers false' do
+        let(:config) { Config.new capture_headers: false }
+
+        it 'does not break on the cookies' do
+          env = Rack::MockRequest.env_for(
+            '/somewhere/in/there?q=yes',
+            method: 'POST',
+            'HTTP_COOKIE' => 'things=1'
+          )
+          env['HTTP_CONTENT_TYPE'] = 'application/json'
+
+          expect { subject.build(rack_env: env, for_type: :transaction) }.not_to raise_error
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
## What does this pull request do?

[PR#1405](https://github.com/elastic/apm-agent-ruby/pull/1405) introduced a bug where if `capture_headers` is `false`, the `ContextBuilder` will raise "undefined method `has_key?' for nil:NilClass"

## Checklist
<!--
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] I have signed the [Contributor License Agreement](https://www.elastic.co/contributor-agreement/).
- [x] My code follows the style guidelines of this project (See `.rubocop.yml`)
- [x] I have rebased my changes on top of the latest main branch
<!--
Update your local repository with the most recent code from the main repo, and rebase your branch on top of the latest main branch. We prefer your initial changes to be squashed into a single commit. Later, if we ask you to make changes, add them as separate commits. This makes them easier to review.
-->
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing [**unit** tests](https://github.com/elastic/apm-agent-ruby/blob/main/CONTRIBUTING.md#testing) pass locally with my changes
<!--
Run the test suite to make sure that nothing is broken. See https://github.com/elastic/apm-agent-ruby/blob/main/CONTRIBUTING.md#testing for details.
-->
~~- [ ] I have made corresponding changes to the documentation~~
- [x] I have updated [CHANGELOG.asciidoc](CHANGELOG.asciidoc)
~~- [ ] I have updated [supported-technologies.asciidoc](docs/supported-technologies.asciidoc)~~
~~- [ ] Added an API method or config option? Document in which version this will be introduced~~

## Related issues
<!--
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.
- Closes #ISSUE_ID
- Relates #ISSUE_ID
- Requires #ISSUE_ID
- Superseds #ISSUE_ID
-->
