### PR TITLE
Don't test ruby 3.1 with rails 7

### DIFF
--- a/.ci/.exclude.yml
+++ b/.ci/.exclude.yml
@@ -73,7 +73,9 @@ exclude:
   - VERSION: elasticobservability/jruby:9.2-8-jdk
     FRAMEWORK: rails-main
 
-  # Only test rails 7.2 on ruby >= 3.1
+  # Only test rails 7.2 on ruby >= 3.4
+  - VERSION: ruby:3.1
+    FRAMEWORK: rails-7.2
   - VERSION: ruby:2.7
     FRAMEWORK: rails-7.2
   - VERSION: ruby:2.6


### PR DESCRIPTION
Rails 7 will install the `i18n` gem, which does not work with ruby v3.1. So let's exclude testing rails 7 with ruby 3.1.

This is the error in ci:

```
NoMethodError:
  undefined method `[]' for Fiber:Class

        current = Fiber[:i18n_config] || self.config = I18n::Config.new
                       ^^^^^^^^^^^^^^
# ./vendor/ruby/3.1.0/gems/i18n-1.15.0/lib/i18n.rb:58:in `config'
# ./vendor/ruby/3.1.0/gems/i18n-1.15.0/lib/i18n.rb:88:in `load_path'
# ./vendor/ruby/3.1.0/gems/activesupport-7.2.3.1/lib/active_support/i18n.rb:16:in `<top (required)>'
# ./vendor/ruby/3.1.0/gems/activesupport-7.2.3.1/lib/active_support/inflector/inflections.rb:4:in `require'
# ./vendor/ruby/3.1.0/gems/activesupport-7.2.3.1/lib/active_support/inflector/inflections.rb:4:in `<top (required)>'
# ./vendor/ruby/3.1.0/gems/activesupport-7.2.3.1/lib/active_support/inflections.rb:3:in `require'
# ./vendor/ruby/3.1.0/gems/activesupport-7.2.3.1/lib/active_support/inflections.rb:3:in `<top (required)>'
# ./vendor/ruby/3.1.0/gems/activesupport-7.2.3.1/lib/active_support/inflector/methods.rb:3:in `require'
# ./vendor/ruby/3.1.0/gems/activesupport-7.2.3.1/lib/active_support/inflector/methods.rb:3:in `<top (required)>'
# ./vendor/ruby/3.1.0/gems/activesupport-7.2.3.1/lib/active_support/dependencies/autoload.rb:3:in `require'
# ./vendor/ruby/3.1.0/gems/activesupport-7.2.3.1/lib/active_support/dependencies/autoload.rb:3:in `<top (required)>'
# ./vendor/ruby/3.1.0/gems/activesupport-7.2.3.1/lib/active_support.rb:27:in `require'
# ./vendor/ruby/3.1.0/gems/activesupport-7.2.3.1/lib/active_support.rb:27:in `<top (required)>'
# ./vendor/ruby/3.1.0/gems/railties-7.2.3.1/lib/rails.rb:5:in `require'
# ./vendor/ruby/3.1.0/gems/railties-7.2.3.1/lib/rails.rb:5:in `<top (required)>'
# ./vendor/gems/bundler-2.6.9/lib/bundler.rb:215:in `require'
# ./spec/spec_helper.rb:31:in `<top (required)>'
# ./spec/elastic_apm/config_spec.rb:20:in `require'
# ./spec/elastic_apm/config_spec.rb:20:in `<top (required)>'

An error occurred while loading ./spec/elastic_apm/context/request/socket_spec.rb.
```

### Root cause

[i18n 1.15.0](https://rubygems.org/gems/i18n/versions/1.15.0) (released 2026-06-17) introduced [Fiber-backed config storage](https://github.com/ruby-i18n/i18n/commit/bfc992d8fe0a8fc74a7133c2948bd7cabf9af635) using `Fiber[]`, which requires Ruby 3.2+. However, i18n 1.15.0 incorrectly declares `required_ruby_version >= 3.1`, so Bundler resolves it for ruby 3.1 but it fails at runtime.