### PR TITLE
github-actions: fix comment format

### DIFF
--- a/.github/workflows/github-commands-comment.yml
+++ b/.github/workflows/github-commands-comment.yml
@@ -13,7 +13,6 @@ jobs:
   comment:
     runs-on: ubuntu-latest
     permissions:
-      issues: write
       pull-requests: write
     steps:
       - uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
@@ -26,7 +25,7 @@ jobs:
               <p>
 
               Just comment with:
-              - `run` `docs-build` : Re-trigger the docs validation. (use unformatted text in the comment!)
+              - \`run\` \`docs-build\` : Re-trigger the docs validation. (use unformatted text in the comment!)
               </p>
               </details>
             `.replace(/  +/g, '')

--- a/.github/workflows/github-commands-comment.yml
+++ b/.github/workflows/github-commands-comment.yml
@@ -15,24 +15,4 @@ jobs:
     permissions:
       pull-requests: write
     steps:
-      - uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
-        continue-on-error: true
-        with:
-          script: |
-            const body = `
-              ### :robot: GitHub comments
-
-              <details><summary>Expand to view the GitHub comments</summary>
-              <p>
-
-              Just comment with:
-              - \`run\` \`docs-build\` : Re-trigger the docs validation. (use unformatted text in the comment!)
-              </p>
-              </details>
-            `.replace(/  +/g, '')
-            github.rest.issues.createComment({
-              issue_number: context.issue.number,
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              body: body
-            })
+      - uses: elastic/oblt-actions/elastic/github-commands@v1

--- a/.github/workflows/github-commands-comment.yml
+++ b/.github/workflows/github-commands-comment.yml
@@ -16,6 +16,7 @@ jobs:
       pull-requests: write
     steps:
       - uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+        continue-on-error: true
         with:
           script: |
             const body = `


### PR DESCRIPTION
Leftover from the automated PR:
- https://github.com/elastic/apm-agent-ruby/pull/1549

It uses [elastic/oblt-actions@main/elastic/github-commands](https://github.com/elastic/oblt-actions/tree/main/elastic/github-commands)

Unfortunately, `pull_request_target` cannot be tested unless it's merged :/