### PR TITLE
Include user context in a newly built Error

### DIFF
--- a/lib/elastic_apm/error_builder.rb
+++ b/lib/elastic_apm/error_builder.rb
@@ -86,6 +86,7 @@ module ElasticAPM
 
       Util.reverse_merge!(error.context.labels, transaction.context.labels)
       Util.reverse_merge!(error.context.custom, transaction.context.custom)
+      error.context.user = transaction.context.user if error.context.user.empty?
     end
   end
 end

--- a/spec/elastic_apm/error_builder_spec.rb
+++ b/spec/elastic_apm/error_builder_spec.rb
@@ -35,6 +35,7 @@ module ElasticAPM
         expect(error.exception.message).to eq 'divided by 0'
         expect(error.exception.type).to eq 'ZeroDivisionError'
         expect(error.exception.handled).to be true
+        expect(error.context.user).to be_empty
       end
 
       it 'sets properties from current transaction', :intercept do
@@ -67,6 +68,22 @@ module ElasticAPM
         expect(error.context.labels).to match(my_tag: '123', more: 'totes')
         expect(error.context.custom)
           .to match(all_the_other_things: 'blah blah')
+        expect(error.context.user)
+          .to have_attributes(id: '321', email: nil, username: nil)
+      end
+
+      it 'keeps an explicit error user over the transaction user', :intercept do
+        with_agent do
+          ElasticAPM.with_transaction('t') do
+            ElasticAPM.set_user(Struct.new(:id).new('txn-user'))
+
+            context = Context.new(user: Context::User.new(id: 'error-user'))
+            ElasticAPM.report(actual_exception, context: context)
+          end
+        end
+
+        error = @intercepted.errors.last
+        expect(error.context.user).to have_attributes(id: 'error-user')
       end
     end
 


### PR DESCRIPTION
<!--
A few suggestions about filling out this PR

1. Use a descriptive title for the PR.
2. If this pull request is work in progress, create a draft PR instead of prefixing the title with WIP.
3. Please label this PR at least one of the following labels, depending on the scope of your change:
- feature request, which adds new behavior
- bug fix
- enhancement, which modifies existing behavior
- breaking change
4. Remove those recommended/optional sections if you don't need them. Only "What does this PR do", "Why is it important?" and "Checklist" are mandatory.
5. Generally, we require that you test any code you are adding or modifying.
Once your changes are ready to submit for review:
6. Submit the pull request: Push your local changes to your forked copy of the repository and submit a pull request (https://help.github.com/articles/using-pull-requests).
7. Please be patient. We might not be able to review your code as fast as we would like to, but we'll do our best to dedicate to it the attention it deserves. Your effort is much appreciated!
-->

## What does this pull request do?

Captured errors now inherit the `ElasticAPM::Context::User` of the active transaction.

`ErrorBuilder#add_current_transaction_fields` already copies the transaction's labels and custom context onto each error, but silently omitted user - so errors reported during an authenticated request arrived with no user, even though the transaction (set via `ElasticAPM.set_user`) had one. 

An explicitly-set error user takes precedence; otherwise the transaction's user is inherited. This aligns the Ruby agent with the Node.js' ([1](https://github.com/elastic/apm-agent-nodejs/blob/2530d9e65a04c12a5703cd805402c2f7a162103b/lib/agent.js#L694), [2](https://github.com/elastic/apm-agent-nodejs/blob/2530d9e65a04c12a5703cd805402c2f7a162103b/lib/instrumentation/transaction.js#L191)), and Python's ([1](https://github.com/elastic/apm-agent-python/blob/d11f8c81ecd28997d1fe4080832ac7044db3aa36/elasticapm/base.py#L521), [2](https://github.com/elastic/apm-agent-python/blob/d11f8c81ecd28997d1fe4080832ac7044db3aa36/elasticapm/traces.py#L1288)) Elastic APM agents - all attaching the transaction's user to captured errors. 

From my understanding of "apm-agent-ruby" **it's an regression hailing from year 2019.**

The original implementation via #35 https://github.com/elastic/apm-agent-ruby/blob/77e9eedda213fc31af73174b2e314868e85b975e/lib/elastic_apm/error_builder.rb#L20

did add the user to `Error`'s context, but it was subsequently lost in #335 with note

> only copying over relevant data such as `tags` and `custom`.

Per included spec (which had no matcher part for error's user) https://github.com/elastic/apm-agent-ruby/blob/eeaded64cafda47e5728ff90a4d0bf12afee7363/spec/elastic_apm/error_builder_spec.rb#L34

it is clear that intent was not to drop user linkage.

## Why is it important?

Lacking a user's information the error metadata is less valuable. Cross-referencing with a specific set of circumstances is harder and more time consuming.

## Checklist
<!--
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] I have signed the [Contributor License Agreement](https://www.elastic.co/contributor-agreement/).
- [x] My code follows the style guidelines of this project (See `.rubocop.yml`)
- [x] I have rebased my changes on top of the latest main branch
<!--
Update your local repository with the most recent code from the main repo, and rebase your branch on top of the latest main branch. We prefer your initial changes to be squashed into a single commit. Later, if we ask you to make changes, add them as separate commits. This makes them easier to review.
-->
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing [**unit** tests](https://github.com/elastic/apm-agent-ruby/blob/main/CONTRIBUTING.md#testing) pass locally with my changes
<!--
Run the test suite to make sure that nothing is broken. See https://github.com/elastic/apm-agent-ruby/blob/main/CONTRIBUTING.md#testing for details.
-->
- [ ] I have made corresponding changes to the documentation
- [ ] I have updated [docs/release-notes/index.md](../docs/release-notes/index.md)
- [ ] I have updated [docs/reference/supported-technologies.md](../docs/reference/supported-technologies.md)
- [ ] Added an API method or config option? Document in which version this will be introduced

## Related issues
<!--
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.
- Closes #ISSUE_ID
- Relates #ISSUE_ID
- Requires #ISSUE_ID
- Superseds #ISSUE_ID
-->
