### PR TITLE
use status code explicitly in central config

### DIFF
--- a/lib/elastic_apm/central_config.rb
+++ b/lib/elastic_apm/central_config.rb
@@ -75,7 +75,7 @@ module ElasticAPM
       resp = perform_request
 
       # rubocop:disable Lint/DuplicateBranch
-      case resp.status
+      case resp.status.code
       when 200..299
         resp
       when 300..399


### PR DESCRIPTION
## Summary

  In `http 6.0.0`, `HTTP::Response::Status` was [changed](https://github.com/httprb/http/blob/main/CHANGELOG.md#changed-4) from inheriting `Delegator` to using `Comparable` + `Forwardable`. This breaks `Range#===` in `CentralConfig#fetch_config`:

  ```ruby
  status = HTTP::Response::Status.new(200)
  (200..299) === status      # => false (http 6.x)
  (200..299) === status.to_i # => true
```

  The case falls through all branches, returns nil, and handle_success(nil) raises NoMethodError: undefined method 'headers' for nil — breaking central config polling silently.

### Fix

  ```case resp.status → case resp.status.code in central_config.rb.```

###  Note on v4.8.0

  This bug is live in `v4.8.0`, which has no upper bound on the http dependency `(>= 3.0)`. When Bundler resolves `http 6.x`, central config breaks silently. A patch release is needed to ship this fix to existing users.

### Reproduction
```
  require "http" # v6.x

  status = HTTP::Response::Status.new(200)

  result = case status
           when 200..299 then :matched
           end

  puts result.inspect  # => nil (expected :matched)
```

###  Environment

  - elastic-apm 4.8.0
  - http 6.0.2
  - Ruby 3.3.4


Resolves #1632