### PR TITLE
Fallback to kicks gem for version check in SneakersSpy

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -168,7 +168,13 @@ end
 
 # sneakers main only supports >=2.5.0
 if Gem::Version.create(RUBY_VERSION) >= Gem::Version.create('2.5.0') && !defined?(JRUBY_VERSION)
-  gem 'sneakers', github: 'jondot/sneakers', ref: 'd761dfe1493', require: nil
+  # The sneakers gem was renamed to kicks, which SneakersSpy also instruments.
+  # Set SNEAKERS_GEM=kicks to run the suite against it instead.
+  if ENV['SNEAKERS_GEM'] == 'kicks'
+    gem 'kicks', '>= 2.12.0', require: nil
+  else
+    gem 'sneakers', github: 'jondot/sneakers', ref: 'd761dfe1493', require: nil
+  end
 end
 
 if Gem::Version.create(RUBY_VERSION) <= Gem::Version.create('2.5.0')

--- a/lib/elastic_apm/spies/sneakers.rb
+++ b/lib/elastic_apm/spies/sneakers.rb
@@ -25,7 +25,8 @@ module ElasticAPM
       include Logging
 
       def self.supported_version?
-        Gem.loaded_specs['sneakers'].version >= Gem::Version.create('2.12.0')
+        spec = Gem.loaded_specs['sneakers'] || Gem.loaded_specs['kicks']
+        spec.present? && spec.version >= Gem::Version.create('2.12.0')
       end
 
       def install

--- a/lib/elastic_apm/spies/sneakers.rb
+++ b/lib/elastic_apm/spies/sneakers.rb
@@ -24,9 +24,11 @@ module ElasticAPM
     class SneakersSpy
       include Logging
 
+      # The sneakers gem was renamed to kicks, which still ships
+      # `lib/sneakers.rb` but registers under a different gem name.
       def self.supported_version?
         spec = Gem.loaded_specs['sneakers'] || Gem.loaded_specs['kicks']
-        spec.present? && spec.version >= Gem::Version.create('2.12.0')
+        spec && spec.version >= Gem::Version.create('2.12.0')
       end
 
       def install

--- a/spec/elastic_apm/spies/sneakers_spec.rb
+++ b/spec/elastic_apm/spies/sneakers_spec.rb
@@ -18,9 +18,18 @@
 # frozen_string_literal: true
 
 require 'spec_helper'
-unless Gem::Specification.find_all_by_name('sneakers', '>=2.12.0').empty? || defined?(JRUBY_VERSION)
+require 'elastic_apm/spies/sneakers'
+
+# The sneakers gem was renamed to kicks. Both ship `lib/sneakers.rb` and define
+# the `Sneakers` constant, but register under different gem names, so either one
+# satisfies the spy.
+queue_gem_bundled =
+  !defined?(JRUBY_VERSION) &&
+  !(Gem::Specification.find_all_by_name('sneakers', '>=2.12.0') +
+    Gem::Specification.find_all_by_name('kicks', '>=2.12.0')).empty?
+
+if queue_gem_bundled
   require 'sneakers'
-  require 'elastic_apm/spies/sneakers'
 
   module ElasticAPM
     RSpec.describe 'Spy: Sneakers', :intercept do
@@ -70,6 +79,10 @@ unless Gem::Specification.find_all_by_name('sneakers', '>=2.12.0').empty? || def
         Sneakers.logger = Logger.new(nil) # silence
       end
 
+      it 'supports the version of the gem in the bundle' do
+        expect(Spies::SneakersSpy.supported_version?).to be_truthy
+      end
+
       it 'instruments job transaction' do
         with_agent do
           worker = TestWorker.new
@@ -105,6 +118,17 @@ unless Gem::Specification.find_all_by_name('sneakers', '>=2.12.0').empty? || def
 
         error, = @intercepted.errors
         expect(error.exception.type).to eq 'ZeroDivisionError'
+      end
+    end
+  end
+elsif Gem.loaded_specs['sneakers'].nil? && Gem.loaded_specs['kicks'].nil?
+  # Neither gem is in the bundle (eg. JRuby, or Ruby below 2.5), so the spy has
+  # no gem spec to read a version from. It has to report the version as
+  # unsupported rather than raise.
+  module ElasticAPM
+    RSpec.describe 'Spy: Sneakers' do
+      it 'is unsupported when neither sneakers nor kicks is bundled' do
+        expect(Spies::SneakersSpy.supported_version?).to be_falsey
       end
     end
   end


### PR DESCRIPTION
## What does this pull request do?

After https://github.com/elastic/apm-agent-ruby/pull/1650 got merged we experienced issue with sneakers spy in our app.

[Sneakers](https://github.com/jondot/sneakers) gem was abandoned and does not work with Ruby 4. It was replaced by the [kicks](https://github.com/ruby-amqp/kicks) gem.

Kicks gem still uses sneakers namespace so it will load SneakersSpy which fails because `Gem.loaded_specs['sneakers']` returns `nil`. We fix it by adding fallback to `Gem.loaded_specs['kicks']`.
Last sneakers version is 2.12.0 and kicks starts from 3.0.0 so this should work properly.

I've added Gemfile switch so we can run specs with kicks gem (`SNEAKERS_GEM=kicks bundle install && bundle exec rspec.`) on demand.

## Checklist

- [x] I have signed the [Contributor License Agreement](https://www.elastic.co/contributor-agreement/).
- [x] My code follows the style guidelines of this project (See `.rubocop.yml`)
- [x] I have rebased my changes on top of the latest main branch
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing [**unit** tests](https://github.com/elastic/apm-agent-ruby/blob/main/CONTRIBUTING.md#testing) pass locally with my changes
- [ ] I have made corresponding changes to the documentation
- [ ] I have updated [docs/release-notes/index.md](../docs/release-notes/index.md)
- [ ] I have updated [docs/reference/supported-technologies.md](../docs/reference/supported-technologies.md)
- [ ] Added an API method or config option? Document in which version this will be introduced