### PR TITLE
github-action: use oblt-actions/git/setup

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,7 +59,7 @@ jobs:
         with:
           ruby-version: 2.6
       - name: Setup Git
-        uses: elastic/apm-pipeline-library/.github/actions/setup-git@current
+        uses: elastic/oblt-actions/git/setup@v1
       - name: Install build system
         run: .ci/scripts/install-build-system.sh
       - name: rake release:update_branch (only for tags)


### PR DESCRIPTION
## Details

⚠️ This PR was created by an automated tool. Please review the changes carefully. ⚠️ 

NOTE: https://github.com/elastic/apm-pipeline-library has been deprecated in favor of 
https://github.com/elastic/oblt-actions.

If there are any questions, please reach out to the @elastic/observablt-ci
