### PR TITLE
[docs] Update mapped_pages

### DIFF
--- a/docs/reference/logs.md
+++ b/docs/reference/logs.md
@@ -1,6 +1,5 @@
 ---
 mapped_pages:
-  - https://www.elastic.co/guide/en/apm/agent/ruby/master/logs.html
   - https://www.elastic.co/guide/en/apm/agent/ruby/current/log-correlation.html
 ---
 


### PR DESCRIPTION
Updates `mapped_pages` to be compatible with the _View previous version_ link.