### PR TITLE
docs(rails): explain disabling agent, fixes #1466

### DIFF
--- a/docs/reference/getting-started-rails.md
+++ b/docs/reference/getting-started-rails.md
@@ -31,3 +31,17 @@ Or if you prefer environment variables, skip the file and set `ELASTIC_APM_SERVE
 
 This automatically sets up error logging and performance tracking but of course there are knobs to turn if you’d like to. See [*Configuration*](/reference/configuration.md).
 
+To load the gem without starting the agent in a particular Rails environment,
+set [`enabled`](/reference/configuration.md#config-enabled) to `false`.
+For example, to start the agent only in production, use ERB in
+`config/elastic_apm.yml`:
+
+```yaml
+enabled: <%= Rails.env.production? %>
+server_url: http://localhost:8200
+secret_token: ''
+```
+
+You can also set `ELASTIC_APM_ENABLED=false` in an environment where the agent
+should not start. The `ElasticAPM` API remains available when the agent is
+disabled, but calls that collect data return `nil`.

--- a/spec/elastic_apm/rails_spec.rb
+++ b/spec/elastic_apm/rails_spec.rb
@@ -30,6 +30,22 @@ if defined?(Rails)
           ElasticAPM.stop
         end
       end
+
+      it "doesn't start the agent when disabled by config" do
+        ElasticAPM::Rails.start(enabled: false)
+
+        expect(ElasticAPM.agent).to be nil
+        expect(ElasticAPM).to_not be_running
+      end
+
+      it "doesn't start the agent when disabled by the environment" do
+        with_env('ELASTIC_APM_ENABLED' => 'false') do
+          ElasticAPM::Rails.start({})
+
+          expect(ElasticAPM.agent).to be nil
+          expect(ElasticAPM).to_not be_running
+        end
+      end
     end
 
     describe 'Rails console' do


### PR DESCRIPTION
## What does this pull request do?

The option to enable the agent dynamically was asked for in #1466 – apparently present since 2020ish, but not documented everywhere, and not tested either.

## Why is it important?

Some environemnts may not need apm testing (e.g., `test`). Users should discover this option more easily.

## Checklist

  - [x] I have signed the [Contributor License Agreement](https://www.elastic.co/contributor-
  agreement/).
  - [x] My code follows the style guidelines of this project (See `.rubocop.yml`)
  - [x] I have rebased my changes on top of the latest main branch
  - [x] I have added tests that prove my fix is effective or that my feature works
  - [x] New and existing [**unit** tests](https://github.com/elastic/apm-agent-ruby/blob/
  main/CONTRIBUTING.md#testing) pass locally with my changes
  - [x] I have made corresponding changes to the documentation
  - [ ] ~~I have updated [docs/release-notes/index.md](../docs/release-notes/index.md)~~ – likely not worth adding there
  - [ ] ~~I have updated [docs/reference/supported-technologies.md](../docs/reference/
  supported-technologies.md)~~ N/A
  - [ ] ~~Added an API method or config option? Document in which version this will be
  introduced~~ N/A


Closes #1466 