### PR TITLE
Support ruby 3.4

### DIFF
--- a/.ci/.exclude.yml
+++ b/.ci/.exclude.yml
@@ -20,6 +20,8 @@ exclude:
 
   # rails-4.2 exclusions
   # Only test on ruby 2.4
+  - VERSION: ruby:3.4
+    FRAMEWORK: rails-4.2
   - VERSION: ruby:3.1
     FRAMEWORK: rails-4.2
   - VERSION: ruby:2.7

--- a/.ci/.exclude.yml
+++ b/.ci/.exclude.yml
@@ -122,6 +122,10 @@ exclude:
     FRAMEWORK: grape-1.6
 
   # only test ruby >= 3.1 with rails 6.1 and rails 7.0
+  - VERSION: ruby:3.4
+    FRAMEWORK: rails-5.2
+  - VERSION: ruby:3.4
+    FRAMEWORK: rails-5.1
   - VERSION: ruby:3.1
     FRAMEWORK: rails-5.2
   - VERSION: ruby:3.1

--- a/.ci/.ruby.yml
+++ b/.ci/.ruby.yml
@@ -1,4 +1,5 @@
 VERSION:
+  - ruby:3.4
   - ruby:3.1
   - ruby:2.7
   - ruby:2.6

--- a/Gemfile
+++ b/Gemfile
@@ -91,6 +91,10 @@ frameworks_versions.each do |framework, version|
     gem 'net-smtp', require: false
   end
 
+  if framework =='rails' && RUBY_VERSION >= '3.4' && ['4.2', '5.2', '6.1'].include?(version)
+    gem 'mutex_m'
+  end
+
   case version
   when 'master' # grape
     gem framework, github: GITHUB_REPOS.fetch(framework)

--- a/lib/elastic_apm/spies/sidekiq.rb
+++ b/lib/elastic_apm/spies/sidekiq.rb
@@ -24,6 +24,7 @@ module ElasticAPM
     class SidekiqSpy
       ACTIVE_JOB_WRAPPER =
         'ActiveJob::QueueAdapters::SidekiqAdapter::JobWrapper'
+      ACTIVE_JOB_WRAPPER_V8 = 'Sidekiq::ActiveJob::Wrapper'
 
       # @api private
       class Middleware
@@ -50,7 +51,7 @@ module ElasticAPM
         klass = job['class']
 
         case klass
-        when ACTIVE_JOB_WRAPPER
+        when ACTIVE_JOB_WRAPPER, ACTIVE_JOB_WRAPPER_V8
           job['wrapped']
         else
           klass

--- a/lib/elastic_apm/stacktrace_builder.rb
+++ b/lib/elastic_apm/stacktrace_builder.rb
@@ -24,7 +24,7 @@ module ElasticAPM
   # @api private
   class StacktraceBuilder
     JAVA_FORMAT = /^(.+)\.([^.]+)\(([^:]+):(\d+)\)$/.freeze
-    RUBY_FORMAT = /^(.+?):(\d+)(?::in `(.+?)')?$/.freeze
+    RUBY_FORMAT = /^(.+?):(\d+)(?::in ['`](.+#)?(.+?)')?$/.freeze
 
     RUBY_VERS_REGEX = %r{ruby(/gems)?[-/](\d+\.)+\d}.freeze
     JRUBY_ORG_REGEX = %r{org/jruby}.freeze
@@ -77,9 +77,9 @@ module ElasticAPM
       ruby_match = line.match(RUBY_FORMAT)
 
       if ruby_match
-        _, file, number, method = ruby_match.to_a
+        _, file, number, module_name, method = ruby_match.to_a
         file.sub!(/\.class$/, '.rb')
-        module_name = nil
+        module_name&.sub!('#', '')
       else
         java_match = line.match(JAVA_FORMAT)
         _, module_name, method, file, number = java_match.to_a

--- a/spec/elastic_apm/spies/mongo_spec.rb
+++ b/spec/elastic_apm/spies/mongo_spec.rb
@@ -52,6 +52,7 @@ module ElasticAPM
         expect(db.instance).to eq 'elastic-apm-test'
         expect(db.type).to eq 'mongodb'
         expect(db.statement).to eq('{"listCollections"=>1}')
+                            .or eq("{\"listCollections\" => 1}")
         expect(db.user).to be nil
 
         destination = span.context.destination
@@ -102,6 +103,7 @@ module ElasticAPM
         expect(db.instance).to eq 'elastic-apm-test'
         expect(db.type).to eq 'mongodb'
         expect(db.statement).to eq('{"find"=>"testing", "filter"=>{"a"=>"bc"}}')
+                            .or eq("{\"find\" => \"testing\", \"filter\" => {\"a\" => \"bc\"}}")
         expect(db.user).to be nil
       end
     end

--- a/spec/integration/mongo_spec.rb
+++ b/spec/integration/mongo_spec.rb
@@ -56,8 +56,10 @@ module ElasticAPM
       db = span.context.db
       expect(db.instance).to eq 'elastic-apm-test'
       expect(db.type).to eq 'mongodb'
-      expect(db.statement).to include '{"listCollections"=>1, "cursor"=>{}, ' \
-        '"nameOnly"=>true'
+      expect(db.statement).to include('{"listCollections"=>1, "cursor"=>{}, ' \
+        '"nameOnly"=>true')
+                          .or include('{"listCollections" => 1, "cursor" => {}, ' \
+        '"nameOnly" => true')
       expect(db.user).to be nil
     end
 
@@ -93,6 +95,7 @@ module ElasticAPM
       expect(db.instance).to eq 'elastic-apm-test'
       expect(db.type).to eq 'mongodb'
       expect(db.statement).to match('"delete"=>"testing"')
+                          .or match('"delete" => "testing"')
       expect(db.user).to be nil
     end
 
@@ -124,7 +127,8 @@ module ElasticAPM
       db = span.context.db
       expect(db.instance).to eq 'elastic-apm-test'
       expect(db.type).to eq 'mongodb'
-      expect(db.statement).to include '{"a"=>BSON::Decimal128(\'1\')}'
+      expect(db.statement).to include('{"a"=>BSON::Decimal128(\'1\')}')
+                          .or include('{"a" => BSON::Decimal128(\'1\')}')
       expect(db.user).to be nil
     end
 
@@ -157,7 +161,8 @@ module ElasticAPM
       db = find_span.context.db
       expect(db.instance).to eq 'elastic-apm-test'
       expect(db.type).to eq 'mongodb'
-      expect(db.statement).to include '{"find"=>"testing"'
+      expect(db.statement).to include('{"find"=>"testing"')
+                          .or include('{"find" => "testing"')
       expect(db.user).to be nil
 
       expect(get_more_span.name).to eq 'elastic-apm-test.testing.getMore'
@@ -169,7 +174,8 @@ module ElasticAPM
       db = get_more_span.context.db
       expect(db.instance).to eq 'elastic-apm-test'
       expect(db.type).to eq 'mongodb'
-      expect(db.statement).to include '{"getMore"=>#<BSON::Int64'
+      expect(db.statement).to include('{"getMore"=>#<BSON::Int64')
+                          .or include('{"getMore" => #<BSON::Int64')
       expect(db.user).to be nil
     end
 


### PR DESCRIPTION
## What does this pull request do?

This fixes the parsing of stack traces in the latest version of ruby.

Ruby 3.4 made a few changes to how traces are formatted:

1. The opening backtick is now a single quote
2. The module name is now included.

```
# ruby 3.3.6:
apm-agent-ruby/spec/support/exception_helpers.rb:22:in `/'

# ruby 3.4.1:
apm-agent-ruby/spec/support/exception_helpers.rb:22:in 'Integer#/'
```

These changes cause problems when the agent parses the string, which manifests as a validation error. 

```
[ElasticAPM] [THREAD:14736]: Closing request with reason scheduled_flush
[ElasticAPM] APM Server responded with an error:
"{\"accepted\":2,\"errors\":[{\"message\":\"validation error: error: exception: stacktrace: requires at least one of the fields 'classname;filename'\",\"document\":\"{\\\"error\\\":{\\\"id\\\":\\\"[key here]\\\",\\\"transaction_id\\\":null,\\\"transaction\\\":null,\\\"trace_id\\\":null,\\\"parent_id\\\":null,\\\"culprit\\\":null,\\\"timestamp\\\":1735577232664940,\\\"exception\\\":{\\\"message\\\":\\\"divided by 0\\\",\\\"type\\\":\\\"ZeroDivisionError\\\",\\\"module\\\":\\\"\\\",\\\"code\\\":null,\\\"attributes\\\":null,\\\"stacktrace\\\":[{\\\"abs_path\\\":null,\\\"filename\\\":null,\\\"function\\\":null,\\\"lineno\\\":0,\\\"library_frame\\\":false},{\\\"abs_path\\\":null,\\\"filename\\\":null,\\\"function\\\":null,\\\"lineno\\\":0,\\\"library_frame\\\":false},{\\\"abs_path\\\":null,\\\"filename\\\":null,\\\"function\\\":null,\\\"lineno\\\":0,\\\"library_frame\\\":false},{\\\"abs_path\\\":null,\\\"filename\\\":null,\\\"function\\\":null,\\\"lineno\\\":0,\\\"library_frame\\\":false},{\\\"abs_path\\\":null,\\\"filename\\\":null,\\\"function\\\":null,\\\"lineno\\\":0,\\\"library_frame\\\":false},{\\\"abs_path\\\":null,\\\"filename\\\":null,\\\"function\\\":null,\\\"lineno\\\":0,\\\"library_frame\\\":false},{\\\"abs_path\\\":null,\\\"filename\\\":null,\\\"function\\\":null,\\\"lineno\\\":0,\\\"library_frame\\\":false},{\\\"abs_path\\\":null,\\\"filename\\\":null,\\\"function\\\":null,\\\"lineno\\\":0,\\\"library_frame\\\":false},{\\\"abs_path\\\":null,\\\"filename\\\":null,\\\"function\\\":null,\\\"lineno\\\":0,\\\"library_frame\\\":false},{\\\"abs_path\\\":null,\\\"filename\\\":null,\\\"function\\\":null,\\\"lineno\\\":0,\\\"library_frame\\\":false},{\\\"abs_path\\\":null,\\\"filename\\\":null,\\\"function\\\":null,\\\"lineno\\\":0,\\\"library_frame\\\":false},{\\\"abs_path\\\":null,\\\"filename\\\":null,\\\"function\\\":null,\\\"lineno\\\":0,\\\"library_frame\\\":false},{\\\"abs_path\\\":null,\\\"filename\\\":null,\\\"function\\\":null,\\\"lineno\\\":0,\\\"library_frame\\\":false},{\\\"abs_path\\\":null,\\\"filename\\\":null,\\\"function\\\":null,\\\"lineno\\\":0,\\\"library_frame\\\":false},{\\\"abs_path\\\":null,\\\"filename\\\":null,\\\"function\\\":null,\\\"lineno\\\":0,\\\"library_frame\\\":false},{\\\"abs_path\\\":null,\\\"filename\\\":null,\\\"function\\\":null,\\\"lineno\\\":0,\\\"library_frame\\\":false},{\\\"abs_path\\\":null,\\\"filename\\\":null,\\\"function\\\":null,\\\"lineno\\\":0,\\\"library_frame\\\":false},{\\\"abs_path\\\":null,\\\"filename\\\":null,\\\"function\\\":null,\\\"lineno\\\":0,\\\"library_frame\\\":false},{\\\"abs_path\\\":null,\\\"filename\\\":null,\\\"function\\\":null,\\\"lineno\\\":0,\\\"library_frame\\\":false},{\\\"abs_path\\\":null,\\\"filename\\\":null,\\\"function\\\":null,\\\"lineno\\\":0,\\\"library_frame\\\":false},{\\\"abs_path\\\":null,\\\"filename\\\":null,\\\"function\\\":null,\\\"lineno\\\":0,\\\"library_frame\\\":false},{\\\"abs_path\\\":null,\\\"filename\\\":null,\\\"function\\\":null,\\\"lineno\\\":0,\\\"library_frame\\\":false},{\\\"abs_path\\\":null,\\\"filename\\\":null,\\\"function\\\":null,\\\"lineno\\\":0,\\\"library_frame\\\":false},{\\\"abs_path\\\":null,\\\"filename\\\":null,\\\"function\\\":null,\\\"lineno\\\":0,\\\"library_frame\\\":false},{\\\"abs_path\\\":null,\\\"filename\\\":null,\\\"function\\\":null,\\\"lineno\\\":0,\\\"library_frame\\\":false},{\\\"abs_path\\\":null,\\\"filename\\\":null,\\\"function\\\":null,\\\"lineno\\\":0,\\\"library_frame\\\":false},{\\\"abs_path\\\":null,\\\"filename\\\":null,\\\"function\\\":null,\\\"lineno\\\":0,\\\"library_frame\\\":false},{\\\"abs_path\\\":null,\\\"filename\\\":null,\\\"function\\\":null,\\\"lineno\\\":0,\\\"library_frame\\\":false},{\\\"abs_path\\\":null,\\\"filename\\\":null,\\\"function\\\":null,\\\"lineno\\\":0,\\\"library_frame\\\":false},{\\\"abs_path\\\":null,\\\"filename\\\":null,\\\"function\\\":null,\\\"lineno\\\":0,\\\"library_frame\\\":false},{\\\"abs_path\\\":null,\\\"filename\\\":null,\\\"function\\\":null,\\\"lineno\\\":0,\\\"library_frame\\\":false},{\\\"abs_path\\\":null,\\\"filename\\\":null,\\\"function\\\":null,\\\"lineno\\\":0,\\\"library_frame\\\":false},{\\\"abs_path\\\":null,\\\"filename\\\":null,\\\"function\\\":null,\\\"lineno\\\":0,\\\"library_frame\\\":false}],\\\"handled\\\":true,\\\"cause\\\":null}}}\"}]}\n"
```

## Why is it important?

This will block users of APM from upgrading to ruby 3.4.

## Checklist

- [x] I have signed the [Contributor License Agreement](https://www.elastic.co/contributor-agreement/).
- [x] My code follows the style guidelines of this project (See `.rubocop.yml`)
- [x] I have rebased my changes on top of the latest main branch
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing [**unit** tests](https://github.com/elastic/apm-agent-ruby/blob/main/CONTRIBUTING.md#testing) pass locally with my changes
- [x] I have made corresponding changes to the documentation
- [x] I have updated [CHANGELOG.asciidoc](CHANGELOG.asciidoc)
- [ ] ~~I have updated [supported-technologies.asciidoc](docs/supported-technologies.asciidoc)~~
- [ ] ~~Added an API method or config option? Document in which version this will be introduced~~

## Related issues

- Closes #1509
