### PR TITLE
Use version 7.0 as http gem upper bound in gemspec

### DIFF
--- a/elastic-apm.gemspec
+++ b/elastic-apm.gemspec
@@ -36,7 +36,7 @@ Gem::Specification.new do |spec|
   end
 
   spec.add_dependency('concurrent-ruby', '~> 1.0')
-  spec.add_dependency('http', '>= 3.0', '< 6.0')
+  spec.add_dependency('http', '>= 3.0', '< 7.0')
   spec.add_runtime_dependency('ruby2_keywords')
 
   spec.require_paths = ['lib']


### PR DESCRIPTION
Increase upper bound for `http` gem to 7.0 from 6.0 in the gemspec.