### PR TITLE
Require rack/chunked for versions < 3.1.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -123,10 +123,10 @@ if RUBY_PLATFORM == 'java'
   else
     gem 'activerecord-jdbcsqlite3-adapter', "~> #{rails.tr('.', '')}.0"
   end
-elsif frameworks_versions['rails'] =~ /^(4|5)/
-  gem 'sqlite3', '~> 1.3.6'
 elsif RUBY_VERSION <= '2.7'
   gem 'sqlite3', '~> 1.4.4'
+elsif frameworks_versions['rails'] =~ /^(4|5)/
+  gem 'sqlite3', '~> 1.3.6'
 else
   gem 'sqlite3', '~> 2.0'
 end

--- a/Gemfile
+++ b/Gemfile
@@ -128,7 +128,7 @@ elsif frameworks_versions['rails'] =~ /^(4|5)/
 elsif RUBY_VERSION < '2.7'
   gem 'sqlite3', '~> 1.4.4'
 else
-  gem 'sqlite3'
+  gem 'sqlite3', '~> 2.0'
 end
 
 # sneakers main only supports >=2.5.0

--- a/Gemfile
+++ b/Gemfile
@@ -123,7 +123,7 @@ if RUBY_PLATFORM == 'java'
   else
     gem 'activerecord-jdbcsqlite3-adapter', "~> #{rails.tr('.', '')}.0"
   end
-elsif RUBY_VERSION <= '2.7'
+elsif RUBY_VERSION < '3.0'
   gem 'sqlite3', '~> 1.4.4'
 elsif frameworks_versions['rails'] =~ /^(4|5)/
   gem 'sqlite3', '~> 1.3.6'

--- a/Gemfile
+++ b/Gemfile
@@ -125,7 +125,7 @@ if RUBY_PLATFORM == 'java'
   end
 elsif frameworks_versions['rails'] =~ /^(4|5)/
   gem 'sqlite3', '~> 1.3.6'
-elsif RUBY_VERSION < '2.7'
+elsif RUBY_VERSION <= '2.7'
   gem 'sqlite3', '~> 1.4.4'
 else
   gem 'sqlite3', '~> 2.0'

--- a/spec/support/mock_intake.rb
+++ b/spec/support/mock_intake.rb
@@ -19,7 +19,7 @@
 
 require 'json'
 require 'timeout'
-require 'rack/chunked'
+require 'rack/chunked' if ::Rack.release < '3.1.0'
 
 class MockIntake
   def initialize


### PR DESCRIPTION
`Rack::Chunked` is deprecated in versions >= 3.1.0