### PR TITLE
github-action: add supported GitHub commands

### DIFF
--- a/.github/workflows/github-commands-comment.yml
+++ b/.github/workflows/github-commands-comment.yml
@@ -1,0 +1,38 @@
+---
+name: github-commands-comment
+
+on:
+  pull_request_target:
+    types:
+      - opened
+
+permissions:
+  contents: read
+
+jobs:
+  comment:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
+    steps:
+      - uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+        with:
+          script: |
+            const body = `
+              ### :robot: GitHub comments
+
+              <details><summary>Expand to view the GitHub comments</summary>
+              <p>
+
+              Just comment with:
+              - `run` `docs-build` : Re-trigger the docs validation. (use unformatted text in the comment!)
+              </p>
+              </details>
+            `.replace(/  +/g, '')
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: body
+            })


### PR DESCRIPTION
## Details

⚠️ This PR was created by an automated tool. Please review the changes carefully. ⚠️ 

Explicitly explain what GitHub commands are supported.

## Why

We want to improve our user experience and make it easier for those GitHub commands
that are supported by the Elastic CI Ecosystem.

If there are any questions, please reach out to the @elastic/observablt-ci
