### PR TITLE
fix(ci): update GitHub project ID from 454 to 1674

### DIFF
--- a/.github/workflows/addToProject.yml
+++ b/.github/workflows/addToProject.yml
@@ -30,7 +30,7 @@ jobs:
       uses: elastic/oblt-actions/github/project-add@v1
       with:
         github-token: ${{ steps.get_token.outputs.token }}
-        project-id: 454
+        project-id: 1674
         item-url: ${{ github.event.issue.html_url }}
 
     - name: Set issue status to Planned
@@ -38,7 +38,7 @@ jobs:
       uses: elastic/oblt-actions/github/project-field-set@v1
       with:
         github-token: ${{ steps.get_token.outputs.token }}
-        project-id: 454
+        project-id: 1674
         item-id: ${{ steps.add-issue-to-project.outputs.item-id }}
         field-name: Status
         field-value: Planned
@@ -49,7 +49,7 @@ jobs:
       uses: elastic/oblt-actions/github/project-add@v1
       with:
         github-token: ${{ steps.get_token.outputs.token }}
-        project-id: 454
+        project-id: 1674
         item-url: ${{ github.event.pull_request.html_url }}
 
     - name: Set pull request status to In Progress
@@ -57,7 +57,7 @@ jobs:
       uses: elastic/oblt-actions/github/project-field-set@v1
       with:
         github-token: ${{ steps.get_token.outputs.token }}
-        project-id: 454
+        project-id: 1674
         item-id: ${{ steps.add-pr-to-project.outputs.item-id }}
         field-name: Status
         field-value: In Progress


### PR DESCRIPTION
## Summary
- Update `project-id` from `454` to `1674` in `.github/workflows/addToProject.yml` for all project-add and project-field-set steps.
- The GitHub project was renamed to ID 1674, but the API does not redirect requests using the old ID.

## Validation
- Verified all four `project-id` references in the workflow were updated.
- Workflow YAML structure unchanged aside from the project ID.

## Risks / Known Gaps
- None expected; field names and status values are unchanged.

Related issue: https://github.com/elastic/observability-robots/issues/2783
