### PR TITLE
update for JSON.parse! calling JSON.parse

### DIFF
--- a/spec/integration/json_spy_spec.rb
+++ b/spec/integration/json_spy_spec.rb
@@ -48,7 +48,7 @@ module ElasticAPM
         end
       end
 
-      expect(@intercepted.spans.length).to be 1
+      expect(@intercepted.spans.length).to be >= 1
       expect(@intercepted.spans.last.name).to eq 'JSON#parse!'
     end
 


### PR DESCRIPTION
`JSON.parse!` calls `JSON.parse` as of version 2.11.0, so two spans are created with `JSON.parse!` is called.

See [this PR](https://github.com/ruby/json/commit/f411ddf1ceaf1ea82c8470c94da522919a4fb3c9#diff-e08e7b431f64661c031319f3bbbec311665959cd74a86f605975fe62ffe8c93dR366-R371)