### PR TITLE
Add applies_to metadata

### DIFF
--- a/docs/reference/advanced-topics.md
+++ b/docs/reference/advanced-topics.md
@@ -7,10 +7,6 @@ applies_to:
     observability:
   product:
     apm_agent_ruby: ga
-products:
-  - id: cloud-serverless
-  - id: observability
-  - id: apm
 ---
 
 # Advanced topics [advanced]

--- a/docs/reference/api-reference.md
+++ b/docs/reference/api-reference.md
@@ -7,10 +7,6 @@ applies_to:
     observability:
   product:
     apm_agent_ruby: ga
-products:
-  - id: cloud-serverless
-  - id: observability
-  - id: apm
 ---
 
 # API reference [api]

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -7,10 +7,6 @@ applies_to:
     observability:
   product:
     apm_agent_ruby: ga
-products:
-  - id: cloud-serverless
-  - id: observability
-  - id: apm
 ---
 
 # Configuration [configuration]

--- a/docs/reference/context.md
+++ b/docs/reference/context.md
@@ -7,10 +7,6 @@ applies_to:
     observability:
   product:
     apm_agent_ruby: ga
-products:
-  - id: cloud-serverless
-  - id: observability
-  - id: apm
 ---
 
 # Adding additional context [context]

--- a/docs/reference/custom-instrumentation.md
+++ b/docs/reference/custom-instrumentation.md
@@ -7,10 +7,6 @@ applies_to:
     observability:
   product:
     apm_agent_ruby: ga
-products:
-  - id: cloud-serverless
-  - id: observability
-  - id: apm
 ---
 
 # Custom instrumentation [custom-instrumentation]

--- a/docs/reference/getting-started-rack.md
+++ b/docs/reference/getting-started-rack.md
@@ -7,10 +7,6 @@ applies_to:
     observability:
   product:
     apm_agent_ruby: ga
-products:
-  - id: cloud-serverless
-  - id: observability
-  - id: apm
 ---
 
 # Getting started with Rack [getting-started-rack]

--- a/docs/reference/getting-started-rails.md
+++ b/docs/reference/getting-started-rails.md
@@ -7,10 +7,6 @@ applies_to:
     observability:
   product:
     apm_agent_ruby: ga
-products:
-  - id: cloud-serverless
-  - id: observability
-  - id: apm
 ---
 
 # Getting started with Rails [getting-started-rails]

--- a/docs/reference/graphql.md
+++ b/docs/reference/graphql.md
@@ -7,10 +7,6 @@ applies_to:
     observability:
   product:
     apm_agent_ruby: ga
-products:
-  - id: cloud-serverless
-  - id: observability
-  - id: apm
 ---
 
 # GraphQL [graphql]

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -8,10 +8,6 @@ applies_to:
     observability:
   product:
     apm_agent_ruby: ga
-products:
-  - id: cloud-serverless
-  - id: observability
-  - id: apm
 ---
 
 # APM Ruby agent [introduction]

--- a/docs/reference/logs.md
+++ b/docs/reference/logs.md
@@ -7,10 +7,6 @@ applies_to:
     observability:
   product:
     apm_agent_ruby: ga
-products:
-  - id: cloud-serverless
-  - id: observability
-  - id: apm
 ---
 
 # Logs [logs]

--- a/docs/reference/metrics.md
+++ b/docs/reference/metrics.md
@@ -7,10 +7,6 @@ applies_to:
     observability:
   product:
     apm_agent_ruby: ga
-products:
-  - id: cloud-serverless
-  - id: observability
-  - id: apm
 ---
 
 # Metrics [metrics]

--- a/docs/reference/opentracing-api.md
+++ b/docs/reference/opentracing-api.md
@@ -7,10 +7,6 @@ applies_to:
     observability:
   product:
     apm_agent_ruby: ga
-products:
-  - id: cloud-serverless
-  - id: observability
-  - id: apm
 ---
 
 # OpenTracing API [opentracing]

--- a/docs/reference/performance-tuning.md
+++ b/docs/reference/performance-tuning.md
@@ -7,10 +7,6 @@ applies_to:
     observability:
   product:
     apm_agent_ruby: ga
-products:
-  - id: cloud-serverless
-  - id: observability
-  - id: apm
 ---
 
 # Performance tuning [tuning-and-overhead]

--- a/docs/reference/set-up-apm-ruby-agent.md
+++ b/docs/reference/set-up-apm-ruby-agent.md
@@ -7,10 +7,6 @@ applies_to:
     observability:
   product:
     apm_agent_ruby: ga
-products:
-  - id: cloud-serverless
-  - id: observability
-  - id: apm
 ---
 
 # Set up the APM Ruby agent [set-up]

--- a/docs/reference/supported-technologies.md
+++ b/docs/reference/supported-technologies.md
@@ -7,10 +7,6 @@ applies_to:
     observability:
   product:
     apm_agent_ruby: ga
-products:
-  - id: cloud-serverless
-  - id: observability
-  - id: apm
 ---
 
 # Supported technologies [supported-technologies]

--- a/docs/reference/upgrading.md
+++ b/docs/reference/upgrading.md
@@ -7,10 +7,6 @@ applies_to:
     observability:
   product:
     apm_agent_ruby: ga
-products:
-  - id: cloud-serverless
-  - id: observability
-  - id: apm
 ---
 
 # Upgrading [upgrading]

--- a/docs/release-notes/index.md
+++ b/docs/release-notes/index.md
@@ -9,10 +9,6 @@ applies_to:
     observability:
   product:
     apm_agent_ruby: ga
-products:
-  - id: cloud-serverless
-  - id: observability
-  - id: apm
 ---
 
 # Elastic APM Ruby Agent release notes [elastic-apm-ruby-agent-release-notes]

--- a/docs/release-notes/known-issues.md
+++ b/docs/release-notes/known-issues.md
@@ -6,10 +6,6 @@ applies_to:
     observability:
   product:
     apm_agent_ruby: ga
-products:
-  - id: cloud-serverless
-  - id: observability
-  - id: apm
 ---
 
 # Elastic APM Ruby Agent known issues [elastic-apm-ruby-agent-known-issues]


### PR DESCRIPTION
Adds ` applies_to` metadata for cumulative docs. See https://docs-v3-preview.elastic.dev/elastic/docs-builder/tree/main/syntax/applies

Contributes to https://github.com/elastic/docs-content-internal/issues/253