### PR TITLE
github-action: use elastic/oblt-actions/version-framework

### DIFF
--- a/.github/workflows/run-matrix.yml
+++ b/.github/workflows/run-matrix.yml
@@ -26,11 +26,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - id: generate
-        uses: elastic/apm-pipeline-library/.github/actions/version-framework@current
+        uses: elastic/oblt-actions/version-framework@v1
         with:
-          versionsFile: ${{ inputs.versionsFile }}
-          frameworksFile: ${{ inputs.frameworksFile }}
-          excludedFile: ${{ inputs.excludedFile }}
+          versions-file: ${{ inputs.versionsFile }}
+          frameworks-file: ${{ inputs.frameworksFile }}
+          excluded-file: ${{ inputs.excludedFile }}
   test:
     needs:
       - create-test-matrix


### PR DESCRIPTION
## Details

⚠️ This PR was created by an automated tool. Please review the changes carefully. ⚠️ 

NOTE: https://github.com/elastic/apm-pipeline-library has been archived. 
https://github.com/elastic/oblt-actions is the new repository for the github actions.

Requires https://github.com/elastic/oblt-actions/pull/150 to be merged.

If there are any questions, please reach out to the @elastic/observablt-ci
