### PR TITLE
Check for default gemfile instead on bundler directory 

### DIFF
--- a/lib/elastic_apm/stacktrace_builder.rb
+++ b/lib/elastic_apm/stacktrace_builder.rb
@@ -30,7 +30,7 @@ module ElasticAPM
     JRUBY_ORG_REGEX = %r{org/jruby}.freeze
 
     GEMS_PATH =
-      if defined?(Bundler) && Bundler.default_bundle_dir
+      if defined?(Bundler) && Bundler.default_gemfile
         Bundler.bundle_path.to_s
       else
         Gem.dir


### PR DESCRIPTION

## What does this pull request do?

When the stacktrace helper attempts to find the path of installed gems, it uses a method to verify a default bundler install path that attempts to write to the filesystem. This behavior prevents the apm agent from running on a read-only filesystem. This PR attempts to keep the spirit of the functionality while getting around the need to write to the filesystem. Instead of checking if there is a default bundler path, it checks to see if there's a default gemfile.

## Why is it important?

Without this bug fix, we cannot run the agent on apps in our secure k8s cluster.

## Checklist
<!--
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] I have signed the [Contributor License Agreement](https://www.elastic.co/contributor-agreement/).
- [x] My code follows the style guidelines of this project (See `.rubocop.yml`)
- [x] I have rebased my changes on top of the latest main branch
<!--
Update your local repository with the most recent code from the main repo, and rebase your branch on top of the latest main branch. We prefer your initial changes to be squashed into a single commit. Later, if we ask you to make changes, add them as separate commits. This makes them easier to review.
-->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing [**unit** tests](https://github.com/elastic/apm-agent-ruby/blob/main/CONTRIBUTING.md#testing) pass locally with my changes
<!--
Run the test suite to make sure that nothing is broken. See https://github.com/elastic/apm-agent-ruby/blob/main/CONTRIBUTING.md#testing for details.
-->
- [ ] I have made corresponding changes to the documentation
- [ ] I have updated [CHANGELOG.asciidoc](CHANGELOG.asciidoc)
- [ ] I have updated [supported-technologies.asciidoc](docs/supported-technologies.asciidoc)
- [ ] Added an API method or config option? Document in which version this will be introduced

## Related issues
- Closes 1464
