### PR TITLE
fix(ci,test): stabilize JRuby and Rails matrix by hardening dependency resolution, test synchronization, and legacy image builds

### DIFF
--- a/.ci/.exclude.yml
+++ b/.ci/.exclude.yml
@@ -103,7 +103,11 @@ exclude:
   - VERSION: elasticobservability/jruby:9.2-8-jdk
     FRAMEWORK: sinatra-main
 
-  # Only test grape master on ruby 2.7 and ruby 3.1
+  # Only test grape master on ruby >= 3.2
+  - VERSION: ruby:3.1
+    FRAMEWORK: grape-master
+  - VERSION: ruby:2.7
+    FRAMEWORK: grape-master
   - VERSION: ruby:2.6
     FRAMEWORK: grape-master
   - VERSION: ruby:2.4

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,10 +9,18 @@ ARG BUNDLER_VERSION
 # For tzdata
 # ENV DEBIAN_FRONTEND=noninteractive
 
-RUN apt-get update -qq \
-      && apt-get install -qq -y --no-install-recommends \
-        build-essential libpq-dev git netbase \
-      && rm -rf /var/lib/apt/lists/*
+RUN set -eux; \
+      apt-get update -qq || ( \
+        find /etc/apt -name '*.list' -type f -print0 | xargs -0 sed -i \
+          -e 's|deb.debian.org/debian|archive.debian.org/debian|g' \
+          -e 's|security.debian.org/debian-security|archive.debian.org/debian-security|g'; \
+        find /etc/apt -name '*.list' -type f -print0 | xargs -0 sed -i '/buster-updates/d'; \
+        printf 'Acquire::Check-Valid-Until "false";\n' > /etc/apt/apt.conf.d/99no-check-valid; \
+        apt-get -o Acquire::Check-Valid-Until=false update -qq \
+      ); \
+      apt-get install -qq -y --no-install-recommends \
+        build-essential libpq-dev git netbase; \
+      rm -rf /var/lib/apt/lists/*
 
 # Configure bundler and PATH
 ENV LANG=C.UTF-8
@@ -36,12 +44,18 @@ RUN set -eux; \
       else \
         gem update --system; \
       fi; \
-      gem install bundler:$BUNDLER_VERSION
+      if ruby -e 'require "rubygems"; exit(Gem::Version.new(RUBY_VERSION) < Gem::Version.new("2.5") ? 0 : 1)'; then \
+        gem install bundler:1.17.3; \
+      else \
+        gem install bundler:$BUNDLER_VERSION; \
+      fi
 
 # Use unpatched, system version for more speed over less security.
-# JRuby 9.2 reports Ruby 2.5, so pin nokogiri to the last supported release.
+# Pin Nokogiri by Ruby compatibility to support old CI targets (e.g. Ruby 2.4).
 RUN set -eux; \
-      if ruby -e 'require "rubygems"; exit(Gem::Version.new(RUBY_VERSION) < Gem::Version.new("3.2") ? 0 : 1)'; then \
+      if ruby -e 'require "rubygems"; exit(Gem::Version.new(RUBY_VERSION) < Gem::Version.new("2.5") ? 0 : 1)'; then \
+        gem install nokogiri -v 1.10.10 -- --use-system-libraries; \
+      elif ruby -e 'require "rubygems"; exit(Gem::Version.new(RUBY_VERSION) < Gem::Version.new("3.2") ? 0 : 1)'; then \
         gem install nokogiri -v 1.12.5 -- --use-system-libraries; \
       else \
         gem install nokogiri -- --use-system-libraries; \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG RUBY_IMAGE
+ARG RUBY_IMAGE=ruby:3.3
 FROM ${RUBY_IMAGE}
 
 ARG USER_ID_GROUP
@@ -11,7 +11,7 @@ ARG BUNDLER_VERSION
 
 RUN apt-get update -qq \
       && apt-get install -qq -y --no-install-recommends \
-        build-essential libpq-dev git \
+        build-essential libpq-dev git netbase \
       && rm -rf /var/lib/apt/lists/*
 
 # Configure bundler and PATH
@@ -29,15 +29,27 @@ ENV FRAMEWORKS $FRAMEWORKS
 RUN mkdir -p $VENDOR_PATH \
       && chown -R $USER_ID_GROUP $VENDOR_PATH
 
-USER $USER_ID_GROUP
-
-# Upgrade RubyGems and install required Bundler version
-RUN gem update --system && \
+# Upgrade RubyGems with a Ruby-version-compatible strategy and install Bundler.
+RUN set -eux; \
+      if ruby -e 'require "rubygems"; exit(Gem::Version.new(RUBY_VERSION) < Gem::Version.new("3.2") ? 0 : 1)'; then \
+        gem update --system 3.2.3; \
+      else \
+        gem update --system; \
+      fi; \
       gem install bundler:$BUNDLER_VERSION
 
-# Use unpatched, system version for more speed over less security
-RUN gem install nokogiri -- --use-system-libraries
+# Use unpatched, system version for more speed over less security.
+# JRuby 9.2 reports Ruby 2.5, so pin nokogiri to the last supported release.
+RUN set -eux; \
+      if ruby -e 'require "rubygems"; exit(Gem::Version.new(RUBY_VERSION) < Gem::Version.new("3.2") ? 0 : 1)'; then \
+        gem install nokogiri -v 1.12.5 -- --use-system-libraries; \
+      else \
+        gem install nokogiri -- --use-system-libraries; \
+      fi
 # Rake is required to build http-parser on some jruby images
 RUN gem install rake
+
+RUN chown -R $USER_ID_GROUP $VENDOR_PATH
+USER $USER_ID_GROUP
 
 WORKDIR /app

--- a/Gemfile
+++ b/Gemfile
@@ -59,7 +59,6 @@ gem 'rake', '>= 13.0', require: nil
 gem 'racecar', require: nil if !defined?(JRUBY_VERSION)
 gem 'resque', require: nil
 gem 'sequel', require: nil
-gem 'shoryuken', require: nil
 gem 'sidekiq', require: nil
 gem 'simplecov', require: false
 gem 'simplecov-cobertura', require: false
@@ -127,6 +126,14 @@ if frameworks_versions.key?('rails')
       gem 'delayed_job', require: nil
     end
   end
+end
+
+# Shoryuken 7.x references ActiveJob::QueueAdapters::AbstractAdapter, which
+# is missing in the Ruby 3.4 + Rails 6.1 matrix target.
+if frameworks_versions['rails'] == '6.1' && RUBY_VERSION >= '3.4'
+  gem 'shoryuken', '< 7.0', require: nil
+else
+  gem 'shoryuken', require: nil
 end
 
 if RUBY_PLATFORM == 'java'

--- a/Gemfile
+++ b/Gemfile
@@ -119,8 +119,13 @@ if frameworks_versions.key?('grape')
 end
 
 if frameworks_versions.key?('rails')
-  unless /^(main|6)/.match?(frameworks_versions['rails'])
-    gem 'delayed_job', require: nil
+  rails_version = frameworks_versions['rails']
+  unless /^(main|6)/.match?(rails_version)
+    if rails_version.start_with?('4.')
+      gem 'delayed_job', '~> 4.1.13', require: nil
+    else
+      gem 'delayed_job', require: nil
+    end
   end
 end
 

--- a/Gemfile
+++ b/Gemfile
@@ -121,7 +121,7 @@ end
 if frameworks_versions.key?('rails')
   rails_version = frameworks_versions['rails']
   unless /^(main|6)/.match?(rails_version)
-    if rails_version.start_with?('4.')
+    if rails_version.start_with?('4.') || rails_version.start_with?('5.')
       gem 'delayed_job', '~> 4.1.13', require: nil
     else
       gem 'delayed_job', require: nil

--- a/Gemfile
+++ b/Gemfile
@@ -107,9 +107,15 @@ frameworks_versions.each do |framework, version|
   end
 end
 
-# Handle Rack::Auth::Digest being removed in rack 3.1, grape requires it
+# Handle Rack::Auth::Digest being removed in rack 3.1, grape requires it.
+# Sinatra 2.x depends on rack 2.x, so use a compatible rack line when both are present.
 if frameworks_versions.key?('grape')
-  gem 'rack', '~> 3.0.0'
+  sinatra_version = frameworks_versions['sinatra']
+  if sinatra_version&.start_with?('2.')
+    gem 'rack', '~> 2.2.0'
+  else
+    gem 'rack', '~> 3.0.0'
+  end
 end
 
 if frameworks_versions.key?('rails')

--- a/bin/dev
+++ b/bin/dev
@@ -36,7 +36,10 @@ FRAMEWORKS = options.fetch(:frameworks, default_frameworks)
 IMAGE_PATH_SAFE = RUBY_IMAGE.tr(':', '_')
 IMAGE_NAME = "apm-agent-ruby:#{IMAGE_PATH_SAFE}"
 VENDOR_PATH = "/vendor/#{IMAGE_PATH_SAFE}"
-DOCKER_PLATFORM = RUBY_IMAGE.include?('jruby') ? 'linux/amd64' : nil
+legacy_ruby_image = RUBY_IMAGE.match?(/^ruby:(2\.[0-9]+|1\.[0-9]+)/)
+DOCKER_PLATFORM = if RUBY_IMAGE.include?('jruby') || legacy_ruby_image
+                    'linux/amd64'
+                  end
 
 def run(cmd)
   env = ["IMAGE_NAME=#{IMAGE_NAME}"]

--- a/bin/dev
+++ b/bin/dev
@@ -26,14 +26,23 @@ end.parse!
 USER_ID_GROUP = %w[u g].map { |f| `id -#{f}`.chomp }.join(':')
 
 RUBY_IMAGE = options.fetch(:image, 'ruby:latest')
-FRAMEWORKS = options.fetch(:frameworks, 'rails,sinatra,grape')
+default_frameworks = if RUBY_IMAGE.include?('jruby')
+                       'rails-6.1,sinatra-2.2,grape-1.6'
+                     else
+                       'rails,sinatra,grape'
+                     end
+FRAMEWORKS = options.fetch(:frameworks, default_frameworks)
 
 IMAGE_PATH_SAFE = RUBY_IMAGE.tr(':', '_')
 IMAGE_NAME = "apm-agent-ruby:#{IMAGE_PATH_SAFE}"
 VENDOR_PATH = "/vendor/#{IMAGE_PATH_SAFE}"
+DOCKER_PLATFORM = RUBY_IMAGE.include?('jruby') ? 'linux/amd64' : nil
 
 def run(cmd)
-  "IMAGE_NAME=#{IMAGE_NAME} #{cmd}".tap do |str|
+  env = ["IMAGE_NAME=#{IMAGE_NAME}"]
+  env << "DOCKER_DEFAULT_PLATFORM=#{DOCKER_PLATFORM}" if DOCKER_PLATFORM
+
+  "#{env.join(' ')} #{cmd}".tap do |str|
     puts str
     system str
   end

--- a/bin/run-bdd
+++ b/bin/run-bdd
@@ -9,9 +9,9 @@ if [[ $specific_feature = '' ]]; then
   echo 'Running all features'
 
   echo "========================================"
-  cucumber
+  bundle exec cucumber
 else
   echo "Running only $specific_feature"
 
-  cucumber $specific_feature
+  bundle exec cucumber $specific_feature
 fi

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,4 @@
 ---
-version: '3.4'
 
 services:
   mongodb:
@@ -14,10 +13,18 @@ services:
       context: .
       args:
         BUNDLER_VERSION: '2.2.21'
+        RUBY_IMAGE: ${RUBY_IMAGE:-ruby:3.3}
+        USER_ID_GROUP: ${USER_ID_GROUP:-1000:1000}
+        FRAMEWORKS: ${FRAMEWORKS:-rails,sinatra,grape}
+        VENDOR_PATH: ${VENDOR_PATH:-/vendor/ruby_3.3}
     image: '$IMAGE_NAME'
     environment:
       HOME: '/tmp'
       MONGODB_URL: 'mongodb:27017'
+      USER_ID: ${USER_ID:-1000}
+      LOCAL_USER_ID: ${LOCAL_USER_ID:-1000}
+      LOCAL_GROUP_ID: ${LOCAL_GROUP_ID:-1000}
+      RUBY_VERSION: ${RUBY_VERSION:-3.3}
     entrypoint:
       'spec/entrypoint.sh'
     tty: true
@@ -28,17 +35,17 @@ services:
       - /tmp:exec,mode=1777
     depends_on:
       - mongodb
-    user: ${USER_ID}
+    user: ${USER_ID:-1000}
     security_opt:
       - no-new-privileges
 
   ruby_rspec:
-    image: apm-agent-ruby:${RUBY_VERSION}
+    image: apm-agent-ruby:${RUBY_VERSION:-3.3}
     environment:
       APP_PATH: /opt/app
       FRAMEWORK: rails
-      LOCAL_USER_ID: ${LOCAL_USER_ID}
-      LOCAL_GROUP_ID: ${LOCAL_GROUP_ID}
+      LOCAL_USER_ID: ${LOCAL_USER_ID:-1000}
+      LOCAL_GROUP_ID: ${LOCAL_GROUP_ID:-1000}
       MONGODB_URL: 'mongodb:27017'
     security_opt:
       - no-new-privileges

--- a/spec/Dockerfile
+++ b/spec/Dockerfile
@@ -34,7 +34,7 @@ RUN set -eux; \
     printf 'Acquire::Check-Valid-Until "false";\n' > /etc/apt/apt.conf.d/99no-check-valid; \
     apt-get -o Acquire::Check-Valid-Until=false update -qq \
   ); \
-  apt-get install -qq -y --no-install-recommends build-essential libpq-dev git tzdata; \
+  apt-get install -qq -y --no-install-recommends build-essential curl gnupg dirmngr libpq-dev git tzdata; \
   rm -rf /var/lib/apt/lists/*
 
 # Install gosu

--- a/spec/Dockerfile
+++ b/spec/Dockerfile
@@ -1,5 +1,5 @@
 # Base image
-ARG RUBY_IMAGE
+ARG RUBY_IMAGE=ruby:3.3
 FROM ${RUBY_IMAGE}
 
 # Env arguments
@@ -25,9 +25,17 @@ COPY build/ /usr/local/bin/
 USER root
 
 # Install dependencies and upgrade ruby system
-RUN \
-  apt-get update > /dev/null \
-  && apt-get install -qq -y build-essential libpq-dev git tzdata
+RUN set -eux; \
+  apt-get update -qq || ( \
+    find /etc/apt -name '*.list' -type f -print0 | xargs -0 sed -i \
+      -e 's|deb.debian.org/debian|archive.debian.org/debian|g' \
+      -e 's|security.debian.org/debian-security|archive.debian.org/debian-security|g'; \
+    find /etc/apt -name '*.list' -type f -print0 | xargs -0 sed -i '/buster-updates/d'; \
+    printf 'Acquire::Check-Valid-Until "false";\n' > /etc/apt/apt.conf.d/99no-check-valid; \
+    apt-get -o Acquire::Check-Valid-Until=false update -qq \
+  ); \
+  apt-get install -qq -y --no-install-recommends build-essential libpq-dev git tzdata; \
+  rm -rf /var/lib/apt/lists/*
 
 # Install gosu
 RUN \

--- a/spec/entrypoint.sh
+++ b/spec/entrypoint.sh
@@ -1,17 +1,27 @@
 #!/bin/bash
 set -x
 
-bundle check || (rm -f Gemfile.lock && bundle)
+if ruby -e 'exit Gem::Version.new(RUBY_VERSION) < Gem::Version.new("2.5") ? 0 : 1'; then
+  # The RubyGems shim-based `bundle _x.y.z_` form can break with custom BUNDLE_BIN paths.
+  # Force a single compatible bundler version for Ruby 2.4 and use plain `bundle`.
+  gem uninstall bundler -v '>= 2' -aIx || true
+  gem list -i bundler -v 1.17.3 >/dev/null || gem install bundler -v 1.17.3
+  BUNDLE_CMD='bundle'
+else
+  BUNDLE_CMD='bundle'
+fi
+
+$BUNDLE_CMD check || (rm -f Gemfile.lock && $BUNDLE_CMD)
 
 # If first arg is a spec path, run spec(s)
 if [[ $1 == spec/* ]]; then
-  bundle exec bin/run-tests $@
+  $BUNDLE_CMD exec bin/run-tests $@
   exit $?
 fi
 
 # If no arguments, run all specs
 if [[ $# == 0 ]]; then
-  bundle exec bin/run-tests
+  $BUNDLE_CMD exec bin/run-tests
   exit $?
 fi
 

--- a/spec/integration/rails_spec.rb
+++ b/spec/integration/rails_spec.rb
@@ -295,7 +295,7 @@ if enabled
         it 'validates the schema', type: :json_schema do
           get '/'
 
-          wait_for transactions: 1, spans: 2
+          wait_for metadatas: 1, transactions: 1, spans: 2
 
           metadata = @mock_intake.metadatas.fetch(0)
           expect(metadata).to match_json_schema(:metadatas),

--- a/spec/integration/rails_spec.rb
+++ b/spec/integration/rails_spec.rb
@@ -295,7 +295,7 @@ if enabled
         it 'validates the schema', type: :json_schema do
           get '/'
 
-          wait_for transactions: 1
+          wait_for transactions: 1, spans: 2
 
           metadata = @mock_intake.metadatas.fetch(0)
           expect(metadata).to match_json_schema(:metadatas),

--- a/spec/support/match_json_schema_matcher.rb
+++ b/spec/support/match_json_schema_matcher.rb
@@ -21,7 +21,7 @@ require 'spec_helper'
 require 'json-schema'
 require 'open-uri'
 
-base = 'https://raw.githubusercontent.com/elastic/apm-server/master/docs/spec/v2'
+base = 'https://raw.githubusercontent.com/elastic/apm-data/main/input/elasticapm/docs/spec/v2'
 
 SCHEMA_URLS = {
   metadatas: "#{base}/metadata.json",

--- a/spec/support/mock_intake.rb
+++ b/spec/support/mock_intake.rb
@@ -222,19 +222,8 @@ class MockIntake
         loop do
           sleep 0.01
 
-          missing = expected.reduce(0) do |total, (kind, count)|
-            total + (count - @mock_intake.count(kind))
-          end
-
-          next if missing > 0
-
-          unless missing == 0
-            puts format(
-              'Expected %s. Got %s',
-              expected,
-              missing
-            )
-            print_received
+          next unless expected.all? do |kind, count|
+            @mock_intake.count(kind) >= count
           end
 
           if block_given?

--- a/spec/support/mock_intake.rb
+++ b/spec/support/mock_intake.rb
@@ -29,6 +29,7 @@ end
 
 class MockIntake
   def initialize
+    @mutex = Mutex.new
     clear!
 
     @span_types = JSON.parse(File.read('./spec/fixtures/span_types.json'))
@@ -91,13 +92,15 @@ class MockIntake
   end
 
   def clear!
-    @requests = []
+    @mutex.synchronize do
+      @requests = []
 
-    @errors = []
-    @metadatas = []
-    @metricsets = []
-    @spans = []
-    @transactions = []
+      @errors = []
+      @metadatas = []
+      @metricsets = []
+      @spans = []
+      @transactions = []
+    end
   end
 
   def reset!
@@ -110,17 +113,34 @@ class MockIntake
 
   def call(env)
     request = Rack::Request.new(env)
-    @requests << request
-
     metadata, *rest = parse_request_body(request)
 
-    metadatas << metadata.values.first
+    @mutex.synchronize do
+      @requests << request
+      metadatas << metadata.values.first
 
-    rest.each do |obj|
-      catalog obj
+      rest.each do |obj|
+        catalog obj
+      end
     end
 
     [202, {}, ['ok']]
+  end
+
+  def count(kind)
+    @mutex.synchronize { public_send(kind).length }
+  end
+
+  def snapshot
+    @mutex.synchronize do
+      {
+        transactions: @transactions.map { |o| o['name'] },
+        spans: @spans.map { |o| o['name'] },
+        errors: @errors.map { |o| o['culprit'] },
+        metricsets: @metricsets.dup,
+        metadatas: @metadatas.count
+      }
+    end
   end
 
   def parse_request_body(request)
@@ -203,7 +223,7 @@ class MockIntake
           sleep 0.01
 
           missing = expected.reduce(0) do |total, (kind, count)|
-            total + (count - @mock_intake.send(kind).length)
+            total + (count - @mock_intake.count(kind))
           end
 
           next if missing > 0
@@ -233,13 +253,7 @@ class MockIntake
     # rubocop:enable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
 
     def print_received
-      pp(
-        transactions: @mock_intake.transactions.map { |o| o['name'] },
-        spans: @mock_intake.spans.map { |o| o['name'] },
-        errors: @mock_intake.errors.map { |o| o['culprit'] },
-        metricsets: @mock_intake.metricsets,
-        metadatas: @mock_intake.metadatas.count
-      )
+      pp(@mock_intake.snapshot)
     end
   end
 end


### PR DESCRIPTION
### Summary

This PR started as a dev workflow fix and was expanded to address several CI instabilities uncovered during matrix runs. The final result is a clean CI run by resolving framework compatibility drift, JRuby test races, and legacy Debian image build failures.

### What changed

- BDD runner reliability: 
  - Updated the BDD runner invocation to use Bundler-managed executables so cucumber is always available in CI environments.
- Matrix compatibility updates:
  - Excluded grape master on Ruby versions no longer supported upstream.
  - Pinned delayed_job for Rails 4.x and 5.x compatibility to avoid ActiveJob adapter NameError failures.
  - Added a targeted shoryuken compatibility constraint for the Ruby 3.4 + Rails 6.1 combination.
- Legacy Debian image resilience:
  - Added Debian Buster archive fallback handling for CI spec image builds.
  - Added required build tools for JRuby-based images, including curl and GPG tooling needed by gosu verification.
  - Added a safe default base image argument in the spec Docker build definition.
- JRuby test flake fixes:
  - Updated the Rails JSON schema integration test wait condition to wait for the full expected payload set.
  - Hardened MockIntake synchronization with mutex-protected writes and synchronized count/snapshot reads.
  - Fixed wait_for logic so each expected event type must independently satisfy its threshold, preventing cross-category cancellation.

### Why this was needed

- Upstream framework changes introduced new resolver failures in the matrix.
- JRuby true concurrency exposed race and visibility issues in test intake polling.
- EOL Debian Buster repositories caused deterministic image build failures in legacy targets.
- Missing base-image utilities caused secondary CI build regressions in JRuby jobs.

### Outcome

CI is now passing after these follow-up commits. Changes are focused on test, CI, and build stability, with no intended production runtime behavior change.

### Notes for reviewers

The PR now includes both the original dev workflow fix and the required CI hardening discovered during validation.
Most changes are in test and CI support paths and are scoped to restore matrix reliability across legacy and JRuby targets.