### PR TITLE
use http status code directly

### DIFF
--- a/lib/elastic_apm/central_config.rb
+++ b/lib/elastic_apm/central_config.rb
@@ -75,7 +75,7 @@ module ElasticAPM
       resp = perform_request
 
       # rubocop:disable Lint/DuplicateBranch
-      case resp.status
+      case resp.status.code
       when 200..299
         resp
       when 300..399


### PR DESCRIPTION
Opening this PR so I can do some testing on the [original PR code changes](https://github.com/elastic/apm-agent-ruby/pull/1615) 