### PR TITLE
[docs] Add `products` to `docset.yml`

### DIFF
--- a/docs/docset.yml
+++ b/docs/docset.yml
@@ -1,4 +1,6 @@
 project: 'APM Ruby agent docs'
+products:
+  - id: apm-agent
 cross_links:
   - apm-agent-rum-js
   - docs-content


### PR DESCRIPTION
Related to https://github.com/elastic/docs-builder/issues/1200

Add `products` to `docset.yml` to be used in the search experience.

cc @KOTungseth 