### PR TITLE
github-action: use elastic/oblt-actions/check-dependent-jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,7 +64,7 @@ jobs:
       - package
     steps:
       - id: check
-        uses: elastic/apm-pipeline-library/.github/actions/check-dependent-jobs@current
+        uses: elastic/oblt-actions/check-dependent-jobs@v1
         with:
-          needs: ${{ toJSON(needs) }}
-      - run: ${{ steps.check.outputs.isSuccess }}
+          jobs: ${{ toJSON(needs) }}
+      - run: ${{ steps.check.outputs.is-success }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -74,10 +74,10 @@ jobs:
       - update-branch
     steps:
       - id: check
-        uses: elastic/apm-pipeline-library/.github/actions/check-dependent-jobs@current
+        uses: elastic/oblt-actions/check-dependent-jobs@v1
         with:
-          needs: ${{ toJSON(needs) }}
-      - run: ${{ steps.check.outputs.isSuccess }}
+          jobs: ${{ toJSON(needs) }}
+      - run: ${{ steps.check.outputs.is-success }}
       - if: ${{ always() && startsWith(github.ref, 'refs/tags') }}
         uses: elastic/oblt-actions/slack/notify-result@v1
         with:


### PR DESCRIPTION
## Details

⚠️ This PR was created by an automated tool. Please review the changes carefully. ⚠️ 

NOTE: https://github.com/elastic/apm-pipeline-library has been archived in favor of 
https://github.com/elastic/oblt-actions.

Requires https://github.com/elastic/oblt-actions/pull/16 to be merged.

If there are any questions, please reach out to the @elastic/observablt-ci
