### PR TITLE
Use headers method directly for forwards compatibility

### DIFF
--- a/lib/elastic_apm/spies/http.rb
+++ b/lib/elastic_apm/spies/http.rb
@@ -49,7 +49,7 @@ module ElasticAPM
             context: context
           ) do |span|
             trace_context = span&.trace_context || transaction.trace_context
-            trace_context.apply_headers { |key, value| req[key] = value }
+            trace_context.apply_headers { |key, value| req.headers[key] = value }
 
             result = super(req, options)
 


### PR DESCRIPTION
Up until version 6.0 of the `http` gem, there was a mixin included in `HTTP::Request` that allow headers to be access via `[]` on the object. As of 6.0, that mixin is removed so `.headers` needs to be called explicitly on the request object to access the headers.
This change ensures compatibility with all http versions after 3.0 up to the current 6.0 series.

